### PR TITLE
release: bump scheduling-kit to 0.7.2

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -99,7 +99,7 @@ npm_package(
     ],
     package = "@tummycrypt/scheduling-kit",
     tags = ["manual"],
-    version = "0.7.1",
+    version = "0.7.2",
     visibility = ["//visibility:public"],
 )
 

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -22,7 +22,7 @@ Subpackage targets (finer-grained caching):
 
 module(
     name = "tummycrypt_scheduling_kit",
-    version = "0.7.1",
+    version = "0.7.2",
     compatibility_level = 1,
 )
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tummycrypt/scheduling-kit",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "Backend-agnostic scheduling components with alternative payment support",
   "type": "module",
   "packageManager": "pnpm@9.15.9",


### PR DESCRIPTION
Summary:
- bump scheduling-kit from 0.7.1 to 0.7.2
- carry the merged payments/types export on a publishable version
- keep package.json, MODULE.bazel, and BUILD.bazel aligned

Why:
The narrow payments/types export needed for the next MassageIthaca #148 cut is merged on scheduling-kit main, but it is not consumable until a new package version exists.

Validation:
- pnpm check:release-metadata
- pnpm build