### PR TITLE
fix(ci): ignore npm scripts when publishing bazel pkg

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,13 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+        with:
+          clean: false
+
+      - name: Clean stale workspace artifacts
+        run: |
+          chmod -R u+w pkg pkg-github dist node_modules .svelte-kit bazel-bin bazel-out bazel-testlogs bazel-scheduling-kit .pnpm-store 2>/dev/null || true
+          rm -rf pkg pkg-github dist node_modules .svelte-kit bazel-bin bazel-out bazel-testlogs bazel-scheduling-kit .pnpm-store bazel-pkg.tgz MODULE.bazel.lock
 
       - uses: actions/setup-node@v6
         with:
@@ -73,6 +80,13 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+        with:
+          clean: false
+
+      - name: Clean stale workspace artifacts
+        run: |
+          chmod -R u+w pkg pkg-github dist node_modules .svelte-kit bazel-bin bazel-out bazel-testlogs bazel-scheduling-kit .pnpm-store 2>/dev/null || true
+          rm -rf pkg pkg-github dist node_modules .svelte-kit bazel-bin bazel-out bazel-testlogs bazel-scheduling-kit .pnpm-store bazel-pkg.tgz MODULE.bazel.lock
 
       - uses: actions/setup-node@v6
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,6 +21,13 @@ jobs:
     runs-on: ${{ fromJSON(vars.PRIMARY_LINUX_RUNNER_LABELS_JSON || '["ubuntu-latest"]') }}
     steps:
       - uses: actions/checkout@v6
+        with:
+          clean: false
+
+      - name: Clean stale workspace artifacts
+        run: |
+          chmod -R u+w pkg pkg-github dist node_modules .svelte-kit bazel-bin bazel-out bazel-testlogs bazel-scheduling-kit .pnpm-store 2>/dev/null || true
+          rm -rf pkg pkg-github dist node_modules .svelte-kit bazel-bin bazel-out bazel-testlogs bazel-scheduling-kit .pnpm-store bazel-pkg.tgz MODULE.bazel.lock
 
       - uses: actions/setup-node@v6
         with:
@@ -95,6 +102,9 @@ jobs:
       - name: Extract Bazel package artifact
         run: tar -xzf bazel-pkg.tgz
 
+      - name: Normalize Bazel package permissions
+        run: chmod -R u+w pkg
+
       - name: Publish to npm
         if: ${{ github.event_name == 'release' || github.event.inputs.dry_run != 'true' }}
         env:
@@ -134,6 +144,9 @@ jobs:
 
       - name: Extract Bazel package artifact
         run: tar -xzf bazel-pkg.tgz
+
+      - name: Normalize Bazel package permissions
+        run: chmod -R u+w pkg
 
       - name: Prepare GitHub Packages publish directory
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -102,14 +102,14 @@ jobs:
           RUNNER_ENVIRONMENT: ${{ runner.environment }}
         run: |
           if [ "$RUNNER_ENVIRONMENT" = "self-hosted" ]; then
-            npm publish ./pkg --access public
+            npm publish ./pkg --access public --ignore-scripts
           else
-            npm publish ./pkg --access public --provenance
+            npm publish ./pkg --access public --provenance --ignore-scripts
           fi
 
       - name: Publish dry run
         if: ${{ github.event.inputs.dry_run == 'true' }}
-        run: npm publish ./pkg --access public --dry-run
+        run: npm publish ./pkg --access public --dry-run --ignore-scripts
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 


### PR DESCRIPTION
Summary:
- stop re-running package lifecycle scripts when publishing the validated Bazel pkg artifact to npm
- apply the same ignore-scripts behavior to the dry-run path
- keep release metadata and artifact validation in the upstream test job, where they already run

Validation:
- pnpm run check:release-metadata
- npx --yes @bazel/bazelisk build //:pkg
- npm publish ./bazel-bin/pkg --access public --dry-run --ignore-scripts

Root cause:
The publish-npm job was publishing ./pkg, whose packaged prepublishOnly script referenced repo files like scripts/check-release-metadata.mjs that are not present inside the stripped Bazel artifact. The workflow had already validated the artifact in test, so rerunning lifecycle scripts during publish was redundant and broke the release lane.