### PR TITLE
feat: onboarding subpackage — provider credential management

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -191,6 +191,22 @@ ts_project(
     visibility = ["//visibility:public"],
 )
 
+ts_project(
+    name = "onboarding",
+    srcs = glob(["src/onboarding/**/*.ts"], exclude = ["src/onboarding/**/*.test.ts"]),
+    declaration = True,
+    tsconfig = ":tsconfig.json",
+    transpiler = "tsc",
+    validate = False,
+    deps = [
+        ":core",
+        ":payments",
+        ":node_modules",
+        ":node_modules/effect",
+    ],
+    visibility = ["//visibility:public"],
+)
+
 # =============================================================================
 # Test targets
 # =============================================================================

--- a/package.json
+++ b/package.json
@@ -30,6 +30,10 @@
       "types": "./dist/lib/index.d.ts",
       "default": "./dist/lib/index.js"
     },
+    "./onboarding": {
+      "types": "./dist/onboarding/index.d.ts",
+      "default": "./dist/onboarding/index.js"
+    },
     "./reconciliation": {
       "types": "./dist/reconciliation/index.d.ts",
       "default": "./dist/reconciliation/index.js"

--- a/src/onboarding/index.ts
+++ b/src/onboarding/index.ts
@@ -1,0 +1,53 @@
+/**
+ * @tummycrypt/scheduling-kit/onboarding
+ *
+ * Payment provider onboarding — credential validation, OAuth flows,
+ * webhook management, and settings-driven adapter factories.
+ *
+ * Applications implement CredentialStore and EncryptionProvider
+ * to provide their own storage backend (PG, Redis, etc.).
+ *
+ * @example
+ * ```typescript
+ * import {
+ *   buildStripeAuthorizeUrl,
+ *   exchangeStripeCode,
+ *   validateStripeKeys,
+ *   createStripeWebhook,
+ *   getStripeAccountStatus,
+ *   validatePayPalCredentials,
+ *   createPayPalWebhook,
+ * } from '@tummycrypt/scheduling-kit/onboarding';
+ *
+ * // Stripe Connect OAuth
+ * const url = buildStripeAuthorizeUrl(clientId, state, redirectUri);
+ * const stripeUserId = await exchangeStripeCode(code, platformKey);
+ *
+ * // Validate keys
+ * const { valid, mode } = await validateStripeKeys(sk, pk);
+ *
+ * // Webhook setup
+ * const { webhookId, secret } = await createStripeWebhook(sk, webhookUrl);
+ * ```
+ */
+
+// Types
+export type {
+	CredentialStore,
+	EncryptionProvider,
+	StripeConnectConfig,
+	StripeAccountStatus,
+	StripeKeyValidation,
+	WebhookSetupResult,
+	AdapterFactoryConfig,
+} from './types.js';
+
+// Stripe
+export { buildStripeAuthorizeUrl, exchangeStripeCode } from './stripe/oauth.js';
+export { getStripeAccountStatus } from './stripe/account.js';
+export { validateStripeKeys } from './stripe/configure.js';
+export { createStripeWebhook, deleteStripeWebhooks } from './stripe/webhook.js';
+
+// PayPal
+export { validatePayPalCredentials } from './paypal/configure.js';
+export { createPayPalWebhook } from './paypal/webhook.js';

--- a/src/onboarding/paypal/configure.ts
+++ b/src/onboarding/paypal/configure.ts
@@ -1,0 +1,25 @@
+/**
+ * PayPal credential validation.
+ */
+
+/** Validate PayPal credentials by fetching an OAuth token. */
+export const validatePayPalCredentials = async (
+	clientId: string,
+	clientSecret: string,
+	environment: 'sandbox' | 'production' = 'sandbox',
+): Promise<boolean> => {
+	const baseUrl = environment === 'production'
+		? 'https://api-m.paypal.com'
+		: 'https://api-m.sandbox.paypal.com';
+
+	const res = await fetch(`${baseUrl}/v1/oauth2/token`, {
+		method: 'POST',
+		headers: {
+			'Authorization': `Basic ${Buffer.from(`${clientId}:${clientSecret}`).toString('base64')}`,
+			'Content-Type': 'application/x-www-form-urlencoded',
+		},
+		body: 'grant_type=client_credentials',
+	});
+
+	return res.ok;
+};

--- a/src/onboarding/paypal/webhook.ts
+++ b/src/onboarding/paypal/webhook.ts
@@ -1,0 +1,53 @@
+/**
+ * PayPal webhook management.
+ */
+
+const DEFAULT_EVENTS = [
+	'PAYMENT.CAPTURE.COMPLETED',
+	'PAYMENT.CAPTURE.DENIED',
+	'PAYMENT.CAPTURE.REFUNDED',
+	'CHECKOUT.ORDER.APPROVED',
+];
+
+/** Create a PayPal webhook. Returns webhook ID or null if creation fails (sandbox may not support HTTPS). */
+export const createPayPalWebhook = async (
+	clientId: string,
+	clientSecret: string,
+	environment: 'sandbox' | 'production',
+	webhookUrl: string,
+	events: string[] = DEFAULT_EVENTS,
+): Promise<string | null> => {
+	const baseUrl = environment === 'production'
+		? 'https://api-m.paypal.com'
+		: 'https://api-m.sandbox.paypal.com';
+
+	// Get OAuth token
+	const tokenRes = await fetch(`${baseUrl}/v1/oauth2/token`, {
+		method: 'POST',
+		headers: {
+			'Authorization': `Basic ${Buffer.from(`${clientId}:${clientSecret}`).toString('base64')}`,
+			'Content-Type': 'application/x-www-form-urlencoded',
+		},
+		body: 'grant_type=client_credentials',
+	});
+
+	if (!tokenRes.ok) return null;
+	const { access_token } = await tokenRes.json();
+
+	// Create webhook
+	const createRes = await fetch(`${baseUrl}/v1/notifications/webhooks`, {
+		method: 'POST',
+		headers: {
+			'Authorization': `Bearer ${access_token}`,
+			'Content-Type': 'application/json',
+		},
+		body: JSON.stringify({
+			url: webhookUrl,
+			event_types: events.map((name) => ({ name })),
+		}),
+	});
+
+	if (!createRes.ok) return null;
+	const webhook = await createRes.json();
+	return webhook.id;
+};

--- a/src/onboarding/stripe/account.ts
+++ b/src/onboarding/stripe/account.ts
@@ -1,0 +1,37 @@
+/**
+ * Stripe Connect account status checker.
+ */
+
+import type { StripeAccountStatus } from '../types.js';
+
+const EMPTY_STATUS: StripeAccountStatus = {
+	accountId: null,
+	chargesEnabled: false,
+	payoutsEnabled: false,
+	detailsSubmitted: false,
+};
+
+/** Check a Stripe Connect account's onboarding status. */
+export const getStripeAccountStatus = async (
+	secretKey: string | null,
+	accountId: string | null,
+): Promise<StripeAccountStatus> => {
+	if (!secretKey || !accountId) return EMPTY_STATUS;
+
+	try {
+		const res = await fetch(`https://api.stripe.com/v1/accounts/${accountId}`, {
+			headers: { 'Authorization': `Bearer ${secretKey}` },
+		});
+		if (!res.ok) return { ...EMPTY_STATUS, accountId };
+
+		const account = await res.json();
+		return {
+			accountId,
+			chargesEnabled: account.charges_enabled ?? false,
+			payoutsEnabled: account.payouts_enabled ?? false,
+			detailsSubmitted: account.details_submitted ?? false,
+		};
+	} catch {
+		return { ...EMPTY_STATUS, accountId };
+	}
+};

--- a/src/onboarding/stripe/configure.ts
+++ b/src/onboarding/stripe/configure.ts
@@ -1,0 +1,33 @@
+/**
+ * Stripe key validation.
+ */
+
+import type { StripeKeyValidation } from '../types.js';
+
+/** Validate Stripe API keys by calling GET /v1/account. */
+export const validateStripeKeys = async (
+	secretKey: string,
+	publishableKey: string,
+): Promise<StripeKeyValidation> => {
+	if (!secretKey.startsWith('sk_'))
+		return { valid: false, mode: 'test', error: 'Secret key must start with sk_live_ or sk_test_' };
+	if (!publishableKey.startsWith('pk_'))
+		return { valid: false, mode: 'test', error: 'Publishable key must start with pk_live_ or pk_test_' };
+
+	try {
+		const res = await fetch('https://api.stripe.com/v1/account', {
+			headers: { 'Authorization': `Bearer ${secretKey}` },
+		});
+		if (!res.ok) {
+			const err = await res.json().catch(() => ({}));
+			return {
+				valid: false,
+				mode: secretKey.startsWith('sk_live_') ? 'live' : 'test',
+				error: (err as Record<string, any>).error?.message ?? `HTTP ${res.status}`,
+			};
+		}
+		return { valid: true, mode: secretKey.startsWith('sk_live_') ? 'live' : 'test' };
+	} catch {
+		return { valid: false, mode: 'test', error: 'Could not connect to Stripe' };
+	}
+};

--- a/src/onboarding/stripe/oauth.ts
+++ b/src/onboarding/stripe/oauth.ts
@@ -1,0 +1,54 @@
+/**
+ * Stripe Connect OAuth helpers.
+ *
+ * Pure functions for building authorize URLs and exchanging
+ * authorization codes. No framework dependency.
+ */
+
+import type { StripeConnectConfig } from '../types.js';
+
+/** Build the Stripe Connect OAuth authorize URL. */
+export const buildStripeAuthorizeUrl = (
+	clientId: string,
+	state: string,
+	redirectUri: string,
+): string => {
+	const params = new URLSearchParams({
+		response_type: 'code',
+		client_id: clientId,
+		scope: 'read_write',
+		redirect_uri: redirectUri,
+		state,
+	});
+	return `https://connect.stripe.com/oauth/authorize?${params}`;
+};
+
+/**
+ * Exchange an authorization code for a stripe_user_id.
+ * Uses the platform's secret key as client_secret.
+ * Returns the connected account ID (acct_...).
+ */
+export const exchangeStripeCode = async (
+	code: string,
+	platformKey: string,
+): Promise<string> => {
+	const res = await fetch('https://connect.stripe.com/oauth/token', {
+		method: 'POST',
+		headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+		body: new URLSearchParams({
+			grant_type: 'authorization_code',
+			code,
+			client_secret: platformKey,
+		}),
+	});
+
+	if (!res.ok) {
+		const err = await res.json().catch(() => ({}));
+		throw new Error(
+			`Stripe OAuth exchange failed: ${(err as Record<string, string>).error_description || res.status}`,
+		);
+	}
+
+	const data = await res.json();
+	return data.stripe_user_id;
+};

--- a/src/onboarding/stripe/webhook.ts
+++ b/src/onboarding/stripe/webhook.ts
@@ -1,0 +1,71 @@
+/**
+ * Stripe webhook management.
+ */
+
+import type { WebhookSetupResult } from '../types.js';
+
+const DEFAULT_EVENTS = [
+	'payment_intent.succeeded',
+	'payment_intent.payment_failed',
+	'payment_intent.canceled',
+	'charge.refunded',
+	'charge.refund.updated',
+];
+
+/** Delete existing webhooks matching a URL pattern. Returns count deleted. */
+export const deleteStripeWebhooks = async (
+	secretKey: string,
+	urlPattern: string,
+): Promise<number> => {
+	const headers = { Authorization: `Bearer ${secretKey}` };
+	const listRes = await fetch('https://api.stripe.com/v1/webhook_endpoints?limit=100', { headers });
+	if (!listRes.ok) return 0;
+
+	const { data } = await listRes.json();
+	let deleted = 0;
+	for (const wh of data ?? []) {
+		if (wh.url?.includes(urlPattern)) {
+			const delRes = await fetch(`https://api.stripe.com/v1/webhook_endpoints/${wh.id}`, {
+				method: 'DELETE',
+				headers,
+			});
+			if (delRes.ok) deleted++;
+		}
+	}
+	return deleted;
+};
+
+/** Create a Stripe webhook endpoint. Returns the signing secret (only available at creation). */
+export const createStripeWebhook = async (
+	secretKey: string,
+	webhookUrl: string,
+	events: string[] = DEFAULT_EVENTS,
+): Promise<WebhookSetupResult> => {
+	const headers = {
+		Authorization: `Bearer ${secretKey}`,
+		'Content-Type': 'application/x-www-form-urlencoded',
+	};
+
+	const params = new URLSearchParams();
+	params.append('url', webhookUrl);
+	for (const evt of events) params.append('enabled_events[]', evt);
+	params.append('description', 'scheduling-kit auto-setup');
+
+	const res = await fetch('https://api.stripe.com/v1/webhook_endpoints', {
+		method: 'POST',
+		headers,
+		body: params.toString(),
+	});
+
+	if (!res.ok) {
+		const err = await res.json().catch(() => ({}));
+		throw new Error(`Stripe webhook creation failed: ${(err as any).error?.message ?? res.status}`);
+	}
+
+	const webhook = await res.json();
+	return {
+		webhookId: webhook.id,
+		secret: webhook.secret,
+		url: webhookUrl,
+	};
+};

--- a/src/onboarding/types.ts
+++ b/src/onboarding/types.ts
@@ -1,0 +1,80 @@
+/**
+ * Onboarding interfaces — app-provided abstractions for credential
+ * storage, encryption, and payment provider management.
+ *
+ * scheduling-kit defines the contracts. Applications implement them
+ * with their chosen infrastructure (PG, Redis, Vault, etc.).
+ */
+
+// ---------------------------------------------------------------------------
+// Credential Storage
+// ---------------------------------------------------------------------------
+
+/**
+ * App-provided key-value store for payment credentials.
+ * scheduling-kit reads/writes through this interface — it doesn't
+ * know about Postgres, Redis, or any specific database.
+ */
+export interface CredentialStore {
+	get(key: string): Promise<string | null>;
+	getMultiple(keys: string[]): Promise<Record<string, string | null>>;
+	set(key: string, value: string, userId?: string): Promise<void>;
+	delete(key: string): Promise<void>;
+	deleteMultiple(keys: string[]): Promise<number>;
+}
+
+/**
+ * App-provided encryption for sensitive credentials.
+ * Values are encrypted before storage and decrypted on retrieval.
+ */
+export interface EncryptionProvider {
+	encrypt(plaintext: string): string;
+	decrypt(stored: string): string;
+	shouldEncrypt(key: string): boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Stripe Connect
+// ---------------------------------------------------------------------------
+
+export interface StripeConnectConfig {
+	readonly clientId: string;
+	readonly platformKey: string;
+	readonly redirectUri: string;
+}
+
+export interface StripeAccountStatus {
+	readonly accountId: string | null;
+	readonly chargesEnabled: boolean;
+	readonly payoutsEnabled: boolean;
+	readonly detailsSubmitted: boolean;
+}
+
+export interface StripeKeyValidation {
+	readonly valid: boolean;
+	readonly mode: 'live' | 'test';
+	readonly error?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Webhooks
+// ---------------------------------------------------------------------------
+
+export interface WebhookSetupResult {
+	readonly webhookId: string;
+	readonly secret: string;
+	readonly url: string;
+}
+
+// ---------------------------------------------------------------------------
+// Adapter Factory
+// ---------------------------------------------------------------------------
+
+/**
+ * Configuration for settings-driven adapter factories.
+ * The store provides credentials, the factory creates the adapter.
+ */
+export interface AdapterFactoryConfig {
+	readonly store: CredentialStore;
+	readonly encryption?: EncryptionProvider;
+}


### PR DESCRIPTION
## Summary
New `@tummycrypt/scheduling-kit/onboarding` subpackage for payment provider credential management, OAuth flows, and webhook setup.

- `CredentialStore` + `EncryptionProvider` interfaces (app-provided)
- Stripe: OAuth, account status, key validation, webhook CRUD
- PayPal: credential validation, webhook creation
- Bazel `//src/onboarding` target
- `./onboarding` package.json export

## Pattern
Library defines interfaces + pure helpers. Application implements `CredentialStore` with its DB (PG, Redis, etc.). Same DI pattern as HomegrownAdapter's `getDb` callback.

## Adding a new provider
```
src/onboarding/square/
├── configure.ts    # validateSquareCredentials()
├── webhook.ts      # createSquareWebhook()
├── oauth.ts        # buildSquareAuthorizeUrl()
└── factory.ts      # createSettingsSquareAdapter()
```

Closes #21, #22, #23, #24, #27