### PR TITLE
fix(payments): normalize public card method

### DIFF
--- a/src/components/CheckoutDrawer.svelte
+++ b/src/components/CheckoutDrawer.svelte
@@ -6,7 +6,7 @@
   import { Effect } from 'effect';
   import type { SchedulingKit } from '../core/pipelines.js';
   import type { Service, Provider, ClientInfo, AvailableDate, TimeSlot } from '../core/types.js';
-  import type { PaymentMethodOption } from '../payments/types.js';
+  import { toPublicPaymentMethodOption, type PaymentMethodOption } from '../payments/types.js';
   import { createCheckoutStore, setCheckoutContext } from '../stores/checkout.svelte.js';
   import { generateIdempotencyKey } from '../core/utils.js';
   import ServicePicker from './ServicePicker.svelte';
@@ -159,14 +159,7 @@
 
     const methods: PaymentMethodOption[] = [];
     for (const adapter of kit.payments.getAll()) {
-      const config = adapter.getClientConfig();
-      methods.push({
-        id: adapter.name,
-        name: adapter.name,
-        displayName: config.displayName,
-        icon: config.icon,
-        available: true,
-      });
+      methods.push(toPublicPaymentMethodOption(adapter));
     }
 
     paymentMethods = methods;

--- a/src/components/HybridCheckoutDrawer.svelte
+++ b/src/components/HybridCheckoutDrawer.svelte
@@ -155,6 +155,22 @@
     step !== 'service' && step !== 'complete' && step !== 'processing' && step !== 'venmo-checkout' && step !== 'stripe-checkout'
   );
 
+  // Public booking surfaces should expose card as the canonical id. Keep the
+  // legacy stripe alias readable for transitional consumers, but do not let
+  // card-like ids fall through into the manual/in-app completion path.
+  const isCardPaymentMethod = (paymentId: string): boolean =>
+    paymentId === 'card' || paymentId === 'stripe';
+
+  const normalizeSelectedPayment = (paymentId: string): string =>
+    isCardPaymentMethod(paymentId) ? 'card' : paymentId;
+
+  const isManualPaymentMethod = (paymentId: string): boolean =>
+    paymentId === 'cash'
+    || paymentId === 'check'
+    || paymentId === 'zelle'
+    || paymentId === 'venmo-direct'
+    || paymentId === 'other';
+
   // =============================================================================
   // HANDLERS
   // =============================================================================
@@ -226,12 +242,15 @@
   };
 
   const handlePaymentSelect = async (paymentId: string) => {
-    selectedPayment = paymentId;
+    selectedPayment = normalizeSelectedPayment(paymentId);
 
     if (paymentId === 'venmo' && capabilities.venmo?.available && onCreatePaymentOrder && onCapturePayment) {
       // Use PayPal SDK flow for Venmo — requires client-side approval
       step = 'venmo-checkout';
-    } else if (paymentId === 'stripe' && capabilities.stripe?.available && onCreateStripeIntent && selectedService) {
+    } else if (paymentId === 'venmo') {
+      errorMessage = 'Venmo is not available right now.';
+      step = 'error';
+    } else if (isCardPaymentMethod(paymentId) && capabilities.stripe?.available && onCreateStripeIntent && selectedService) {
       // Create PaymentIntent server-side, then show Stripe Elements
       step = 'processing';
       try {
@@ -245,8 +264,14 @@
         errorMessage = e instanceof Error ? e.message : 'Failed to initialize payment';
         step = 'error';
       }
-    } else {
+    } else if (isCardPaymentMethod(paymentId)) {
+      errorMessage = 'Card payments are not available right now.';
+      step = 'error';
+    } else if (isManualPaymentMethod(paymentId)) {
       processCustomPayment(paymentId);
+    } else {
+      errorMessage = 'This payment method is not supported in the current checkout flow.';
+      step = 'error';
     }
   };
 

--- a/src/components/PaymentSelector.svelte
+++ b/src/components/PaymentSelector.svelte
@@ -36,6 +36,7 @@
   const getIcon = (method: PaymentMethodOption): string => {
     const icons: Record<string, string> = {
       venmo: '💙',
+      card: '💳',
       stripe: '💳',
       cash: '💵',
       zelle: '⚡',

--- a/src/core/pipelines.ts
+++ b/src/core/pipelines.ts
@@ -18,7 +18,7 @@ import { Errors } from './types.js';
 import { validateWith, generateIdempotencyKey, withCorrelationId } from './utils.js';
 import type { SchedulingAdapter } from '../adapters/types.js';
 import type { PaymentAdapter, PaymentRegistry as CanonicalPaymentRegistry } from '../payments/types.js';
-import { createPaymentRegistry } from '../payments/types.js';
+import { createPaymentRegistry, toPublicPaymentMethodId } from '../payments/types.js';
 import { z } from 'zod';
 
 // =============================================================================
@@ -344,6 +344,7 @@ export const createSchedulingKit = (
   const payments = new Map<string, PaymentAdapter>();
   for (const a of registry.getAll()) {
     payments.set(a.name, a);
+    payments.set(toPublicPaymentMethodId(a.name), a);
   }
 
   return {

--- a/src/payments/types.ts
+++ b/src/payments/types.ts
@@ -243,6 +243,25 @@ export const getDefaultCapabilities = (): PaymentCapabilities => ({
   cash: false,
 });
 
+export const toPublicPaymentMethodId = (paymentMethod: string): string =>
+  paymentMethod === 'stripe' ? 'card' : paymentMethod;
+
+export const toInternalPaymentMethodId = (paymentMethod: string): string =>
+  paymentMethod === 'card' ? 'stripe' : paymentMethod;
+
+export const toPublicPaymentMethodOption = (adapter: PaymentAdapter): PaymentMethodOption => {
+  const config = adapter.getClientConfig();
+  const publicId = toPublicPaymentMethodId(adapter.name);
+
+  return {
+    id: publicId,
+    name: publicId,
+    displayName: config.displayName,
+    icon: publicId === 'card' ? 'card' : config.icon,
+    available: true,
+  };
+};
+
 export const createPaymentRegistry = (): PaymentRegistry => {
   const adapters = new Map<string, PaymentAdapter>();
 
@@ -251,7 +270,7 @@ export const createPaymentRegistry = (): PaymentRegistry => {
       adapters.set(adapter.name, adapter);
     },
 
-    get: (name) => adapters.get(name),
+    get: (name) => adapters.get(name) ?? adapters.get(toInternalPaymentMethodId(name)),
 
     getAll: () => Array.from(adapters.values()),
 
@@ -262,14 +281,7 @@ export const createPaymentRegistry = (): PaymentRegistry => {
         try {
           const available = await Effect.runPromise(adapter.isAvailable());
           if (available) {
-            const config = adapter.getClientConfig();
-            methods.push({
-              id: adapter.name,
-              name: adapter.name,
-              displayName: config.displayName,
-              icon: config.icon,
-              available: true,
-            });
+            methods.push(toPublicPaymentMethodOption(adapter));
           }
         } catch {
           // Adapter unavailable — skip

--- a/src/tests/components/hybrid-checkout-state.test.ts
+++ b/src/tests/components/hybrid-checkout-state.test.ts
@@ -90,7 +90,7 @@ const buildPaymentOptions = (opts: { hasVenmo?: boolean; hasStripe?: boolean } =
   const { hasVenmo = true, hasStripe = false } = opts;
   const result: PaymentOption[] = [];
   if (hasVenmo) result.push({ id: 'venmo' });
-  if (hasStripe) result.push({ id: 'stripe' });
+  if (hasStripe) result.push({ id: 'card' });
   result.push({ id: 'cash' });
   return result;
 };
@@ -100,7 +100,11 @@ const paymentOptions = buildPaymentOptions();
 
 const routePayment = (paymentId: string, hasPaypalSdk: boolean, hasStripeSdk: boolean = false): HybridStep => {
   if (paymentId === 'venmo' && hasPaypalSdk) return 'venmo-checkout';
-  if (paymentId === 'stripe' && hasStripeSdk) return 'stripe-checkout';
+  if ((paymentId === 'card' || paymentId === 'stripe') && hasStripeSdk) return 'stripe-checkout';
+  if (paymentId === 'venmo') return 'error';
+  if (paymentId === 'card' || paymentId === 'stripe') return 'error';
+  if (paymentId === 'bitcoin') return 'error';
+  if (paymentId === 'other') return 'error';
   return 'processing';
 };
 
@@ -290,25 +294,25 @@ describe('HybridCheckoutDrawer state machine', () => {
   // 5. Payment routing
   // -----------------------------------------------------------------------
   describe('routePayment', () => {
-    it('should route card to processing when no SDK', () => {
-      expect(routePayment('card', false)).toBe('processing');
-      expect(routePayment('card', true)).toBe('processing');
+    it('should route card with Stripe SDK to stripe-checkout', () => {
+      expect(routePayment('card', false, true)).toBe('stripe-checkout');
     });
 
-    it('should route stripe with Stripe SDK to stripe-checkout', () => {
+    it('should keep the legacy stripe alias routing to stripe-checkout', () => {
       expect(routePayment('stripe', false, true)).toBe('stripe-checkout');
     });
 
-    it('should route stripe without Stripe SDK to processing', () => {
-      expect(routePayment('stripe', false, false)).toBe('processing');
+    it('should fail card-like methods when Stripe is unavailable', () => {
+      expect(routePayment('card', false, false)).toBe('error');
+      expect(routePayment('stripe', false, false)).toBe('error');
     });
 
     it('should route venmo with PayPal SDK to venmo-checkout', () => {
       expect(routePayment('venmo', true)).toBe('venmo-checkout');
     });
 
-    it('should route venmo without PayPal SDK to processing', () => {
-      expect(routePayment('venmo', false)).toBe('processing');
+    it('should fail venmo when PayPal is unavailable', () => {
+      expect(routePayment('venmo', false)).toBe('error');
     });
 
     it('should route cash to processing', () => {
@@ -316,9 +320,15 @@ describe('HybridCheckoutDrawer state machine', () => {
       expect(routePayment('cash', true)).toBe('processing');
     });
 
-    it('should route unknown payment methods to processing', () => {
-      expect(routePayment('bitcoin', false)).toBe('processing');
+    it('should route explicit manual payment methods to processing', () => {
       expect(routePayment('check', true)).toBe('processing');
+      expect(routePayment('zelle', false)).toBe('processing');
+      expect(routePayment('venmo-direct', false)).toBe('processing');
+    });
+
+    it('should fail unknown payment methods', () => {
+      expect(routePayment('bitcoin', false)).toBe('error');
+      expect(routePayment('other', true)).toBe('error');
     });
   });
 
@@ -420,7 +430,7 @@ describe('HybridCheckoutDrawer state machine', () => {
       expect(stepTitles[step]).toBe('Booking Confirmed');
     });
 
-    it('should complete a stripe flow: service -> ... -> stripe-checkout -> complete', () => {
+    it('should complete a card flow through stripe-checkout -> complete', () => {
       let step: HybridStep = 'service';
 
       step = forwardTransitions[step] as HybridStep;
@@ -429,7 +439,7 @@ describe('HybridCheckoutDrawer state machine', () => {
       step = forwardTransitions[step] as HybridStep;
       expect(step).toBe('payment');
 
-      step = routePayment('stripe', false, true);
+      step = routePayment('card', false, true);
       expect(step).toBe('stripe-checkout');
       expect(canGoBack(step)).toBe(false);
 
@@ -442,7 +452,7 @@ describe('HybridCheckoutDrawer state machine', () => {
       expect(stepTitles[step]).toBe('Booking Confirmed');
     });
 
-    it('should complete a card flow: service -> ... -> processing -> complete', () => {
+    it('should fail card flow when Stripe is unavailable', () => {
       let step: HybridStep = 'service';
 
       step = forwardTransitions[step] as HybridStep;
@@ -452,11 +462,7 @@ describe('HybridCheckoutDrawer state machine', () => {
       expect(step).toBe('payment');
 
       step = routePayment('card', false);
-      expect(step).toBe('processing');
-      expect(canGoBack(step)).toBe(false);
-
-      step = 'complete';
-      expect(stepTitles[step]).toBe('Booking Confirmed');
+      expect(step).toBe('error');
     });
 
     it('should complete a cash flow: service -> ... -> processing -> complete', () => {
@@ -531,10 +537,10 @@ describe('HybridCheckoutDrawer state machine', () => {
       expect(ids).toContain('cash');
     });
 
-    it('should include stripe when configured', () => {
+    it('should include card when configured', () => {
       const opts = buildPaymentOptions({ hasVenmo: true, hasStripe: true });
       expect(opts).toHaveLength(3);
-      expect(opts.map((p) => p.id)).toEqual(['venmo', 'stripe', 'cash']);
+      expect(opts.map((p) => p.id)).toEqual(['venmo', 'card', 'cash']);
     });
 
     it('should show only cash when no adapters configured', () => {

--- a/src/tests/unit/core/pipelines.test.ts
+++ b/src/tests/unit/core/pipelines.test.ts
@@ -106,9 +106,11 @@ const createMockPaymentAdapter = (name = 'cash'): PaymentAdapter => ({
     })
   ),
   getClientConfig: () => ({
-    enabled: true,
-    displayName: 'Cash',
-    instructions: 'Pay in cash at appointment',
+    name,
+    displayName: name === 'stripe' ? 'Credit/Debit Card' : `Pay with ${name}`,
+    icon: name === 'stripe' ? 'stripe' : name,
+    environment: 'production' as const,
+    supportedCurrencies: ['USD'],
   }),
 });
 
@@ -481,6 +483,37 @@ describe('createSchedulingKit', () => {
     expect(kit.payments.get('venmo')).toBeDefined();
     expect(kit.payments.get('zelle')).toBeDefined();
     expect(kit.payments.getAll().length).toBe(3);
+  });
+
+  it('aliases stripe adapters behind the public card id', async () => {
+    const stripe = createMockPaymentAdapter('stripe');
+    const kit = createSchedulingKit(scheduler, [stripe]);
+
+    expect(kit.payments.get('stripe')).toBe(stripe);
+    expect(kit.payments.get('card')).toBe(stripe);
+
+    const methods = await kit.payments.getAvailableMethods();
+    expect(methods).toEqual([
+      expect.objectContaining({
+        id: 'card',
+        name: 'card',
+        displayName: 'Credit/Debit Card',
+        icon: 'card',
+      }),
+    ]);
+  });
+
+  it('completeBooking accepts the public card id for stripe-backed flows', async () => {
+    const stripe = createMockPaymentAdapter('stripe');
+    const kit = createSchedulingKit(scheduler, [stripe]);
+
+    const result = await expectSuccess(
+      kit.completeBooking(createBookingRequest(), 'card')
+    );
+
+    expect(result.booking).toBeDefined();
+    expect(stripe.createIntent).toHaveBeenCalled();
+    expect(stripe.capturePayment).toHaveBeenCalled();
   });
 
   it('completeBooking delegates to pipeline', async () => {

--- a/tests/e2e/payment-selector.test.ts
+++ b/tests/e2e/payment-selector.test.ts
@@ -24,12 +24,12 @@ const createMockPaymentMethods = () => [
     icon: 'cash',
   },
   {
-    id: 'stripe',
-    displayName: 'Credit Card',
+    id: 'card',
+    displayName: 'Credit/Debit Card',
     description: 'Pay with card',
     available: true,
     processingFeePercent: 2.9,
-    icon: 'stripe',
+    icon: 'card',
   },
   {
     id: 'disabled',
@@ -57,7 +57,7 @@ describe('PaymentSelector Component', () => {
 
     expect(screen.getByText('Venmo')).toBeInTheDocument();
     expect(screen.getByText('Cash')).toBeInTheDocument();
-    expect(screen.getByText('Credit Card')).toBeInTheDocument();
+    expect(screen.getByText('Credit/Debit Card')).toBeInTheDocument();
   });
 
   it('shows loading state', () => {


### PR DESCRIPTION
## What changed
- normalize the public Stripe booking method to `card` at the package boundary
- keep the legacy `stripe` alias readable internally during transition
- route unsupported `card` and `venmo` selections to error instead of falling through to manual completion
- emit public payment options through shared helpers so drawer, checkout, and registry stay aligned
- teach the booking pipeline factory to resolve Stripe-backed flows through the public `card` id

## Why
`MassageIthaca` surfaced a real divergence: Acuity capabilities exposed card as `card`, while `scheduling-kit` still branched on `stripe` in the hybrid drawer and registry. That let card flows miss Stripe checkout and fall through into incorrect local completion paths.

## Impact
This makes `scheduling-kit` the owner of the canonical public card payment id. Consumers can keep using `card` across page and drawer shells while the package preserves internal Stripe processing semantics.

## Validation
- `/Users/jess/git/scheduling-kit/node_modules/.bin/vitest run src/tests/unit/core/pipelines.test.ts src/tests/unit/core/wizard-pipeline.test.ts src/tests/components/hybrid-checkout-state.test.ts tests/e2e/payment-selector.test.ts src/tests/hybrid-checkout-capabilities.test.ts`
- full `svelte-check` remains noisy in this repo due pre-existing unrelated errors, so validation for this slice stayed focused to the affected payment controller and selector tests

## Root cause
Public payment-method ids and internal adapter names were leaking across the same boundary. The registry, older checkout path, and hybrid drawer were not all consuming the same contract.
