### PR TITLE
feat: provider status helpers + SetupStep type (#32)

### DIFF
--- a/src/onboarding/__tests__/onboarding.test.ts
+++ b/src/onboarding/__tests__/onboarding.test.ts
@@ -11,7 +11,153 @@ import { validateStripeKeys } from '../stripe/configure.js';
 import { getStripeAccountStatus } from '../stripe/account.js';
 import { validatePayPalCredentials } from '../paypal/configure.js';
 import { createAdapterFactory } from '../factory.js';
+import {
+	getStripeStatus,
+	getPayPalStatus,
+	getStripeSetupSteps,
+	getPayPalSetupSteps,
+	getOverallProgress,
+	type StripeState,
+	type PayPalState,
+} from '../status.js';
 import type { CredentialStore } from '../types.js';
+
+// ---------------------------------------------------------------------------
+// Status helpers
+// ---------------------------------------------------------------------------
+
+describe('Provider status', () => {
+	const emptyStripe: StripeState = {
+		platformConfigured: false, accountId: null,
+		chargesEnabled: false, payoutsEnabled: false, detailsSubmitted: false,
+		webhookConfigured: false,
+	};
+
+	it('stripe: not_configured when no platform keys', () => {
+		expect(getStripeStatus(emptyStripe)).toBe('not_configured');
+	});
+
+	it('stripe: incomplete when platform configured but no charges', () => {
+		expect(getStripeStatus({ ...emptyStripe, platformConfigured: true })).toBe('incomplete');
+	});
+
+	it('stripe: incomplete when account exists but not verified', () => {
+		expect(getStripeStatus({ ...emptyStripe, accountId: 'acct_1', detailsSubmitted: true })).toBe('incomplete');
+	});
+
+	it('stripe: connected when charges + payouts enabled', () => {
+		expect(getStripeStatus({
+			...emptyStripe, platformConfigured: true, accountId: 'acct_1',
+			chargesEnabled: true, payoutsEnabled: true, detailsSubmitted: true, webhookConfigured: true,
+		})).toBe('connected');
+	});
+
+	it('paypal: not_configured when no platform keys', () => {
+		expect(getPayPalStatus({ platformConfigured: false, payeeEmail: null })).toBe('not_configured');
+	});
+
+	it('paypal: incomplete when platform configured but no email', () => {
+		expect(getPayPalStatus({ platformConfigured: true, payeeEmail: null })).toBe('incomplete');
+	});
+
+	it('paypal: connected when platform + email', () => {
+		expect(getPayPalStatus({ platformConfigured: true, payeeEmail: 'jen@example.com' })).toBe('connected');
+	});
+});
+
+describe('Setup steps', () => {
+	it('stripe: first step current when nothing configured', () => {
+		const steps = getStripeSetupSteps({
+			platformConfigured: false, accountId: null,
+			chargesEnabled: false, payoutsEnabled: false, detailsSubmitted: false,
+			webhookConfigured: false,
+		});
+		expect(steps[0].current).toBe(true);
+		expect(steps[0].complete).toBe(false);
+		expect(steps[1].current).toBe(false);
+		expect(steps[2].current).toBe(false);
+	});
+
+	it('stripe: second step current after platform configured', () => {
+		const steps = getStripeSetupSteps({
+			platformConfigured: true, accountId: null,
+			chargesEnabled: false, payoutsEnabled: false, detailsSubmitted: false,
+			webhookConfigured: false,
+		});
+		expect(steps[0].complete).toBe(true);
+		expect(steps[1].current).toBe(true);
+	});
+
+	it('stripe: third step current after account linked', () => {
+		const steps = getStripeSetupSteps({
+			platformConfigured: true, accountId: 'acct_1',
+			chargesEnabled: false, payoutsEnabled: false, detailsSubmitted: true,
+			webhookConfigured: false,
+		});
+		expect(steps[0].complete).toBe(true);
+		expect(steps[1].complete).toBe(true);
+		expect(steps[2].current).toBe(true);
+	});
+
+	it('stripe: all complete when fully configured', () => {
+		const steps = getStripeSetupSteps({
+			platformConfigured: true, accountId: 'acct_1',
+			chargesEnabled: true, payoutsEnabled: true, detailsSubmitted: true,
+			webhookConfigured: true,
+		});
+		expect(steps.every(s => s.complete)).toBe(true);
+		expect(steps.every(s => !s.current)).toBe(true);
+	});
+
+	it('paypal: first step current when nothing configured', () => {
+		const steps = getPayPalSetupSteps({ platformConfigured: false, payeeEmail: null });
+		expect(steps[0].current).toBe(true);
+		expect(steps[1].current).toBe(false);
+	});
+
+	it('paypal: second step current after platform configured', () => {
+		const steps = getPayPalSetupSteps({ platformConfigured: true, payeeEmail: null });
+		expect(steps[0].complete).toBe(true);
+		expect(steps[1].current).toBe(true);
+	});
+
+	it('paypal: all complete when connected', () => {
+		const steps = getPayPalSetupSteps({ platformConfigured: true, payeeEmail: 'a@b.com' });
+		expect(steps.every(s => s.complete)).toBe(true);
+	});
+});
+
+describe('Overall progress', () => {
+	it('0 of 5 when nothing configured', () => {
+		const p = getOverallProgress(
+			{ platformConfigured: false, accountId: null, chargesEnabled: false, payoutsEnabled: false, detailsSubmitted: false, webhookConfigured: false },
+			{ platformConfigured: false, payeeEmail: null },
+		);
+		expect(p.complete).toBe(0);
+		expect(p.total).toBe(5);
+	});
+
+	it('5 of 5 when everything configured', () => {
+		const p = getOverallProgress(
+			{ platformConfigured: true, accountId: 'acct_1', chargesEnabled: true, payoutsEnabled: true, detailsSubmitted: true, webhookConfigured: true },
+			{ platformConfigured: true, payeeEmail: 'a@b.com' },
+		);
+		expect(p.complete).toBe(5);
+		expect(p.total).toBe(5);
+	});
+
+	it('partial progress tracked correctly', () => {
+		const p = getOverallProgress(
+			{ platformConfigured: true, accountId: null, chargesEnabled: false, payoutsEnabled: false, detailsSubmitted: false, webhookConfigured: false },
+			{ platformConfigured: true, payeeEmail: 'a@b.com' },
+		);
+		expect(p.complete).toBe(3); // stripe platform + paypal platform + paypal email
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Existing tests
+// ---------------------------------------------------------------------------
 
 describe('Stripe OAuth', () => {
 	it('builds correct authorize URL', () => {

--- a/src/onboarding/index.ts
+++ b/src/onboarding/index.ts
@@ -45,6 +45,19 @@ export type {
 // Factory
 export { createAdapterFactory, type AdapterFactory } from './factory.js';
 
+// Status helpers
+export {
+	getStripeStatus,
+	getPayPalStatus,
+	getStripeSetupSteps,
+	getPayPalSetupSteps,
+	getOverallProgress,
+	type ProviderStatus,
+	type SetupStep,
+	type StripeState,
+	type PayPalState,
+} from './status.js';
+
 // Stripe
 export { buildStripeAuthorizeUrl, exchangeStripeCode } from './stripe/oauth.js';
 export { getStripeAccountStatus } from './stripe/account.js';

--- a/src/onboarding/status.ts
+++ b/src/onboarding/status.ts
@@ -1,0 +1,105 @@
+/**
+ * Provider status helpers for UI consumption.
+ *
+ * Pure functions that compute setup step completion from state.
+ * Framework-agnostic — apps use these to drive their own UI.
+ */
+
+export type ProviderStatus = 'connected' | 'incomplete' | 'not_configured';
+
+export interface SetupStep {
+	readonly id: string;
+	readonly label: string;
+	readonly description: string;
+	readonly complete: boolean;
+	readonly current: boolean;
+}
+
+export interface StripeState {
+	readonly platformConfigured: boolean;
+	readonly accountId: string | null;
+	readonly chargesEnabled: boolean;
+	readonly payoutsEnabled: boolean;
+	readonly detailsSubmitted: boolean;
+	readonly webhookConfigured: boolean;
+}
+
+export interface PayPalState {
+	readonly platformConfigured: boolean;
+	readonly payeeEmail: string | null;
+}
+
+export const getStripeStatus = (state: StripeState): ProviderStatus => {
+	if (state.chargesEnabled && state.payoutsEnabled) return 'connected';
+	if (state.platformConfigured || state.accountId) return 'incomplete';
+	return 'not_configured';
+};
+
+export const getPayPalStatus = (state: PayPalState): ProviderStatus => {
+	if (state.platformConfigured && state.payeeEmail) return 'connected';
+	if (state.platformConfigured) return 'incomplete';
+	return 'not_configured';
+};
+
+export const getStripeSetupSteps = (state: StripeState): SetupStep[] => {
+	const platformDone = state.platformConfigured;
+	const accountDone = !!(state.accountId && state.detailsSubmitted);
+	const webhookDone = state.webhookConfigured;
+
+	return [
+		{
+			id: 'platform',
+			label: 'Platform Keys',
+			description: 'Enter your Stripe API keys to enable payment processing.',
+			complete: platformDone,
+			current: !platformDone,
+		},
+		{
+			id: 'connect',
+			label: 'Link Your Account',
+			description: 'Connect your Stripe account to receive payments directly.',
+			complete: accountDone,
+			current: platformDone && !accountDone,
+		},
+		{
+			id: 'webhook',
+			label: 'Payment Notifications',
+			description: 'Set up automatic payment status updates.',
+			complete: webhookDone,
+			current: platformDone && accountDone && !webhookDone,
+		},
+	];
+};
+
+export const getPayPalSetupSteps = (state: PayPalState): SetupStep[] => {
+	const platformDone = state.platformConfigured;
+	const emailDone = !!state.payeeEmail;
+
+	return [
+		{
+			id: 'platform',
+			label: 'Platform Credentials',
+			description: 'Enter your PayPal API credentials to enable Venmo payments.',
+			complete: platformDone,
+			current: !platformDone,
+		},
+		{
+			id: 'email',
+			label: 'Your PayPal Email',
+			description: 'Payments from clients will be routed to this account.',
+			complete: emailDone,
+			current: platformDone && !emailDone,
+		},
+	];
+};
+
+/** Count completed steps across all providers. */
+export const getOverallProgress = (stripe: StripeState, paypal: PayPalState): { complete: number; total: number } => {
+	const stripeSteps = getStripeSetupSteps(stripe);
+	const paypalSteps = getPayPalSetupSteps(paypal);
+	const all = [...stripeSteps, ...paypalSteps];
+	return {
+		complete: all.filter((s) => s.complete).length,
+		total: all.length,
+	};
+};


### PR DESCRIPTION
getStripeSetupSteps(), getPayPalSetupSteps(), getOverallProgress() + 17 tests. Pure logic for UI step indicators.