### PR TITLE
fix(ci): partition pnpm caches by runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,9 +44,9 @@ jobs:
       - uses: actions/cache@v5
         with:
           path: ${{ env.PNPM_STORE_PATH }}
-          key: ${{ runner.os }}-node-${{ matrix.node-version }}-pnpm-${{ env.PNPM_VERSION }}-${{ hashFiles('pnpm-lock.yaml') }}
+          key: ${{ runner.os }}-${{ runner.name }}-node-${{ matrix.node-version }}-pnpm-${{ env.PNPM_VERSION }}-${{ hashFiles('pnpm-lock.yaml') }}
           restore-keys: |
-            ${{ runner.os }}-node-${{ matrix.node-version }}-pnpm-${{ env.PNPM_VERSION }}-
+            ${{ runner.os }}-${{ runner.name }}-node-${{ matrix.node-version }}-pnpm-${{ env.PNPM_VERSION }}-
 
       - name: Verify release metadata
         run: node scripts/check-release-metadata.mjs
@@ -102,9 +102,9 @@ jobs:
       - uses: actions/cache@v5
         with:
           path: ${{ env.PNPM_STORE_PATH }}
-          key: ${{ runner.os }}-node-${{ env.DEFAULT_NODE_VERSION }}-pnpm-${{ env.PNPM_VERSION }}-${{ hashFiles('pnpm-lock.yaml') }}
+          key: ${{ runner.os }}-${{ runner.name }}-node-${{ env.DEFAULT_NODE_VERSION }}-pnpm-${{ env.PNPM_VERSION }}-${{ hashFiles('pnpm-lock.yaml') }}
           restore-keys: |
-            ${{ runner.os }}-node-${{ env.DEFAULT_NODE_VERSION }}-pnpm-${{ env.PNPM_VERSION }}-
+            ${{ runner.os }}-${{ runner.name }}-node-${{ env.DEFAULT_NODE_VERSION }}-pnpm-${{ env.PNPM_VERSION }}-
 
       - name: Verify release metadata
         run: node scripts/check-release-metadata.mjs

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -43,9 +43,9 @@ jobs:
       - uses: actions/cache@v5
         with:
           path: ${{ env.PNPM_STORE_PATH }}
-          key: ${{ runner.os }}-node-${{ env.DEFAULT_NODE_VERSION }}-pnpm-${{ env.PNPM_VERSION }}-${{ hashFiles('pnpm-lock.yaml') }}
+          key: ${{ runner.os }}-${{ runner.name }}-node-${{ env.DEFAULT_NODE_VERSION }}-pnpm-${{ env.PNPM_VERSION }}-${{ hashFiles('pnpm-lock.yaml') }}
           restore-keys: |
-            ${{ runner.os }}-node-${{ env.DEFAULT_NODE_VERSION }}-pnpm-${{ env.PNPM_VERSION }}-
+            ${{ runner.os }}-${{ runner.name }}-node-${{ env.DEFAULT_NODE_VERSION }}-pnpm-${{ env.PNPM_VERSION }}-
 
       - name: Verify release metadata
         run: node scripts/check-release-metadata.mjs


### PR DESCRIPTION
Summary:
- isolate workspace-local pnpm store caches by runner name on self-hosted honey runners
- stop honey-sk-1 and honey-sk-2 from restoring each others pnpm store snapshots
- keep the existing workspace-local store model introduced for the self-hosted lane

Root cause:
The publish workflow test job restored a cache snapshot created on another runner, and pnpm then tried to copy from an absolute store path under honey-sk-1 while running on honey-sk-2. Partitioning the cache key by runner name removes that cross-runner contamination.

Validation:
- observed publish run 24519258595 fail in Install dependencies with ERR_PNPM_ENOENT referencing honey-sk-1 from a honey-sk-2 job
- patched CI and publish cache keys to include runner.name