### PR TITLE
fix(publish): tolerate existing GitHub Packages version

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -163,7 +163,20 @@ jobs:
             pkg.publishConfig = { registry: 'https://npm.pkg.github.com' };
             require('fs').writeFileSync('./pkg-github/package.json', JSON.stringify(pkg, null, 2) + '\n');
           "
-          npm publish ./pkg-github --ignore-scripts
+          set +e
+          output=$(npm publish ./pkg-github --ignore-scripts 2>&1)
+          status=$?
+          set -e
+
+          echo "$output"
+
+          if [ "$status" -ne 0 ]; then
+            if echo "$output" | grep -q "Cannot publish over existing version"; then
+              echo "GitHub Packages already has this version; treating as success."
+              exit 0
+            fi
+            exit "$status"
+          fi
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
## Summary
- make the GitHub Packages publish step idempotent when the target version already exists
- keep npm publish truth green instead of turning a duplicate GitHub Packages version into a failed overall publish run
- preserve real failures by only swallowing the specific existing-version conflict

## Why
The current scheduling-kit publish workflow already proves and publishes the Bazel-built npm artifact correctly, but the GitHub Packages leg still fails with E409 when @jesssullivan/scheduling-kit already has that version. That leaves the publish surface noisier than the real release state.

## Validation
- local workflow YAML parse via Ruby
- next step is GitHub workflow_dispatch publish dry-run on this branch
