### PR TITLE
[codex] add Bazel package artifact preflight

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -46,6 +46,9 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Validate Bazel package artifact
+        run: npx --yes @bazel/bazelisk build //:pkg
+
       - name: Sync SvelteKit
         run: pnpm exec svelte-kit sync
 


### PR DESCRIPTION
## What changed

This PR adds the first concrete `TIN-104` workflow slice to `scheduling-kit`.

- preserves the release-authority doc updates
- adds a Bazel package-artifact preflight to the publish workflow:
  `npx --yes @bazel/bazelisk build //:pkg`

The preflight runs in the workflow test job before the normal build/publish
lane.

## Why it changed

`scheduling-kit` already has a real Bazel `//:pkg` target, but CI publish was
still pnpm/npm-first with no Bazel signal at all. This PR is the smallest real
step toward Bazel artifact truth.

It does **not** claim Bazel is already the artifact authority. It turns Bazel
into an explicit discovery/validation gate first.

## Impact

- publish CI now proves the Bazel package target still builds
- failures in the Bazel layer become visible before publish
- gives us runner-level evidence for how stable the migratory Bazel layer
  actually is

## Caveat

Bazel infrastructure is still in a migratory state. Local exploratory runs were
noisy and surfaced bzlmod churn warnings, so this PR should be treated as a
discovery gate rather than a claim that Bazel publish authority is solved.

## Validation

- local diff reviewed
- local Bazel probe was exploratory only, not treated as readiness proof

