### PR TITLE
perf(payments): export narrow capability types subpath

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,10 @@
       "types": "./dist/payments/index.d.ts",
       "default": "./dist/payments/index.js"
     },
+    "./payments/types": {
+      "types": "./dist/payments/types.d.ts",
+      "default": "./dist/payments/types.js"
+    },
     "./core": {
       "types": "./dist/core/index.d.ts",
       "default": "./dist/core/index.js"


### PR DESCRIPTION
Summary:
- export the payments/types subpath as public API
- let consumers import PaymentCapabilities and getDefaultCapabilities without pulling in the full payments barrel
- keep Stripe and Venmo adapter exports on the broader payments path

Why:
MassageIthaca still needs a package-owned way to import default payment capability semantics for lazy booking surfaces. Today that forces a runtime import of the full payments barrel, which also exports Stripe adapters and pulls dist/payments/stripe.js into the client graph.

Validation:
- pnpm check:release-metadata
- pnpm build
- self-import of the new payments/types subpath from the package root