### PR TITLE
[codex] perf(components): drop zod from browser client form

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -99,7 +99,7 @@ npm_package(
     ],
     package = "@tummycrypt/scheduling-kit",
     tags = ["manual"],
-    version = "0.7.0",
+    version = "0.7.1",
     visibility = ["//visibility:public"],
 )
 

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -22,7 +22,7 @@ Subpackage targets (finer-grained caching):
 
 module(
     name = "tummycrypt_scheduling_kit",
-    version = "0.7.0",
+    version = "0.7.1",
     compatibility_level = 1,
 )
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tummycrypt/scheduling-kit",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Backend-agnostic scheduling components with alternative payment support",
   "type": "module",
   "packageManager": "pnpm@9.15.9",

--- a/src/components/ClientForm.svelte
+++ b/src/components/ClientForm.svelte
@@ -1,9 +1,8 @@
 <script lang="ts">
   /**
    * ClientForm Component
-   * Client information form with Zod validation
+   * Client information form with lightweight browser validation.
    */
-  import { z } from 'zod';
   import type { ClientInfo } from '../core/types.js';
 
   // Props
@@ -48,15 +47,6 @@
   // Validation errors
   let errors = $state<Record<string, string>>({});
 
-  // Validation schema
-  const ClientSchema = z.object({
-    firstName: z.string().min(1, 'First name is required'),
-    lastName: z.string().min(1, 'Last name is required'),
-    email: z.string().email('Please enter a valid email address'),
-    phone: z.string().optional().transform(val => val || undefined),
-    notes: z.string().optional().transform(val => val || undefined),
-  });
-
   // Format phone number as user types
   const formatPhone = (value: string): string => {
     // Remove non-digits
@@ -80,21 +70,22 @@
 
   // Validate form
   const validate = (): boolean => {
-    const result = ClientSchema.safeParse({
-      firstName,
-      lastName,
-      email,
-      phone,
-      notes,
-    });
-
     const newErrors: Record<string, string> = {};
+    const trimmedFirstName = firstName.trim();
+    const trimmedLastName = lastName.trim();
+    const trimmedEmail = email.trim();
+    const emailPattern = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
-    if (!result.success) {
-      for (const error of result.error.errors) {
-        const field = error.path[0] as string;
-        newErrors[field] = error.message;
-      }
+    if (!trimmedFirstName) {
+      newErrors.firstName = 'First name is required';
+    }
+
+    if (!trimmedLastName) {
+      newErrors.lastName = 'Last name is required';
+    }
+
+    if (!trimmedEmail || !emailPattern.test(trimmedEmail)) {
+      newErrors.email = 'Please enter a valid email address';
     }
 
     if (showIntakeFields) {

--- a/src/tests/components/client-form.test.ts
+++ b/src/tests/components/client-form.test.ts
@@ -5,19 +5,40 @@
  * functions here and test them in a Node environment.
  */
 import { describe, it, expect } from 'vitest';
-import { z } from 'zod';
 
 // ---------------------------------------------------------------------------
 // Re-implemented pure logic from ClientForm.svelte
 // ---------------------------------------------------------------------------
 
-const ClientSchema = z.object({
-  firstName: z.string().min(1, 'First name is required'),
-  lastName: z.string().min(1, 'Last name is required'),
-  email: z.string().email('Please enter a valid email address'),
-  phone: z.string().optional().transform((val) => val || undefined),
-  notes: z.string().optional().transform((val) => val || undefined),
-});
+interface ClientFields {
+  firstName: string;
+  lastName: string;
+  email: string;
+}
+
+const validateClientFields = (
+  fields: Partial<ClientFields>,
+): Record<string, string> => {
+  const errors: Record<string, string> = {};
+  const trimmedFirstName = fields.firstName?.trim() ?? '';
+  const trimmedLastName = fields.lastName?.trim() ?? '';
+  const trimmedEmail = fields.email?.trim() ?? '';
+  const emailPattern = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+  if (!trimmedFirstName) {
+    errors.firstName = 'First name is required';
+  }
+
+  if (!trimmedLastName) {
+    errors.lastName = 'Last name is required';
+  }
+
+  if (!trimmedEmail || !emailPattern.test(trimmedEmail)) {
+    errors.email = 'Please enter a valid email address';
+  }
+
+  return errors;
+};
 
 const formatPhone = (value: string): string => {
   const digits = value.replace(/\D/g, '');
@@ -73,137 +94,90 @@ interface ClientInfo {
 
 describe('ClientForm validation logic', () => {
   // -----------------------------------------------------------------------
-  // ClientSchema
+  // validateClientFields
   // -----------------------------------------------------------------------
-  describe('ClientSchema', () => {
+  describe('validateClientFields', () => {
     const validData = {
       firstName: 'Jane',
       lastName: 'Doe',
       email: 'jane@example.com',
-      phone: '6071234567',
-      notes: 'Jaw pain on left side',
     };
 
     it('accepts fully valid data', () => {
-      const result = ClientSchema.safeParse(validData);
-      expect(result.success).toBe(true);
-      if (result.success) {
-        expect(result.data.firstName).toBe('Jane');
-        expect(result.data.lastName).toBe('Doe');
-        expect(result.data.email).toBe('jane@example.com');
-      }
-    });
-
-    it('accepts data without optional phone and notes', () => {
-      const result = ClientSchema.safeParse({
-        firstName: 'Jane',
-        lastName: 'Doe',
-        email: 'jane@example.com',
-      });
-      expect(result.success).toBe(true);
-      if (result.success) {
-        expect(result.data.phone).toBeUndefined();
-        expect(result.data.notes).toBeUndefined();
-      }
-    });
-
-    it('transforms empty phone string to undefined', () => {
-      const result = ClientSchema.safeParse({
-        ...validData,
-        phone: '',
-      });
-      expect(result.success).toBe(true);
-      if (result.success) {
-        expect(result.data.phone).toBeUndefined();
-      }
-    });
-
-    it('transforms empty notes string to undefined', () => {
-      const result = ClientSchema.safeParse({
-        ...validData,
-        notes: '',
-      });
-      expect(result.success).toBe(true);
-      if (result.success) {
-        expect(result.data.notes).toBeUndefined();
-      }
+      expect(validateClientFields(validData)).toEqual({});
     });
 
     it('rejects missing firstName', () => {
-      const result = ClientSchema.safeParse({
+      expect(validateClientFields({
         lastName: 'Doe',
         email: 'jane@example.com',
+      })).toMatchObject({
+        firstName: 'First name is required',
       });
-      expect(result.success).toBe(false);
     });
 
     it('rejects empty firstName', () => {
-      const result = ClientSchema.safeParse({
+      expect(validateClientFields({
         firstName: '',
         lastName: 'Doe',
         email: 'jane@example.com',
+      })).toMatchObject({
+        firstName: 'First name is required',
       });
-      expect(result.success).toBe(false);
-      if (!result.success) {
-        const firstNameIssue = result.error.issues.find(
-          (i) => i.path[0] === 'firstName',
-        );
-        expect(firstNameIssue?.message).toBe('First name is required');
-      }
     });
 
     it('rejects missing lastName', () => {
-      const result = ClientSchema.safeParse({
+      expect(validateClientFields({
         firstName: 'Jane',
         email: 'jane@example.com',
+      })).toMatchObject({
+        lastName: 'Last name is required',
       });
-      expect(result.success).toBe(false);
     });
 
     it('rejects empty lastName', () => {
-      const result = ClientSchema.safeParse({
+      expect(validateClientFields({
         firstName: 'Jane',
         lastName: '',
         email: 'jane@example.com',
+      })).toMatchObject({
+        lastName: 'Last name is required',
       });
-      expect(result.success).toBe(false);
-      if (!result.success) {
-        const lastNameIssue = result.error.issues.find(
-          (i) => i.path[0] === 'lastName',
-        );
-        expect(lastNameIssue?.message).toBe('Last name is required');
-      }
     });
 
     it('rejects invalid email', () => {
-      const result = ClientSchema.safeParse({
+      expect(validateClientFields({
         firstName: 'Jane',
         lastName: 'Doe',
         email: 'not-an-email',
+      })).toMatchObject({
+        email: 'Please enter a valid email address',
       });
-      expect(result.success).toBe(false);
-      if (!result.success) {
-        const emailIssue = result.error.issues.find(
-          (i) => i.path[0] === 'email',
-        );
-        expect(emailIssue?.message).toBe('Please enter a valid email address');
-      }
     });
 
     it('rejects missing email', () => {
-      const result = ClientSchema.safeParse({
+      expect(validateClientFields({
         firstName: 'Jane',
         lastName: 'Doe',
+      })).toMatchObject({
+        email: 'Please enter a valid email address',
       });
-      expect(result.success).toBe(false);
     });
 
-    it('rejects completely empty object', () => {
-      const result = ClientSchema.safeParse({});
-      expect(result.success).toBe(false);
-      if (!result.success) {
-        expect(result.error.issues.length).toBeGreaterThanOrEqual(3);
-      }
+    it('rejects completely empty object with all required errors', () => {
+      expect(validateClientFields({})).toEqual({
+        firstName: 'First name is required',
+        lastName: 'Last name is required',
+        email: 'Please enter a valid email address',
+      });
+    });
+
+    it('accepts surrounding whitespace when the trimmed values are valid', () => {
+      expect(validateClientFields({
+        firstName: ' Jane ',
+        lastName: ' Doe ',
+        email: ' jane@example.com ',
+      })).toEqual({});
     });
   });
 
@@ -369,26 +343,19 @@ describe('ClientForm validation logic', () => {
       expect(info.customFields?.['field-16606770']).toBe('Ibuprofen 200mg');
     });
 
-    it('constructs ClientInfo from validated schema output', () => {
-      const parsed = ClientSchema.parse({
-        firstName: 'Jane',
-        lastName: 'Doe',
-        email: 'jane@example.com',
-        phone: '6072014926',
-        notes: '',
-      });
-
+    it('constructs ClientInfo from valid component field state', () => {
       const info: ClientInfo = {
-        firstName: parsed.firstName,
-        lastName: parsed.lastName,
-        email: parsed.email,
-        phone: parsed.phone,
-        notes: parsed.notes,
+        firstName: ' Jane '.trim(),
+        lastName: ' Doe '.trim(),
+        email: ' Jane@Example.com '.trim().toLowerCase(),
+        phone: '(607) 201-4926'.replace(/\D/g, '') || undefined,
+        notes: ''.trim() || undefined,
       };
 
       expect(info.firstName).toBe('Jane');
+      expect(info.lastName).toBe('Doe');
+      expect(info.email).toBe('jane@example.com');
       expect(info.phone).toBe('6072014926');
-      // notes was empty string, transformed to undefined by schema
       expect(info.notes).toBeUndefined();
     });
   });


### PR DESCRIPTION
## What Changed

- replaced `zod`-based browser validation in `ClientForm.svelte` with lightweight inline field checks
- updated the pure logic `ClientForm` test file to match the new validation contract
- bumped `@tummycrypt/scheduling-kit` release metadata from `0.7.0` to `0.7.1`

## Why

`ClientForm.svelte` is a browser component, but it was importing full `zod` runtime validation for only three fields: first name, last name, and email. In a clean `MassageIthaca` build, that pulled a `vendor-zod` client chunk of `113.87 kB` into the booking graph.

A throwaway app-level proof build showed that removing the `zod` import from the browser `ClientForm` removes that `vendor-zod` chunk entirely from the client output.

## Impact

- reduces client bundle weight on booking surfaces that render `ClientForm`
- keeps the same user-visible validation messages for required names and email format
- does not change public package APIs

## Validation

- `pnpm exec vitest run src/tests/components/client-form.test.ts`
- `pnpm exec vitest run --config vitest.component.config.ts tests/e2e/client-form.test.ts`
- `pnpm run check:release-metadata`
- `pnpm build`

Refs #44
