### PR TITLE
[codex] Route CI to honey self-hosted runner stopgap

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ env:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.PRIMARY_LINUX_RUNNER_LABELS_JSON || '["ubuntu-latest"]') }}
 
     strategy:
       matrix:
@@ -68,7 +68,7 @@ jobs:
         run: pnpm build
 
   build:
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.PRIMARY_LINUX_RUNNER_LABELS_JSON || '["ubuntu-latest"]') }}
     needs: test
 
     steps:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,7 +17,7 @@ env:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.PRIMARY_LINUX_RUNNER_LABELS_JSON || '["ubuntu-latest"]') }}
     steps:
       - uses: actions/checkout@v6
 
@@ -76,7 +76,7 @@ jobs:
 
   publish-npm:
     needs: [test]
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.PRIMARY_LINUX_RUNNER_LABELS_JSON || '["ubuntu-latest"]') }}
     permissions:
       contents: read
       id-token: write
@@ -109,7 +109,7 @@ jobs:
 
   publish-github:
     needs: [test]
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.PRIMARY_LINUX_RUNNER_LABELS_JSON || '["ubuntu-latest"]') }}
     permissions:
       contents: read
       packages: write


### PR DESCRIPTION
## Summary
- route core CI and publish jobs through `PRIMARY_LINUX_RUNNER_LABELS_JSON`
- default to `ubuntu-latest` when the repo variable is absent
- enable the temporary honey self-hosted runner stopgap for this repo

## Notes
- repo variable set in GitHub: `["self-hosted","Linux","X64","honey","scheduling-kit","nix"]`
- temporary repo runner is live as `honey-sk-1`
- this is an interim lane until the local/lab-managed runner stack is finalized
