### PR TITLE
fix(ci): GitHub Packages scope @jesssullivan

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -96,7 +96,7 @@ jobs:
           node-version: 20
           cache: pnpm
           registry-url: https://npm.pkg.github.com
-          scope: '@tummycrypt'
+          scope: '@jesssullivan'
 
       - name: Install dependencies
         run: pnpm install --no-frozen-lockfile
@@ -106,7 +106,15 @@ jobs:
 
       - name: Publish to GitHub Packages
         if: ${{ github.event_name == 'release' || github.event.inputs.dry_run != 'true' }}
-        run: npm publish
+        run: |
+          # Temporarily override scope for GH Packages (npm scope != GH owner)
+          node -e "
+            const pkg = require('./package.json');
+            pkg.name = '@jesssullivan/scheduling-kit';
+            pkg.publishConfig = { registry: 'https://npm.pkg.github.com' };
+            require('fs').writeFileSync('package.json', JSON.stringify(pkg, null, 2) + '\n');
+          "
+          npm publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
npm scope @tummycrypt doesn't map to a GitHub org. Rewrites package name to @jesssullivan/scheduling-kit at publish time for the GH Packages mirror.