### PR TITLE
[codex] Sprint S build truth and package boundary cleanup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [main]
 
+env:
+  PNPM_VERSION: 9.15.9
+  DEFAULT_NODE_VERSION: 22
+
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -19,7 +23,7 @@ jobs:
 
       - uses: pnpm/action-setup@v4
         with:
-          version: 9.15.9
+          version: ${{ env.PNPM_VERSION }}
 
       - uses: actions/setup-node@v4
         with:
@@ -27,7 +31,7 @@ jobs:
           cache: pnpm
 
       - name: Install dependencies
-        run: pnpm install --no-frozen-lockfile
+        run: pnpm install --frozen-lockfile
 
       - name: Sync SvelteKit
         run: pnpm exec svelte-kit sync
@@ -58,15 +62,15 @@ jobs:
 
       - uses: pnpm/action-setup@v4
         with:
-          version: 9.15.9
+          version: ${{ env.PNPM_VERSION }}
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: ${{ env.DEFAULT_NODE_VERSION }}
           cache: pnpm
 
       - name: Install dependencies
-        run: pnpm install --no-frozen-lockfile
+        run: pnpm install --frozen-lockfile
 
       - name: Build
         run: pnpm build

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,6 +11,10 @@ on:
         type: boolean
         default: true
 
+env:
+  PNPM_VERSION: 9.15.9
+  DEFAULT_NODE_VERSION: 22
+
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -19,18 +23,18 @@ jobs:
 
       - uses: pnpm/action-setup@v4
         with:
-          version: 9.15.9
+          version: ${{ env.PNPM_VERSION }}
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: ${{ env.DEFAULT_NODE_VERSION }}
           cache: pnpm
 
       - name: Install dependencies
-        run: pnpm install --no-frozen-lockfile
+        run: pnpm install --frozen-lockfile
 
       - name: Sync SvelteKit
-        run: npx svelte-kit sync
+        run: pnpm exec svelte-kit sync
 
       - name: Run tests
         run: pnpm test:unit
@@ -52,16 +56,16 @@ jobs:
 
       - uses: pnpm/action-setup@v4
         with:
-          version: 9.15.9
+          version: ${{ env.PNPM_VERSION }}
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: ${{ env.DEFAULT_NODE_VERSION }}
           cache: pnpm
           registry-url: https://registry.npmjs.org
 
       - name: Install dependencies
-        run: pnpm install --no-frozen-lockfile
+        run: pnpm install --frozen-lockfile
 
       - name: Build
         run: pnpm build
@@ -89,17 +93,17 @@ jobs:
 
       - uses: pnpm/action-setup@v4
         with:
-          version: 9.15.9
+          version: ${{ env.PNPM_VERSION }}
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: ${{ env.DEFAULT_NODE_VERSION }}
           cache: pnpm
           registry-url: https://npm.pkg.github.com
           scope: '@jesssullivan'
 
       - name: Install dependencies
-        run: pnpm install --no-frozen-lockfile
+        run: pnpm install --frozen-lockfile
 
       - name: Build
         run: pnpm build

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,7 +1,7 @@
 """
 BUILD.bazel for @tummycrypt/scheduling-kit.
 
-Dual-mode build: works with both pnpm (standalone) and Bazel (CI/production).
+Dual-mode build: pnpm remains the publish path, Bazel provides the hermetic graph.
   Standalone: pnpm build            (svelte-kit sync && svelte-package)
   Bazel:      bazel build //:pkg    (hermetic, cacheable)
 
@@ -87,7 +87,7 @@ npm_package(
     ],
     package = "@tummycrypt/scheduling-kit",
     tags = ["manual"],
-    version = "0.5.0",
+    version = "0.6.1",
     visibility = ["//visibility:public"],
 )
 

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -5,6 +5,7 @@ Backend-agnostic scheduling library with pluggable adapters, payment processors,
 and Svelte UI components. Published as @tummycrypt/scheduling-kit on npm.
 
 Bzlmod-native configuration for Bazel 8+.
+CI and publishing remain pnpm-driven today; Bazel targets are the hermetic build graph.
 
 Build targets:
   bazel build //:scheduling_kit       # Svelte package build (dist/)
@@ -21,7 +22,7 @@ Subpackage targets (finer-grained caching):
 
 module(
     name = "tummycrypt_scheduling_kit",
-    version = "0.5.0",
+    version = "0.6.1",
     compatibility_level = 1,
 )
 

--- a/README.md
+++ b/README.md
@@ -1,18 +1,18 @@
 # @tummycrypt/scheduling-kit
 
-Backend-agnostic scheduling system with Svelte 5 components, multiple scheduling adapters, and alternative payment support. Built with fp-ts for functional composition and Zod for runtime validation.
+Backend-agnostic scheduling system with Svelte 5 components, multiple scheduling adapters, and alternative payment support. Built with Effect for typed workflows and Zod for runtime validation.
 
 Docs, prebuilts, packages and blog post to come later.  Another tinyland artifact it is time to publish.  This package powers scheduling transactions for small buisnesses in the eastern US for whom I've done contracting work. 
 
 ## Features
 
-- **Multiple scheduling backends** -- Acuity, Cal.com, or bring-your-own PostgreSQL (HomegrownAdapter)
+- **Multiple scheduling backends** -- Acuity REST API, Cal.com, or bring-your-own PostgreSQL (HomegrownAdapter)
 - **Svelte 5 components** -- ServicePicker, DateTimePicker, ClientForm, CheckoutDrawer, and more
 - **Payment adapters** -- Stripe, Venmo/PayPal SDK, cash, Zelle, check
 - **Availability engine** -- Pure-function slot generation, DST-safe via `Intl.DateTimeFormat`
 - **Reconciliation** -- Alt-payment matching and webhook handling
 - **Test infrastructure** -- Cassette-based API recording/playback, MSW mocking, property-based tests
-- **Functional core** -- fp-ts `TaskEither` pipelines throughout
+- **Functional core** -- Effect-powered scheduling flows and typed error handling
 
 ## Installation
 
@@ -36,6 +36,7 @@ pnpm add -D playwright-core
 ## Quick Start
 
 ```typescript
+import { Effect } from 'effect';
 import {
   createSchedulingKit,
   createHomegrownAdapter,
@@ -67,7 +68,9 @@ const venmo = createVenmoAdapter({
 const kit = createSchedulingKit(scheduler, [stripe, venmo]);
 
 // Complete a booking
-const result = await kit.completeBooking(request, 'stripe')();
+const result = await Effect.runPromise(
+  kit.completeBooking(request, 'stripe')
+);
 ```
 
 ## Adapters
@@ -90,6 +93,7 @@ const adapter = createHomegrownAdapter({
 ### AcuityAdapter
 
 API-based adapter for Acuity Scheduling (requires Powerhouse plan).
+For browser automation and no-API migration flows, use `@tummycrypt/scheduling-bridge`.
 
 ```typescript
 import { createAcuityAdapter } from '@tummycrypt/scheduling-kit/adapters';
@@ -152,11 +156,11 @@ Svelte 5 components using runes syntax. Optional Skeleton 4 integration for styl
 | `ProviderPicker` | Practitioner/provider selector |
 | `BookingConfirmation` | Post-booking confirmation display |
 | `CheckoutDrawer` | Full checkout flow in a slide-out drawer |
-| `HybridCheckoutDrawer` | Checkout with Acuity embed handoff |
+| `HybridCheckoutDrawer` | Checkout with Acuity iframe handoff |
 | `VenmoButton` | Venmo/PayPal payment button |
 | `VenmoCheckout` | Full Venmo checkout flow |
 | `StripeCheckout` | Stripe Elements checkout |
-| `AcuityEmbedHandoff` | Acuity iframe embed with message passing |
+| `AcuityEmbedHandoff` | Acuity iframe handoff with postMessage integration |
 
 ```svelte
 <script lang="ts">

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.6.1",
   "description": "Backend-agnostic scheduling components with alternative payment support",
   "type": "module",
+  "packageManager": "pnpm@9.15.9",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
@@ -90,7 +91,7 @@
     }
   },
   "dependencies": {
-    "@tummycrypt/tinyland-auth-pg": "0.1.0",
+    "@tummycrypt/tinyland-auth-pg": "^0.1.1",
     "drizzle-orm": "0.39.3",
     "effect": "^3.19.14",
     "zod": "^4.3.5"
@@ -136,12 +137,12 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/Jesssullivan/scheduling-kit.git"
+    "url": "git+https://github.com/Jesssullivan/scheduling-kit.git"
   },
   "publishConfig": {
     "access": "public"
   },
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=20 <25"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,8 +15,8 @@ importers:
         specifier: ^4.0.0
         version: 4.13.0(svelte@5.54.1)
       '@tummycrypt/tinyland-auth-pg':
-        specifier: 0.1.0
-        version: 0.1.0(@tummycrypt/tinyland-auth@0.2.0(@sveltejs/kit@2.55.0(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.54.1)(vite@6.4.1(@types/node@20.19.37)))(svelte@5.54.1)(typescript@5.9.3)(vite@6.4.1(@types/node@20.19.37)))(svelte@5.54.1))(@types/pg@8.11.6)
+        specifier: ^0.1.1
+        version: 0.1.1(@tummycrypt/tinyland-auth@0.2.0(@sveltejs/kit@2.55.0(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.54.1)(vite@6.4.1(@types/node@20.19.37)))(svelte@5.54.1)(typescript@5.9.3)(vite@6.4.1(@types/node@20.19.37)))(svelte@5.54.1))(@types/pg@8.11.6)
       drizzle-orm:
         specifier: 0.39.3
         version: 0.39.3(@neondatabase/serverless@0.10.4)(@types/pg@8.11.6)
@@ -731,8 +731,8 @@ packages:
       vitest:
         optional: true
 
-  '@tummycrypt/tinyland-auth-pg@0.1.0':
-    resolution: {integrity: sha512-FH+2xb/yXOFXVxGB59xpzkttkuxdAcB9A3PDWoihRaj8s5ljrbwzBH8JO/vK8zBxifFx/z/6yUqp3KsofKJ2Wg==}
+  '@tummycrypt/tinyland-auth-pg@0.1.1':
+    resolution: {integrity: sha512-ASAeuCRKptgt6c0piTq32FahJgErwo1iQLwcGN3Pzh1EDZh9IB8BEaXHpg5KwaGcM5klrjdgW/hH47agmcC5FQ==}
     peerDependencies:
       '@tummycrypt/tinyland-auth': ^0.2.0
 
@@ -2788,7 +2788,7 @@ snapshots:
       vite: 6.4.1(@types/node@20.19.37)
       vitest: 4.1.0(@types/node@20.19.37)(jsdom@28.1.0)(msw@2.7.0(@types/node@20.19.37)(typescript@5.9.3))(vite@6.4.1(@types/node@20.19.37))
 
-  '@tummycrypt/tinyland-auth-pg@0.1.0(@tummycrypt/tinyland-auth@0.2.0(@sveltejs/kit@2.55.0(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.54.1)(vite@6.4.1(@types/node@20.19.37)))(svelte@5.54.1)(typescript@5.9.3)(vite@6.4.1(@types/node@20.19.37)))(svelte@5.54.1))(@types/pg@8.11.6)':
+  '@tummycrypt/tinyland-auth-pg@0.1.1(@tummycrypt/tinyland-auth@0.2.0(@sveltejs/kit@2.55.0(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.54.1)(vite@6.4.1(@types/node@20.19.37)))(svelte@5.54.1)(typescript@5.9.3)(vite@6.4.1(@types/node@20.19.37)))(svelte@5.54.1))(@types/pg@8.11.6)':
     dependencies:
       '@neondatabase/serverless': 0.10.4
       '@tummycrypt/tinyland-auth': 0.2.0(@sveltejs/kit@2.55.0(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.54.1)(vite@6.4.1(@types/node@20.19.37)))(svelte@5.54.1)(typescript@5.9.3)(vite@6.4.1(@types/node@20.19.37)))(svelte@5.54.1)

--- a/src/adapters/index.ts
+++ b/src/adapters/index.ts
@@ -5,7 +5,8 @@
 // Types
 export * from './types.js';
 
-// Acuity Adapter (API-based, requires Powerhouse plan)
+// Acuity Adapter (API-based, requires Powerhouse plan).
+// Browser automation lives in @tummycrypt/scheduling-bridge.
 export { createAcuityAdapter } from './acuity.js';
 
 // Cal.com Adapter (stub for future migration)

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,10 +2,11 @@
  * @tummycrypt/scheduling-kit
  *
  * Backend-agnostic scheduling components with alternative payment support.
- * Built with Svelte 5 and fp-ts for functional composition.
+ * Built with Svelte 5 and Effect for typed workflow composition.
  *
  * @example
  * ```typescript
+ * import { Effect } from 'effect';
  * import {
  *   createSchedulingKit,
  *   createAcuityAdapter,
@@ -30,7 +31,9 @@
  * const kit = createSchedulingKit(scheduler, [venmo]);
  *
  * // Complete a booking
- * const result = await kit.completeBooking(request, 'venmo')();
+ * const result = await Effect.runPromise(
+ *   kit.completeBooking(request, 'venmo')
+ * );
  * ```
  */
 


### PR DESCRIPTION
## What changed
- align Bazel metadata with the published package version and current package policy
- tighten CI and publish workflows around the current pnpm and Node expectations
- update internal dependency alignment and packageManager metadata
- refresh docs and package-level examples to match the Effect-era API surface
- clarify that browser automation belongs in @tummycrypt/scheduling-bridge while Acuity REST/embed helpers stay here

## Why
The package had drift between Bazel, npm metadata, CI assumptions, and public docs. This brings the repo back to one coherent source of truth and sharpens the boundary with the bridge.

## Impact
- build metadata, publish workflow, and docs now describe the same package reality
- consumers get a clearer separation between headless scheduling-kit features and bridge-owned automation concerns

## Validation
- pnpm test:unit
- pnpm build
- pnpm publint