### PR TITLE
fix(ci): make github package artifact writable

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -136,7 +136,9 @@ jobs:
         run: tar -xzf bazel-pkg.tgz
 
       - name: Prepare GitHub Packages publish directory
-        run: cp -R pkg pkg-github
+        run: |
+          cp -R pkg pkg-github
+          chmod -R u+w pkg-github
 
       - name: Publish to GitHub Packages
         if: ${{ github.event_name == 'release' || github.event.inputs.dry_run != 'true' }}


### PR DESCRIPTION
## Summary
- make the copied pkg-github directory writable after extracting the Bazel artifact
- avoid EACCES when the GitHub Packages sidecar rewrites package.json on self-hosted runners
- keep the npmjs.com publish lane and GitHub Packages sidecar consistent

## Validation
- workflow-only change
- based on the failing self-hosted publish log pattern already seen in the corrected publish lane
