### PR TITLE
build(bazel): publish scheduling-kit from bazel artifact

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -49,6 +49,19 @@ jobs:
       - name: Validate Bazel package artifact
         run: npx --yes @bazel/bazelisk build //:pkg
 
+      - name: Validate Bazel npm package contents
+        run: npm pack --dry-run ./bazel-bin/pkg
+
+      - name: Archive Bazel package artifact
+        run: tar -czf bazel-pkg.tgz -C bazel-bin pkg
+
+      - name: Upload Bazel package artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: bazel-pkg
+          path: bazel-pkg.tgz
+          if-no-files-found: error
+
       - name: Sync SvelteKit
         run: pnpm exec svelte-kit sync
 
@@ -68,46 +81,29 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@v6
-
       - uses: actions/setup-node@v6
         with:
           node-version: ${{ env.DEFAULT_NODE_VERSION }}
           package-manager-cache: false
           registry-url: https://registry.npmjs.org
 
-      - name: Enable Corepack
-        run: corepack enable
-
-      - name: Resolve pnpm store path
-        id: pnpm-store
-        run: echo "path=$(pnpm store path --silent)" >> "$GITHUB_OUTPUT"
-
-      - uses: actions/cache@v5
+      - name: Download Bazel package artifact
+        uses: actions/download-artifact@v4
         with:
-          path: ${{ steps.pnpm-store.outputs.path }}
-          key: ${{ runner.os }}-node-${{ env.DEFAULT_NODE_VERSION }}-pnpm-${{ env.PNPM_VERSION }}-${{ hashFiles('pnpm-lock.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-node-${{ env.DEFAULT_NODE_VERSION }}-pnpm-${{ env.PNPM_VERSION }}-
+          name: bazel-pkg
 
-      - name: Verify release metadata
-        run: node scripts/check-release-metadata.mjs
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
-
-      - name: Build
-        run: pnpm build
+      - name: Extract Bazel package artifact
+        run: tar -xzf bazel-pkg.tgz
 
       - name: Publish to npm
         if: ${{ github.event_name == 'release' || github.event.inputs.dry_run != 'true' }}
-        run: npm publish --access public --provenance
+        run: npm publish ./pkg --access public --provenance
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Publish dry run
         if: ${{ github.event.inputs.dry_run == 'true' }}
-        run: npm publish --access public --dry-run
+        run: npm publish ./pkg --access public --dry-run
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
@@ -118,8 +114,6 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@v6
-
       - uses: actions/setup-node@v6
         with:
           node-version: ${{ env.DEFAULT_NODE_VERSION }}
@@ -127,45 +121,30 @@ jobs:
           registry-url: https://npm.pkg.github.com
           scope: '@jesssullivan'
 
-      - name: Enable Corepack
-        run: corepack enable
-
-      - name: Resolve pnpm store path
-        id: pnpm-store
-        run: echo "path=$(pnpm store path --silent)" >> "$GITHUB_OUTPUT"
-
-      - uses: actions/cache@v5
+      - name: Download Bazel package artifact
+        uses: actions/download-artifact@v4
         with:
-          path: ${{ steps.pnpm-store.outputs.path }}
-          key: ${{ runner.os }}-node-${{ env.DEFAULT_NODE_VERSION }}-pnpm-${{ env.PNPM_VERSION }}-${{ hashFiles('pnpm-lock.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-node-${{ env.DEFAULT_NODE_VERSION }}-pnpm-${{ env.PNPM_VERSION }}-
+          name: bazel-pkg
 
-      - name: Verify release metadata
-        run: node scripts/check-release-metadata.mjs
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
-
-      - name: Build
-        run: pnpm build
+      - name: Extract Bazel package artifact
+        run: tar -xzf bazel-pkg.tgz
 
       - name: Publish to GitHub Packages
         if: ${{ github.event_name == 'release' || github.event.inputs.dry_run != 'true' }}
         run: |
           # Temporarily override scope for GH Packages (npm scope != GH owner)
           node -e "
-            const pkg = require('./package.json');
+            const pkg = require('./pkg/package.json');
             pkg.name = '@jesssullivan/scheduling-kit';
             pkg.publishConfig = { registry: 'https://npm.pkg.github.com' };
-            require('fs').writeFileSync('package.json', JSON.stringify(pkg, null, 2) + '\n');
+            require('fs').writeFileSync('./pkg/package.json', JSON.stringify(pkg, null, 2) + '\n');
           "
-          npm publish --ignore-scripts
+          npm publish ./pkg --ignore-scripts
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Publish dry run
         if: ${{ github.event.inputs.dry_run == 'true' }}
-        run: npm publish --dry-run --ignore-scripts
+        run: npm publish ./pkg --dry-run --ignore-scripts
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -20,6 +20,8 @@ load("@aspect_rules_js//js:defs.bzl", "js_library", "js_run_binary")
 load("@aspect_rules_js//npm:defs.bzl", "npm_package")
 load("@aspect_rules_ts//ts:defs.bzl", "ts_project")
 load("@npm//:defs.bzl", "npm_link_all_packages")
+load("@npm//:svelte-check/package_json.bzl", svelte_check = "bin")
+load("@npm//:@sveltejs/package/package_json.bzl", svelte_package = "bin")
 load("@npm//:vitest/package_json.bzl", vitest_bin = "bin")
 
 # =============================================================================
@@ -27,6 +29,16 @@ load("@npm//:vitest/package_json.bzl", vitest_bin = "bin")
 # =============================================================================
 
 npm_link_all_packages(name = "node_modules")
+
+svelte_check.svelte_check_binary(
+    name = "svelte_check",
+    visibility = ["//visibility:public"],
+)
+
+svelte_package.svelte_package_binary(
+    name = "svelte_package",
+    visibility = ["//visibility:public"],
+)
 
 # =============================================================================
 # Svelte package build
@@ -38,7 +50,7 @@ npm_link_all_packages(name = "node_modules")
 js_run_binary(
     name = "scheduling_kit_build",
     tags = ["manual"],
-    tool = ":node_modules/@sveltejs/package",
+    tool = ":svelte_package",
     srcs = glob(
         [
             "src/**/*.ts",
@@ -219,7 +231,7 @@ vitest_bin.vitest_test(
         "tsconfig.json",
         ":node_modules/vitest",
         "vitest.config.ts",
-    ] + glob(["src/**/*.ts"]) + glob(["src/tests/**/*.test.ts"]),
+    ] + glob(["src/**/*.ts"]),
     args = [
         "run",
         "--reporter=verbose",
@@ -237,7 +249,7 @@ vitest_bin.vitest_test(
 js_run_binary(
     name = "typecheck",
     tags = ["manual"],
-    tool = ":node_modules/svelte-check",
+    tool = ":svelte_check",
     srcs = glob(
         [
             "src/**/*.ts",

--- a/package.json
+++ b/package.json
@@ -143,6 +143,12 @@
   "publishConfig": {
     "access": "public"
   },
+  "pnpm": {
+    "onlyBuiltDependencies": [
+      "esbuild",
+      "msw"
+    ]
+  },
   "engines": {
     "node": ">=20 <25"
   }


### PR DESCRIPTION
## Summary
- fix Bazel package rule execution for `//:pkg`
- validate the Bazel-built package with `npm pack --dry-run ./bazel-bin/pkg`
- archive and publish the Bazel package artifact instead of rebuilding from source in publish jobs

## Validation
- `npx --yes @bazel/bazelisk cquery //:pkg --output=files`
- `npx --yes @bazel/bazelisk build //:pkg`
- `npm pack --dry-run ./bazel-bin/pkg`