### PR TITLE
feat(payments)!: converge PaymentCapabilities contract from tinyland-inc

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -157,12 +157,12 @@ jobs:
             pkg.publishConfig = { registry: 'https://npm.pkg.github.com' };
             require('fs').writeFileSync('package.json', JSON.stringify(pkg, null, 2) + '\n');
           "
-          npm publish
+          npm publish --ignore-scripts
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Publish dry run
         if: ${{ github.event.inputs.dry_run == 'true' }}
-        run: npm publish --dry-run
+        run: npm publish --dry-run --ignore-scripts
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -87,7 +87,7 @@ npm_package(
     ],
     package = "@tummycrypt/scheduling-kit",
     tags = ["manual"],
-    version = "0.6.1",
+    version = "0.7.0",
     visibility = ["//visibility:public"],
 )
 

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -22,7 +22,7 @@ Subpackage targets (finer-grained caching):
 
 module(
     name = "tummycrypt_scheduling_kit",
-    version = "0.6.1",
+    version = "0.7.0",
     compatibility_level = 1,
 )
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tummycrypt/scheduling-kit",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "description": "Backend-agnostic scheduling components with alternative payment support",
   "type": "module",
   "packageManager": "pnpm@9.15.9",

--- a/src/components/HybridCheckoutDrawer.svelte
+++ b/src/components/HybridCheckoutDrawer.svelte
@@ -5,7 +5,7 @@
    *
    * Flow:
    * 1. Custom UI for service/provider/datetime/client selection
-   * 2. Payment method selection (Venmo, Card via Stripe, Cash)
+   * 2. Payment method selection (Venmo, Card via Stripe)
    * 3. Collect payment via our own adapter
    * 4. Book on Acuity at $0 via wizard automation
    */
@@ -20,6 +20,8 @@
   import BookingConfirmation from './BookingConfirmation.svelte';
   import VenmoCheckout from './VenmoCheckout.svelte';
   import StripeCheckout from './StripeCheckout.svelte';
+  import type { PaymentCapabilities } from '../payments/types.js';
+  import { getDefaultCapabilities } from '../payments/types.js';
 
   // =============================================================================
   // TYPES
@@ -37,13 +39,6 @@
     | 'complete'
     | 'error';
 
-  interface PaymentOption {
-    id: string;
-    name: string;
-    icon: string;
-    description: string;
-  }
-
   // =============================================================================
   // PROPS
   // =============================================================================
@@ -54,9 +49,7 @@
     providers = [],
     loadingServices = false,
     loadingProviders = false,
-    paypalClientId,
-    paypalEnvironment = 'sandbox',
-    stripePublishableKey,
+    capabilities = getDefaultCapabilities(),
     onClose,
     onLoadDates,
     onLoadSlots,
@@ -64,7 +57,6 @@
     onCapturePayment,
     onCreateStripeIntent,
     onBookWithPaymentRef,
-    onCashPayment,
     onBookingComplete,
     timezone = 'America/New_York',
     skipProvider = false,
@@ -80,12 +72,8 @@
     loadingServices?: boolean;
     /** Loading state for providers */
     loadingProviders?: boolean;
-    /** PayPal Client ID for Venmo SDK */
-    paypalClientId?: string;
-    /** PayPal environment */
-    paypalEnvironment?: 'sandbox' | 'production';
-    /** Stripe publishable key (enables card payment option) */
-    stripePublishableKey?: string;
+    /** Server-derived payment capabilities */
+    capabilities?: PaymentCapabilities;
     /** Close callback */
     onClose?: () => void;
     /** Load available dates callback (startDate/endDate override default 60-day window) */
@@ -100,8 +88,6 @@
     onCreateStripeIntent?: (params: { amount: number; currency: string; description: string }) => Promise<{ clientSecret: string; intentId: string }>;
     /** Create booking with a pre-captured payment reference */
     onBookWithPaymentRef?: (params: { serviceId: string; datetime: string; client: ClientInfo; paymentRef: string; paymentProcessor: string }) => Promise<{ booking: Partial<Booking> }>;
-    /** Process Cash payment callback */
-    onCashPayment?: (data: { service: Service; client: ClientInfo; datetime: string }) => Promise<void>;
     /** Booking complete callback */
     onBookingComplete?: (booking: Partial<Booking> | AcuityBookingData) => void;
     /** IANA timezone for date/time display */
@@ -136,33 +122,8 @@
   // Stripe intent (created server-side when user selects card payment)
   let stripeIntent = $state<{ clientSecret: string; intentId: string } | undefined>(undefined);
 
-  // Payment options — dynamically built from available adapters
-  const paymentOptions = $derived.by(() => {
-    const opts: PaymentOption[] = [];
-    if (paypalClientId) {
-      opts.push({
-        id: 'venmo',
-        name: 'Venmo',
-        icon: '💙',
-        description: 'Pay with Venmo',
-      });
-    }
-    if (stripePublishableKey) {
-      opts.push({
-        id: 'stripe',
-        name: 'Credit/Debit Card',
-        icon: '💳',
-        description: 'Pay with card',
-      });
-    }
-    opts.push({
-      id: 'cash',
-      name: 'Cash at Visit',
-      icon: '💵',
-      description: 'Pay cash when you arrive',
-    });
-    return opts;
-  });
+  // Payment options — derived from server-provided capabilities
+  const paymentOptions = $derived(capabilities.methods);
 
   // =============================================================================
   // DERIVED
@@ -267,10 +228,10 @@
   const handlePaymentSelect = async (paymentId: string) => {
     selectedPayment = paymentId;
 
-    if (paymentId === 'venmo' && paypalClientId && onCreatePaymentOrder && onCapturePayment) {
+    if (paymentId === 'venmo' && capabilities.venmo?.available && onCreatePaymentOrder && onCapturePayment) {
       // Use PayPal SDK flow for Venmo — requires client-side approval
       step = 'venmo-checkout';
-    } else if (paymentId === 'stripe' && stripePublishableKey && onCreateStripeIntent && selectedService) {
+    } else if (paymentId === 'stripe' && capabilities.stripe?.available && onCreateStripeIntent && selectedService) {
       // Create PaymentIntent server-side, then show Stripe Elements
       step = 'processing';
       try {
@@ -297,16 +258,6 @@
     errorMessage = undefined;
 
     try {
-      const paymentData = {
-        service: selectedService,
-        client: clientInfo,
-        datetime: selectedDatetime,
-      };
-
-      if (paymentId === 'cash' && onCashPayment) {
-        await onCashPayment(paymentData);
-      }
-
       // Create a local booking record
       const booking: Partial<Booking> = {
         id: `local-${Date.now()}`,
@@ -320,7 +271,7 @@
         currency: selectedService.currency,
         client: clientInfo,
         status: 'pending',
-        paymentStatus: paymentId === 'cash' ? 'pending' : 'paid',
+        paymentStatus: 'paid',
       };
       completedBooking = booking;
 
@@ -592,10 +543,10 @@
                        bg-surface-100-900 hover:bg-surface-200-800 transition-colors"
                 onclick={() => handlePaymentSelect(option.id)}
               >
-                <span class="text-2xl">{option.icon}</span>
+                <span class="text-2xl">{option.icon ?? ''}</span>
                 <div class="flex-1">
-                  <p class="font-medium">{option.name}</p>
-                  <p class="text-sm text-surface-600-400">{option.description}</p>
+                  <p class="font-medium">{option.displayName}</p>
+                  <p class="text-sm text-surface-600-400">{option.description ?? ''}</p>
                 </div>
                 <span class="text-surface-400-600">→</span>
               </button>
@@ -619,10 +570,10 @@
             </div>
           {/if}
 
-          {#if paypalClientId && onCreatePaymentOrder && onCapturePayment && selectedService}
+          {#if capabilities.venmo?.available && onCreatePaymentOrder && onCapturePayment && selectedService}
             <VenmoCheckout
-              clientId={paypalClientId}
-              environment={paypalEnvironment}
+              clientId={capabilities.venmo?.clientId ?? ''}
+              environment={capabilities.venmo?.environment ?? 'sandbox'}
               amount={selectedService.price}
               currency={selectedService.currency ?? 'USD'}
               description={selectedService.name}
@@ -660,9 +611,9 @@
             </div>
           {/if}
 
-          {#if stripePublishableKey && stripeIntent && selectedService}
+          {#if capabilities.stripe?.available && stripeIntent && selectedService}
             <StripeCheckout
-              publishableKey={stripePublishableKey}
+              publishableKey={capabilities.stripe?.publishableKey ?? ''}
               clientSecret={stripeIntent.clientSecret}
               amount={selectedService.price}
               currency={selectedService.currency ?? 'USD'}

--- a/src/payments/types.ts
+++ b/src/payments/types.ts
@@ -200,6 +200,49 @@ export interface PaymentRegistry {
   getAvailableMethods(): Promise<PaymentMethodOption[]>;
 }
 
+// =============================================================================
+// PAYMENT CAPABILITIES CONTRACT
+// =============================================================================
+
+/** Stripe payment capability for a practitioner */
+export interface StripeCapability {
+  readonly available: boolean;
+  readonly publishableKey: string;
+  readonly connectedAccountId?: string;
+}
+
+/** Venmo/PayPal payment capability for a practitioner */
+export interface VenmoCapability {
+  readonly available: boolean;
+  readonly clientId: string;
+  readonly environment: 'sandbox' | 'production';
+}
+
+/**
+ * Server-derived payment capabilities for a practitioner.
+ *
+ * This is the single source of truth for what payment methods
+ * are available on any booking surface. Both the drawer and
+ * the full-page booking flow must use this contract.
+ *
+ * `cash: false` is a type-level guarantee — Cash at Visit
+ * is structurally impossible without changing this type.
+ */
+export interface PaymentCapabilities {
+  readonly methods: PaymentMethodOption[];
+  readonly stripe: StripeCapability | null;
+  readonly venmo: VenmoCapability | null;
+  readonly cash: false;
+}
+
+/** Returns safe default capabilities (nothing available, loading state) */
+export const getDefaultCapabilities = (): PaymentCapabilities => ({
+  methods: [],
+  stripe: null,
+  venmo: null,
+  cash: false,
+});
+
 export const createPaymentRegistry = (): PaymentRegistry => {
   const adapters = new Map<string, PaymentAdapter>();
 

--- a/src/tests/hybrid-checkout-capabilities.test.ts
+++ b/src/tests/hybrid-checkout-capabilities.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+describe('HybridCheckoutDrawer Capabilities Contract', () => {
+  const componentPath = resolve(import.meta.dirname, '../components/HybridCheckoutDrawer.svelte');
+  const content = readFileSync(componentPath, 'utf8');
+
+  it('should accept capabilities prop', () => {
+    expect(content).toContain('capabilities');
+  });
+
+  it('should NOT accept legacy paypalClientId prop', () => {
+    const propsMatch = content.match(/let\s*\{[^}]*\}\s*[=:]\s*\$props/s);
+    if (propsMatch) {
+      expect(propsMatch[0]).not.toContain('paypalClientId');
+    }
+  });
+
+  it('should NOT accept legacy stripePublishableKey prop', () => {
+    const propsMatch = content.match(/let\s*\{[^}]*\}\s*[=:]\s*\$props/s);
+    if (propsMatch) {
+      expect(propsMatch[0]).not.toContain('stripePublishableKey');
+    }
+  });
+
+  it('should NOT have Cash at Visit in payment options', () => {
+    expect(content).not.toMatch(/id:\s*['"]cash['"]/);
+  });
+
+  it('should import PaymentCapabilities type', () => {
+    expect(content).toContain('PaymentCapabilities');
+  });
+
+  it('should derive payment options from capabilities.methods', () => {
+    expect(content).toContain('capabilities.methods');
+  });
+});

--- a/src/tests/payments-capabilities.test.ts
+++ b/src/tests/payments-capabilities.test.ts
@@ -1,0 +1,29 @@
+// tests for PaymentCapabilities type contract and getDefaultCapabilities factory
+import { describe, it, expect } from 'vitest';
+
+describe('PaymentCapabilities', () => {
+  it('should export PaymentCapabilities type with required fields', async () => {
+    const { getDefaultCapabilities } = await import('../payments/index.js');
+    const caps = getDefaultCapabilities();
+    expect(caps).toHaveProperty('methods');
+    expect(caps).toHaveProperty('stripe');
+    expect(caps).toHaveProperty('venmo');
+    expect(caps).toHaveProperty('cash');
+    expect(caps.cash).toBe(false);
+  });
+
+  it('should return empty methods from default capabilities', async () => {
+    const { getDefaultCapabilities } = await import('../payments/index.js');
+    const caps = getDefaultCapabilities();
+    expect(caps.methods).toEqual([]);
+    expect(caps.stripe).toBeNull();
+    expect(caps.venmo).toBeNull();
+  });
+
+  it('should enforce cash is always false', async () => {
+    const { getDefaultCapabilities } = await import('../payments/index.js');
+    const caps = getDefaultCapabilities();
+    const cashValue: false = caps.cash;
+    expect(cashValue).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- merge the newer PaymentCapabilities / drawer contract work from tinyland-inc into the functional Jess release lane
- align package and Bazel metadata to 0.7.0 on the release repo
- keep the healthier Jess CI/release-truth structure while moving the real package surface forward

## Validation
- pnpm exec vitest run src/tests/hybrid-checkout-capabilities.test.ts src/tests/payments-capabilities.test.ts
- pnpm build

## Why
The real release blocker was repo convergence, not npm auth: Jess is the functional release lane, but tinyland held the newer 0.7.0 package code. This PR converges those so the functional release repo can publish the package that MassageIthaca actually needs.
