### PR TITLE
fix: make publish workflow self-hosted-safe

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -97,9 +97,15 @@ jobs:
 
       - name: Publish to npm
         if: ${{ github.event_name == 'release' || github.event.inputs.dry_run != 'true' }}
-        run: npm publish ./pkg --access public --provenance
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          RUNNER_ENVIRONMENT: ${{ runner.environment }}
+        run: |
+          if [ "$RUNNER_ENVIRONMENT" = "self-hosted" ]; then
+            npm publish ./pkg --access public
+          else
+            npm publish ./pkg --access public --provenance
+          fi
 
       - name: Publish dry run
         if: ${{ github.event.inputs.dry_run == 'true' }}
@@ -129,22 +135,25 @@ jobs:
       - name: Extract Bazel package artifact
         run: tar -xzf bazel-pkg.tgz
 
+      - name: Prepare GitHub Packages publish directory
+        run: cp -R pkg pkg-github
+
       - name: Publish to GitHub Packages
         if: ${{ github.event_name == 'release' || github.event.inputs.dry_run != 'true' }}
         run: |
           # Temporarily override scope for GH Packages (npm scope != GH owner)
           node -e "
-            const pkg = require('./pkg/package.json');
+            const pkg = require('./pkg-github/package.json');
             pkg.name = '@jesssullivan/scheduling-kit';
             pkg.publishConfig = { registry: 'https://npm.pkg.github.com' };
-            require('fs').writeFileSync('./pkg/package.json', JSON.stringify(pkg, null, 2) + '\n');
+            require('fs').writeFileSync('./pkg-github/package.json', JSON.stringify(pkg, null, 2) + '\n');
           "
-          npm publish ./pkg --ignore-scripts
+          npm publish ./pkg-github --ignore-scripts
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Publish dry run
         if: ${{ github.event.inputs.dry_run == 'true' }}
-        run: npm publish ./pkg --dry-run --ignore-scripts
+        run: npm publish ./pkg-github --dry-run --ignore-scripts
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- publish to npm without provenance on self-hosted runners
- publish GitHub Packages from a writable copy of the Bazel artifact

## Why
The self-hosted honey runner lane cannot use npm provenance, and the current GitHub Packages step mutates a read-only downloaded artifact. This keeps future package publishes truthful instead of reporting false greens or failing on the sidecar path.
