### PR TITLE
docs(boundary): clarify scheduling-kit Acuity ownership

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,8 +49,8 @@ Current operational truth:
 
 - local development should default to `jesssullivan/main`
 - that branch is the current functional release line
-- `tinyland-inc/origin/main` is still divergent and should be treated as a
-  convergence target, not an equally authoritative release surface
+- `tinyland-inc/origin/main` is now a downstream mirror/validation surface,
+  not an equally authoritative release surface
 
 ## Build Truth
 
@@ -73,8 +73,8 @@ And, right now, the functional release repo is:
 
 - `Jesssullivan/scheduling-kit`
 
-Do not silently assume the `tinyland-inc` remote is equivalent while the split
-is unresolved.
+Do not silently assume the `tinyland-inc` remote is equivalent just because it
+still exists.
 
 ### Bazel role
 
@@ -135,9 +135,9 @@ Current publish flows target:
 
 That GitHub Packages rename is operationally real. Do not break it accidentally when editing the publish flow.
 
-Until `TIN-103` is resolved, any release/publish changes should be made against
-the functional release line first, then ported deliberately into convergence
-work. Do not split package truth across both remotes by accident.
+Release/publish changes should be made against the functional release line
+first, then ported deliberately into the mirror when needed. Do not split
+package truth across both remotes by accident.
 
 ## Effect / Architecture Notes
 

--- a/README.md
+++ b/README.md
@@ -47,12 +47,11 @@ the published npm package and Bazel metadata do not silently drift apart.
 Current reality:
 
 - the functional release line is `Jesssullivan/scheduling-kit`
-- `tinyland-inc/scheduling-kit` is still a convergence target while remote truth
-  is being cleaned up
+- `tinyland-inc/scheduling-kit` is now a downstream mirror and validation
+  surface, not a second publish authority
 
-Until that convergence work is complete, treat `Jesssullivan/main` as the
-release authority for package publication and metadata changes. Do not assume
-both `main` branches are equivalent.
+Treat `Jesssullivan/main` as the release authority for package publication and
+metadata changes. Do not assume both `main` branches are equivalent.
 
 Longer term, the intended publish shape is:
 
@@ -100,6 +99,22 @@ const result = await Effect.runPromise(
   kit.completeBooking(request, 'stripe')
 );
 ```
+
+## Ownership Boundary
+
+This package owns reusable scheduling contracts, payment adapters, checkout UI,
+and Acuity REST plus iframe handoff primitives.
+
+It does **not** own:
+
+- browser automation
+- remote Acuity scraping
+- Modal deployment/runtime control
+- site-specific booking orchestration
+
+If your Acuity flow needs browser automation or remote bridge-backed booking
+semantics, that ownership belongs to `@tummycrypt/scheduling-bridge` plus the
+adopter app that wires the handoff.
 
 ## Adapters
 
@@ -184,11 +199,11 @@ Svelte 5 components using runes syntax. Optional Skeleton 4 integration for styl
 | `ProviderPicker` | Practitioner/provider selector |
 | `BookingConfirmation` | Post-booking confirmation display |
 | `CheckoutDrawer` | Full checkout flow in a slide-out drawer |
-| `HybridCheckoutDrawer` | Checkout with Acuity iframe handoff |
+| `HybridCheckoutDrawer` | Checkout UI that hands booking off to adopter-provided Acuity flow |
 | `VenmoButton` | Venmo/PayPal payment button |
 | `VenmoCheckout` | Full Venmo checkout flow |
 | `StripeCheckout` | Stripe Elements checkout |
-| `AcuityEmbedHandoff` | Acuity iframe handoff with postMessage integration |
+| `AcuityEmbedHandoff` | Prefilled Acuity iframe primitive with postMessage integration |
 
 ```svelte
 <script lang="ts">

--- a/src/components/AcuityEmbedHandoff.svelte
+++ b/src/components/AcuityEmbedHandoff.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   /**
    * AcuityEmbedHandoff Component
-   * Shows a pre-filled Acuity embed for completing booking with card payment
+   * Shows a pre-filled Acuity iframe as a handoff primitive
    * Listens for postMessage to capture booking confirmation
    */
   import { onMount, onDestroy } from 'svelte';

--- a/src/components/HybridCheckoutDrawer.svelte
+++ b/src/components/HybridCheckoutDrawer.svelte
@@ -7,7 +7,7 @@
    * 1. Custom UI for service/provider/datetime/client selection
    * 2. Payment method selection (Venmo, Card via Stripe)
    * 3. Collect payment via our own adapter
-   * 4. Book on Acuity at $0 via wizard automation
+   * 4. Hand booking off to adopter-provided completion logic
    */
   import type { Service, Provider, ClientInfo, TimeSlot, Booking, PaymentIntent, PaymentResult } from '../core/types.js';
   import type { AcuityBookingData } from '../lib/acuity-listener.js';
@@ -64,7 +64,7 @@
   }: {
     /** Whether drawer is open */
     open?: boolean;
-    /** Available services (from scraper or API) */
+    /** Available services from the adopter's scheduling source */
     services?: Service[];
     /** Available providers */
     providers?: Provider[];

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -14,7 +14,7 @@ export { default as BookingConfirmation } from './BookingConfirmation.svelte';
 export { default as CheckoutDrawer } from './CheckoutDrawer.svelte';
 export { default as HybridCheckoutDrawer } from './HybridCheckoutDrawer.svelte';
 
-// Acuity embed components (for hybrid flow)
+// Acuity iframe handoff primitives for adopter-owned flows
 export { default as AcuityEmbedHandoff } from './AcuityEmbedHandoff.svelte';
 
 // Venmo/PayPal payment components

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,15 +9,14 @@
  * import { Effect } from 'effect';
  * import {
  *   createSchedulingKit,
- *   createAcuityAdapter,
+ *   createHomegrownAdapter,
  *   createVenmoAdapter,
  * } from '@tummycrypt/scheduling-kit';
  *
  * // Create adapters
- * const scheduler = createAcuityAdapter({
- *   type: 'acuity',
- *   userId: process.env.ACUITY_USER_ID,
- *   apiKey: process.env.ACUITY_API_KEY,
+ * const scheduler = createHomegrownAdapter({
+ *   db: drizzleInstance,
+ *   timezone: 'America/New_York',
  * });
  *
  * const venmo = createVenmoAdapter({


### PR DESCRIPTION
## Summary
- clarify that Jesssullivan/scheduling-kit is the sole release authority and tinyland-inc/scheduling-kit is mirror-only
- make the root README and root entrypoint example stop implying that scheduling-kit owns the full Acuity booking flow
- reframe HybridCheckoutDrawer and AcuityEmbedHandoff as UI handoff primitives for adopter-owned bridge flows
- refresh package agent notes to match current canonical-vs-mirror reality

## Why
This tightens #44 by making the package boundary explicit: Acuity REST and iframe handoff helpers can live here, but browser automation and full Acuity flow ownership belong to @tummycrypt/scheduling-bridge plus the adopter app.

## Validation
- doc and comment framing change only
- attempted local pnpm build in temp clone, but the clone had no node_modules, so build could not run there
