### PR TITLE
fix: migrate all tests from fp-ts to Effect

### DIFF
--- a/tests/integration/acuity.test.ts
+++ b/tests/integration/acuity.test.ts
@@ -4,7 +4,7 @@
  */
 
 import { describe, it, expect, beforeAll, afterAll, afterEach, beforeEach } from 'vitest';
-import * as E from 'fp-ts/Either';
+import { Effect, Exit, Cause, Option } from 'effect';
 import { createAcuityAdapter } from '../../src/adapters/acuity.js';
 import type { SchedulingAdapter } from '../../src/adapters/types.js';
 import { server } from '../../src/tests/mocks/server.js';
@@ -14,9 +14,9 @@ import {
   getAcuityMockState,
 } from '../../src/tests/mocks/handlers/index.js';
 import {
-  expectRightAsync,
-  expectLeftTagAsync,
-} from '../../src/tests/helpers/fp-ts.js';
+  expectSuccess,
+  expectFailureTag,
+} from '../../src/tests/helpers/effect.js';
 
 // MSW server lifecycle
 beforeAll(() => {
@@ -45,18 +45,18 @@ describe('Acuity Integration: Full Booking Lifecycle', () => {
 
   it('creates and cancels a booking', async () => {
     // 1. Get available services
-    const services = await expectRightAsync(adapter.getServices());
+    const services = await expectSuccess(adapter.getServices());
     expect(services.length).toBeGreaterThan(0);
     const service = services.find(s => s.name.includes('TMD 60'));
     expect(service).toBeDefined();
 
     // 2. Get providers for the service
-    const providers = await expectRightAsync(adapter.getProviders());
+    const providers = await expectSuccess(adapter.getProviders());
     expect(providers.length).toBeGreaterThan(0);
     const provider = providers[0];
 
     // 3. Check availability dates
-    const dates = await expectRightAsync(
+    const dates = await expectSuccess(
       adapter.getAvailableDates({
         serviceId: service!.id,
         providerId: provider.id,
@@ -67,7 +67,7 @@ describe('Acuity Integration: Full Booking Lifecycle', () => {
     expect(dates.length).toBeGreaterThan(0);
 
     // 4. Get time slots for a specific date
-    const slots = await expectRightAsync(
+    const slots = await expectSuccess(
       adapter.getAvailableSlots({
         serviceId: service!.id,
         providerId: provider.id,
@@ -79,7 +79,7 @@ describe('Acuity Integration: Full Booking Lifecycle', () => {
     expect(availableSlot).toBeDefined();
 
     // 5. Create a booking
-    const booking = await expectRightAsync(
+    const booking = await expectSuccess(
       adapter.createBooking({
         serviceId: service!.id,
         providerId: provider.id,
@@ -98,20 +98,19 @@ describe('Acuity Integration: Full Booking Lifecycle', () => {
     expect(booking.serviceId).toBe(service!.id);
 
     // 6. Verify booking can be retrieved
-    const retrieved = await expectRightAsync(adapter.getBooking(booking.id));
+    const retrieved = await expectSuccess(adapter.getBooking(booking.id));
     expect(retrieved.id).toBe(booking.id);
 
     // 7. Cancel the booking
-    const cancelResult = await adapter.cancelBooking(booking.id, 'Integration test cleanup')();
-    expect(E.isRight(cancelResult)).toBe(true);
+    await expectSuccess(adapter.cancelBooking(booking.id, 'Integration test cleanup'));
   });
 
   it('creates reservation (block) for slot protection', async () => {
-    const services = await expectRightAsync(adapter.getServices());
-    const providers = await expectRightAsync(adapter.getProviders());
+    const services = await expectSuccess(adapter.getServices());
+    const providers = await expectSuccess(adapter.getProviders());
 
     // Create a reservation
-    const reservation = await expectRightAsync(
+    const reservation = await expectSuccess(
       adapter.createReservation({
         serviceId: services[0].id,
         providerId: providers[0].id,
@@ -129,7 +128,7 @@ describe('Acuity Integration: Full Booking Lifecycle', () => {
     expect(mockState.blocks.size).toBe(1);
 
     // Release the reservation
-    await expectRightAsync(adapter.releaseReservation(reservation.id));
+    await expectSuccess(adapter.releaseReservation(reservation.id));
 
     // Verify it's removed
     const stateAfter = getAcuityMockState();
@@ -138,7 +137,7 @@ describe('Acuity Integration: Full Booking Lifecycle', () => {
 
   it('handles slot taken scenario', async () => {
     // First booking takes the slot
-    const booking1 = await expectRightAsync(
+    const booking1 = await expectSuccess(
       adapter.createBooking({
         serviceId: '12345',
         providerId: '67890',
@@ -156,7 +155,7 @@ describe('Acuity Integration: Full Booking Lifecycle', () => {
 
     // Second booking tries the same slot
     // The mock should reject it (slot no longer available)
-    const slotCheck = await expectRightAsync(
+    const slotCheck = await expectSuccess(
       adapter.checkSlotAvailability({
         serviceId: '12345',
         providerId: '67890',
@@ -170,7 +169,7 @@ describe('Acuity Integration: Full Booking Lifecycle', () => {
 
   it('handles reschedule operation', async () => {
     // Create initial booking
-    const booking = await expectRightAsync(
+    const booking = await expectSuccess(
       adapter.createBooking({
         serviceId: '12345',
         datetime: '2026-02-15T19:00:00.000Z',
@@ -184,7 +183,7 @@ describe('Acuity Integration: Full Booking Lifecycle', () => {
     );
 
     // Reschedule to a new time
-    const rescheduled = await expectRightAsync(
+    const rescheduled = await expectSuccess(
       adapter.rescheduleBooking(booking.id, '2026-02-16T20:00:00.000Z')
     );
 
@@ -207,7 +206,7 @@ describe('Acuity Integration: Error Handling', () => {
   it('handles authentication failure', async () => {
     configureAcuityMock({ simulateAuthFailure: true });
 
-    const error = await expectLeftTagAsync(
+    const error = await expectFailureTag(
       adapter.getServices(),
       'AcuityError'
     );
@@ -225,7 +224,7 @@ describe('Acuity Integration: Error Handling', () => {
     configureAcuityMock({ simulateRateLimit: true });
 
     // Rate limit is one-shot in mock, so retry should succeed
-    const services = await expectRightAsync(adapter.getServices());
+    const services = await expectSuccess(adapter.getServices());
     expect(services.length).toBeGreaterThan(0);
   });
 
@@ -233,15 +232,15 @@ describe('Acuity Integration: Error Handling', () => {
     configureAcuityMock({ failNextRequest: true });
 
     // Server error should be returned as AcuityError
-    const result = await adapter.getServices()();
+    const exit = await Effect.runPromiseExit(adapter.getServices());
 
     // Could be success (if retry succeeds) or failure
     // Just verify it doesn't hang or throw
-    expect(result).toBeDefined();
+    expect(exit).toBeDefined();
   });
 
   it('returns error for unknown resources', async () => {
-    const error = await expectLeftTagAsync(
+    const error = await expectFailureTag(
       adapter.getBooking('nonexistent-booking-id'),
       'AcuityError'
     );
@@ -267,7 +266,7 @@ describe('Acuity Integration: Client Operations', () => {
   });
 
   it('finds existing client by email', async () => {
-    const result = await expectRightAsync(
+    const result = await expectSuccess(
       adapter.findOrCreateClient({
         firstName: 'John',
         lastName: 'Doe',
@@ -280,7 +279,7 @@ describe('Acuity Integration: Client Operations', () => {
   });
 
   it('indicates new client for unknown email', async () => {
-    const result = await expectRightAsync(
+    const result = await expectSuccess(
       adapter.findOrCreateClient({
         firstName: 'New',
         lastName: 'Customer',
@@ -293,7 +292,7 @@ describe('Acuity Integration: Client Operations', () => {
   });
 
   it('returns null for unknown client email lookup', async () => {
-    const client = await expectRightAsync(
+    const client = await expectSuccess(
       adapter.getClientByEmail('definitely.not.found@example.com')
     );
 
@@ -313,7 +312,7 @@ describe('Acuity Integration: Availability Queries', () => {
   });
 
   it('returns dates within the requested range', async () => {
-    const dates = await expectRightAsync(
+    const dates = await expectSuccess(
       adapter.getAvailableDates({
         serviceId: '12345',
         startDate: '2026-02-01',
@@ -331,7 +330,7 @@ describe('Acuity Integration: Availability Queries', () => {
   });
 
   it('returns time slots for a specific date', async () => {
-    const slots = await expectRightAsync(
+    const slots = await expectSuccess(
       adapter.getAvailableSlots({
         serviceId: '12345',
         date: '2026-02-15',
@@ -347,10 +346,10 @@ describe('Acuity Integration: Availability Queries', () => {
   });
 
   it('filters availability by provider', async () => {
-    const providers = await expectRightAsync(adapter.getProviders());
+    const providers = await expectSuccess(adapter.getProviders());
     const provider = providers[0];
 
-    const slots = await expectRightAsync(
+    const slots = await expectSuccess(
       adapter.getAvailableSlots({
         serviceId: '12345',
         providerId: provider.id,
@@ -365,7 +364,7 @@ describe('Acuity Integration: Availability Queries', () => {
   });
 
   it('checkSlotAvailability returns boolean', async () => {
-    const available = await expectRightAsync(
+    const available = await expectSuccess(
       adapter.checkSlotAvailability({
         serviceId: '12345',
         datetime: '2026-02-15T14:00:00.000Z',

--- a/tests/integration/booking-flow.test.ts
+++ b/tests/integration/booking-flow.test.ts
@@ -4,8 +4,7 @@
  */
 
 import { describe, it, expect, beforeAll, afterAll, afterEach, beforeEach, vi } from 'vitest';
-import * as E from 'fp-ts/Either';
-import * as TE from 'fp-ts/TaskEither';
+import { Effect, Exit, Cause, Option } from 'effect';
 import { createAcuityAdapter } from '../../src/adapters/acuity.js';
 import { createManualPaymentAdapter } from '../../src/payments/manual.js';
 import {
@@ -22,10 +21,10 @@ import {
   getAcuityMockState,
 } from '../../src/tests/mocks/handlers/index.js';
 import {
-  expectRightAsync,
-  expectLeftAsync,
-  expectLeftTagAsync,
-} from '../../src/tests/helpers/fp-ts.js';
+  expectSuccess,
+  expectFailure,
+  expectFailureTag,
+} from '../../src/tests/helpers/effect.js';
 import { createClient, createBookingRequest } from '../../src/tests/helpers/factories.js';
 
 // MSW server lifecycle
@@ -73,7 +72,7 @@ describe('Complete Booking Flow: Happy Path', () => {
 
   it('completes full booking with cash payment', async () => {
     // Use pre-defined booking request with UTC datetime format
-    const result = await expectRightAsync(
+    const result = await expectSuccess(
       kit.completeBooking(
         createBookingRequest({
           client: createClient({
@@ -96,7 +95,7 @@ describe('Complete Booking Flow: Happy Path', () => {
   });
 
   it('completes booking with Venmo payment', async () => {
-    const result = await expectRightAsync(
+    const result = await expectSuccess(
       kit.completeBooking(
         createBookingRequest({
           client: createClient({
@@ -116,7 +115,7 @@ describe('Complete Booking Flow: Happy Path', () => {
   });
 
   it('includes payment reference in booking notes', async () => {
-    const result = await expectRightAsync(
+    const result = await expectSuccess(
       kit.completeBooking(
         createBookingRequest({
           idempotencyKey: 'payment-ref-test',
@@ -151,7 +150,7 @@ describe('Complete Booking Flow: Error Recovery', () => {
   });
 
   it('fails with invalid payment method', async () => {
-    const error = await expectLeftTagAsync(
+    const error = await expectFailureTag(
       kit.completeBooking(
         createBookingRequest({ idempotencyKey: 'invalid-payment-key' }),
         'bitcoin' // Not a valid payment method
@@ -166,7 +165,7 @@ describe('Complete Booking Flow: Error Recovery', () => {
   });
 
   it('fails with validation error for invalid email', async () => {
-    const error = await expectLeftTagAsync(
+    const error = await expectFailureTag(
       kit.completeBooking(
         createBookingRequest({
           client: createClient({ email: 'not-an-email' }),
@@ -184,7 +183,7 @@ describe('Complete Booking Flow: Error Recovery', () => {
     // Configure mock to report slot as unavailable
     configureAcuityMock({ simulateSlotTaken: true });
 
-    const error = await expectLeftTagAsync(
+    const error = await expectFailureTag(
       kit.completeBooking(
         createBookingRequest({ idempotencyKey: 'slot-taken-key' }),
         'cash'
@@ -203,15 +202,21 @@ describe('Complete Booking Flow: Error Recovery', () => {
     configureAcuityMock({ failOnBookingCreate: true });
 
     // This should fail but cleanup (release reservation) should still happen
-    const result = await kit.completeBooking(
-      createBookingRequest({ idempotencyKey: 'api-failure-key' }),
-      'cash'
-    )();
+    const exit = await Effect.runPromiseExit(
+      kit.completeBooking(
+        createBookingRequest({ idempotencyKey: 'api-failure-key' }),
+        'cash'
+      )
+    );
 
-    // Should be a Left with AcuityError
-    expect(E.isLeft(result)).toBe(true);
-    if (E.isLeft(result)) {
-      expect(result.left._tag).toBe('AcuityError');
+    // Should be a failure with AcuityError
+    expect(Exit.isFailure(exit)).toBe(true);
+    if (Exit.isFailure(exit)) {
+      const failure = Cause.failureOption(exit.cause);
+      expect(Option.isSome(failure)).toBe(true);
+      if (Option.isSome(failure)) {
+        expect(failure.value._tag).toBe('AcuityError');
+      }
     }
   });
 });
@@ -238,7 +243,7 @@ describe('Complete Booking Flow: Cancellation with Refund', () => {
 
   it('cancels booking without refund', async () => {
     // First create a booking
-    const booking = await expectRightAsync(
+    const booking = await expectSuccess(
       kit.completeBooking(
         createBookingRequest({
           idempotencyKey: 'cancel-no-refund-key',
@@ -248,7 +253,7 @@ describe('Complete Booking Flow: Cancellation with Refund', () => {
     );
 
     // Cancel without refund
-    const result = await expectRightAsync(
+    const result = await expectSuccess(
       kit.cancelBooking({
         bookingId: booking.booking.id,
         reason: 'Customer request',
@@ -262,7 +267,7 @@ describe('Complete Booking Flow: Cancellation with Refund', () => {
 
   it('cancels booking with refund', async () => {
     // First create a booking
-    const booking = await expectRightAsync(
+    const booking = await expectSuccess(
       kit.completeBooking(
         createBookingRequest({
           idempotencyKey: 'cancel-with-refund-key',
@@ -272,7 +277,7 @@ describe('Complete Booking Flow: Cancellation with Refund', () => {
     );
 
     // Cancel with refund
-    const result = await expectRightAsync(
+    const result = await expectSuccess(
       kit.cancelBooking({
         bookingId: booking.booking.id,
         reason: 'Service cancelled',
@@ -286,7 +291,7 @@ describe('Complete Booking Flow: Cancellation with Refund', () => {
   });
 
   it('handles cancellation of nonexistent booking', async () => {
-    const error = await expectLeftTagAsync(
+    const error = await expectFailureTag(
       kit.cancelBooking({
         bookingId: 'nonexistent-booking-id',
       }),
@@ -324,39 +329,45 @@ describe('Complete Booking Flow: Concurrent Bookings', () => {
 
   it('handles multiple bookings at different times', async () => {
     const bookingPromises = [
-      kit.completeBooking(
-        createBookingRequest({
-          datetime: '2026-02-15T14:00:00.000Z',
-          client: createClient({ email: 'client1@example.com' }),
-          idempotencyKey: 'concurrent-1',
-        }),
-        'cash'
-      )(),
-      kit.completeBooking(
-        createBookingRequest({
-          datetime: '2026-02-15T15:00:00.000Z',
-          client: createClient({ email: 'client2@example.com' }),
-          idempotencyKey: 'concurrent-2',
-        }),
-        'cash'
-      )(),
-      kit.completeBooking(
-        createBookingRequest({
-          datetime: '2026-02-15T16:00:00.000Z',
-          client: createClient({ email: 'client3@example.com' }),
-          idempotencyKey: 'concurrent-3',
-        }),
-        'cash'
-      )(),
+      Effect.runPromiseExit(
+        kit.completeBooking(
+          createBookingRequest({
+            datetime: '2026-02-15T14:00:00.000Z',
+            client: createClient({ email: 'client1@example.com' }),
+            idempotencyKey: 'concurrent-1',
+          }),
+          'cash'
+        )
+      ),
+      Effect.runPromiseExit(
+        kit.completeBooking(
+          createBookingRequest({
+            datetime: '2026-02-15T15:00:00.000Z',
+            client: createClient({ email: 'client2@example.com' }),
+            idempotencyKey: 'concurrent-2',
+          }),
+          'cash'
+        )
+      ),
+      Effect.runPromiseExit(
+        kit.completeBooking(
+          createBookingRequest({
+            datetime: '2026-02-15T16:00:00.000Z',
+            client: createClient({ email: 'client3@example.com' }),
+            idempotencyKey: 'concurrent-3',
+          }),
+          'cash'
+        )
+      ),
     ];
 
     const results = await Promise.all(bookingPromises);
 
     // All bookings should succeed (different times)
-    results.forEach((result, i) => {
-      expect(E.isRight(result)).toBe(true);
-      if (E.isRight(result)) {
-        expect(result.right.booking.id).toBeDefined();
+    results.forEach((exit, i) => {
+      expect(Exit.isSuccess(exit)).toBe(true);
+      if (Exit.isSuccess(exit)) {
+        expect(exit.value.booking.id).toBeDefined();
       }
     });
 
@@ -393,7 +404,7 @@ describe('Complete Booking Flow: Idempotency', () => {
       idempotencyKey: 'idempotent-key-12345',
     });
 
-    const result = await expectRightAsync(
+    const result = await expectSuccess(
       kit.completeBooking(request, 'cash')
     );
 

--- a/tests/live/acuity.live.test.ts
+++ b/tests/live/acuity.live.test.ts
@@ -10,9 +10,10 @@
  */
 
 import { describe, it, expect, beforeAll } from 'vitest';
-import * as E from 'fp-ts/Either';
+import { Effect, Exit, Cause, Option } from 'effect';
 import { createAcuityAdapter } from '../../src/adapters/acuity.js';
 import type { SchedulingAdapter } from '../../src/adapters/types.js';
+import type { SchedulingError } from '../../src/core/types.js';
 
 // Skip all tests if RUN_LIVE_TESTS is not set
 const RUN_LIVE_TESTS = process.env.RUN_LIVE_TESTS === 'true';
@@ -20,6 +21,17 @@ const RUN_LIVE_TESTS = process.env.RUN_LIVE_TESTS === 'true';
 // Get credentials from environment
 const ACUITY_USER_ID = process.env.ACUITY_USER_ID;
 const ACUITY_API_KEY = process.env.ACUITY_API_KEY;
+
+/** Run an Effect and return { ok, value, error } for flexible assertions */
+const run = async <A>(effect: Effect.Effect<A, SchedulingError>): Promise<
+  { ok: true; value: A } | { ok: false; error: SchedulingError }
+> => {
+  const exit = await Effect.runPromiseExit(effect);
+  if (Exit.isSuccess(exit)) return { ok: true, value: exit.value };
+  const failure = Cause.failureOption(exit.cause);
+  if (Option.isSome(failure)) return { ok: false, error: failure.value };
+  throw new Error(`Unexpected defect: ${Cause.pretty(exit.cause)}`);
+};
 
 describe.skipIf(!RUN_LIVE_TESTS)('Acuity Live API Tests', () => {
   let adapter: SchedulingAdapter;
@@ -40,10 +52,10 @@ describe.skipIf(!RUN_LIVE_TESTS)('Acuity Live API Tests', () => {
 
   describe('Connection & Error Handling', () => {
     it('validates credentials and reports API access level', async () => {
-      const result = await adapter.getServices()();
+      const result = await run(adapter.getServices());
 
-      if (E.isLeft(result)) {
-        const error = result.left;
+      if (!result.ok) {
+        const error = result.error;
         if (error._tag === 'AcuityError' && error.statusCode === 403) {
           console.log('\n========================================');
           console.log('ACUITY API ACCESS: POWERHOUSE REQUIRED');
@@ -66,10 +78,10 @@ describe.skipIf(!RUN_LIVE_TESTS)('Acuity Live API Tests', () => {
         console.log('\n========================================');
         console.log('ACUITY API ACCESS: FULL ACCESS');
         console.log('========================================');
-        console.log(`Found ${result.right.length} services`);
+        console.log(`Found ${result.value.length} services`);
         console.log('========================================\n');
 
-        expect(result.right.length).toBeGreaterThan(0);
+        expect(result.value.length).toBeGreaterThan(0);
       }
     });
 
@@ -80,28 +92,28 @@ describe.skipIf(!RUN_LIVE_TESTS)('Acuity Live API Tests', () => {
         apiKey: 'invalid',
       });
 
-      const result = await badAdapter.getServices()();
+      const result = await run(badAdapter.getServices());
 
-      expect(E.isLeft(result)).toBe(true);
-      if (E.isLeft(result)) {
-        expect(result.left._tag).toBe('AcuityError');
-        expect(result.left.statusCode).toBe(401);
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error._tag).toBe('AcuityError');
+        expect(result.error.statusCode).toBe(401);
         console.log(`✓ Auth error correctly handled (401)`);
       }
     });
 
     it('handles 403 Forbidden gracefully (Powerhouse required)', async () => {
       // This test verifies the adapter correctly handles API access restrictions
-      const result = await adapter.getServices()();
+      const result = await run(adapter.getServices());
 
       // Either succeeds (has Powerhouse) or fails with 403 (no Powerhouse)
       // Both outcomes are valid - we're testing error handling
-      if (E.isLeft(result)) {
-        expect(result.left._tag).toBe('AcuityError');
+      if (!result.ok) {
+        expect(result.error._tag).toBe('AcuityError');
         // Could be 403 (no Powerhouse) or another error
-        console.log(`✓ API restriction handled: ${result.left.statusCode}`);
+        console.log(`✓ API restriction handled: ${result.error.statusCode}`);
       } else {
-        console.log(`✓ API access available: ${result.right.length} services`);
+        console.log(`✓ API access available: ${result.value.length} services`);
       }
 
       // This test always passes - it's verifying error handling works
@@ -113,42 +125,42 @@ describe.skipIf(!RUN_LIVE_TESTS)('Acuity Live API Tests', () => {
   // They are kept here for reference and future use
   describe('Read Operations (requires Powerhouse plan)', () => {
     it('lists services (skipped without Powerhouse)', async () => {
-      const result = await adapter.getServices()();
+      const result = await run(adapter.getServices());
 
-      if (E.isLeft(result) && result.left.statusCode === 403) {
+      if (!result.ok && result.error.statusCode === 403) {
         console.log('⏭️  Skipped: Requires Powerhouse plan');
         return; // Skip gracefully
       }
 
-      expect(E.isRight(result)).toBe(true);
-      if (E.isRight(result)) {
-        console.log(`Services: ${result.right.map((s) => s.name).join(', ')}`);
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        console.log(`Services: ${result.value.map((s) => s.name).join(', ')}`);
       }
     });
 
     it('lists providers (skipped without Powerhouse)', async () => {
-      const result = await adapter.getProviders()();
+      const result = await run(adapter.getProviders());
 
-      if (E.isLeft(result) && result.left.statusCode === 403) {
+      if (!result.ok && result.error.statusCode === 403) {
         console.log('⏭️  Skipped: Requires Powerhouse plan');
         return;
       }
 
-      expect(E.isRight(result)).toBe(true);
-      if (E.isRight(result)) {
-        console.log(`Providers: ${result.right.map((p) => p.name).join(', ')}`);
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        console.log(`Providers: ${result.value.map((p) => p.name).join(', ')}`);
       }
     });
 
     it('checks availability (skipped without Powerhouse)', async () => {
-      const services = await adapter.getServices()();
+      const servicesResult = await run(adapter.getServices());
 
-      if (E.isLeft(services) && services.left.statusCode === 403) {
+      if (!servicesResult.ok && servicesResult.error.statusCode === 403) {
         console.log('⏭️  Skipped: Requires Powerhouse plan');
         return;
       }
 
-      if (E.isLeft(services)) return;
+      if (!servicesResult.ok) return;
 
       const startDate = new Date();
       const endDate = new Date();
@@ -156,14 +168,14 @@ describe.skipIf(!RUN_LIVE_TESTS)('Acuity Live API Tests', () => {
 
       const formatDate = (d: Date) => d.toISOString().split('T')[0];
 
-      const result = await adapter.getAvailableDates({
-        serviceId: services.right[0].id,
+      const result = await run(adapter.getAvailableDates({
+        serviceId: servicesResult.value[0].id,
         startDate: formatDate(startDate),
         endDate: formatDate(endDate),
-      })();
+      }));
 
-      if (E.isRight(result)) {
-        console.log(`Found ${result.right.length} available dates`);
+      if (result.ok) {
+        console.log(`Found ${result.value.length} available dates`);
       }
     });
   });

--- a/tests/live/smoke-booking.live.test.ts
+++ b/tests/live/smoke-booking.live.test.ts
@@ -18,7 +18,7 @@
  */
 
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
-import { Effect } from 'effect';
+import { Effect, Exit, Cause, Option } from 'effect';
 import type { Browser, Page } from 'playwright';
 import {
 	BrowserService,
@@ -35,7 +35,7 @@ import {
 	toBooking,
 } from '../../src/middleware/steps/index.js';
 import { createScraperAdapter } from '../../src/adapters/acuity-scraper.js';
-import * as E from 'fp-ts/Either';
+import type { SchedulingError } from '../../src/core/types.js';
 
 const RUN_SMOKE = process.env.RUN_SMOKE_TEST === 'true';
 const ACUITY_BASE_URL = 'https://MassageIthaca.as.me';
@@ -47,6 +47,17 @@ const TEST_CLIENT = {
 	lastName: 'TestBooking',
 	email: 'smoketest@massageithaca.com',
 	phone: '6075551234',
+};
+
+/** Run an Effect and return { ok, value } or { ok, error } */
+const run = async <A>(effect: Effect.Effect<A, SchedulingError>): Promise<
+	{ ok: true; value: A } | { ok: false; error: SchedulingError }
+> => {
+	const exit = await Effect.runPromiseExit(effect);
+	if (Exit.isSuccess(exit)) return { ok: true, value: exit.value };
+	const failure = Cause.failureOption(exit.cause);
+	if (Option.isSome(failure)) return { ok: false, error: failure.value };
+	throw new Error(`Unexpected defect: ${Cause.pretty(exit.cause)}`);
 };
 
 describe.skipIf(!RUN_SMOKE)('Smoke Test: Full Booking Flow', () => {
@@ -68,11 +79,11 @@ describe.skipIf(!RUN_SMOKE)('Smoke Test: Full Booking Flow', () => {
 			});
 
 			// Get services
-			const servicesResult = await scraper.getServices()();
-			expect(E.isRight(servicesResult)).toBe(true);
-			if (!E.isRight(servicesResult)) return;
+			const servicesResult = await run(scraper.getServices());
+			expect(servicesResult.ok).toBe(true);
+			if (!servicesResult.ok) return;
 
-			const services = servicesResult.right;
+			const services = servicesResult.value;
 			console.log(`  Found ${services.length} services`);
 
 			// Pick the first service with available slots
@@ -85,14 +96,14 @@ describe.skipIf(!RUN_SMOKE)('Smoke Test: Full Booking Flow', () => {
 				];
 
 				for (const month of months) {
-					const datesResult = await scraper.getAvailableDates(service.id, month)();
-					if (!E.isRight(datesResult) || datesResult.right.length === 0) continue;
+					const datesResult = await run(scraper.getAvailableDates(service.id, month));
+					if (!datesResult.ok || datesResult.value.length === 0) continue;
 
-					const date = datesResult.right[0];
-					const slotsResult = await scraper.getTimeSlots(service.id, date)();
-					if (!E.isRight(slotsResult) || slotsResult.right.length === 0) continue;
+					const date = datesResult.value[0];
+					const slotsResult = await run(scraper.getTimeSlots(service.id, date));
+					if (!slotsResult.ok || slotsResult.value.length === 0) continue;
 
-					const slot = slotsResult.right.find((s) => s.available);
+					const slot = slotsResult.value.find((s) => s.available);
 					if (!slot) continue;
 
 					targetServiceName = service.name;


### PR DESCRIPTION
## Summary
- Migrated 4 test files from fp-ts to Effect patterns (integration + live tests)
- Integration: `expectSuccess`/`expectFailureTag` + `Effect.runPromiseExit`
- Live: `E.isRight`/`E.isLeft` thunks → Effect Exit-based assertions
- Zero `fp-ts` imports remain in test files
- 505/505 tests passing (17 files, 27 integration)

## Test plan
- [x] `npx vitest run` — 505 passing
- [x] Integration config — 27 passing
- [x] Zero fp-ts grep matches