### PR TITLE
[codex] Make package lane repo-owned and isolated

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   package:
-    uses: tinyland-inc/ci-templates/.github/workflows/js-bazel-package.yml@jess/tin-164-add-bazel-js-package-workflow
+    uses: tinyland-inc/ci-templates/.github/workflows/js-bazel-package.yml@0e13cc4e50b191f48191f08b3db081307d3447ce
     with:
       runner_mode: repo_owned
       runner_labels_json: ${{ vars.PRIMARY_LINUX_RUNNER_LABELS_JSON }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,11 +11,13 @@ jobs:
   package:
     uses: tinyland-inc/ci-templates/.github/workflows/js-bazel-package.yml@jess/tin-164-add-bazel-js-package-workflow
     with:
-      runner_labels_json: ${{ vars.PRIMARY_LINUX_RUNNER_LABELS_JSON || '["ubuntu-latest"]' }}
+      runner_mode: repo_owned
+      runner_labels_json: ${{ vars.PRIMARY_LINUX_RUNNER_LABELS_JSON }}
+      workspace_mode: isolated
+      publish_mode: same_runner
       node_versions: '["20", "22"]'
       publish_node_version: "22"
       pnpm_version: "9.15.9"
-      cleanup_paths: "pkg pkg-github dist node_modules .svelte-kit bazel-bin bazel-out bazel-testlogs bazel-scheduling-kit .pnpm-store bazel-pkg.tgz MODULE.bazel.lock"
       prepare_command: pnpm exec svelte-kit sync
       metadata_check_command: pnpm check:release-metadata
       lint_command: pnpm lint

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   package:
-    uses: tinyland-inc/ci-templates/.github/workflows/js-bazel-package.yml@jess/tin-164-add-bazel-js-package-workflow
+    uses: tinyland-inc/ci-templates/.github/workflows/js-bazel-package.yml@0e13cc4e50b191f48191f08b3db081307d3447ce
     with:
       runner_mode: repo_owned
       runner_labels_json: ${{ vars.PRIMARY_LINUX_RUNNER_LABELS_JSON }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,13 +13,15 @@ on:
 
 jobs:
   package:
-    uses: tinyland-inc/ci-templates/.github/workflows/js-bazel-package.yml@dde8c378815e47aa027c163278430c0d98ae007b
+    uses: tinyland-inc/ci-templates/.github/workflows/js-bazel-package.yml@jess/tin-164-add-bazel-js-package-workflow
     with:
-      runner_labels_json: ${{ vars.PRIMARY_LINUX_RUNNER_LABELS_JSON || '["ubuntu-latest"]' }}
+      runner_mode: repo_owned
+      runner_labels_json: ${{ vars.PRIMARY_LINUX_RUNNER_LABELS_JSON }}
+      workspace_mode: isolated
+      publish_mode: same_runner
       node_versions: '["20", "22"]'
       publish_node_version: "22"
       pnpm_version: "9.15.9"
-      cleanup_paths: "pkg pkg-github dist node_modules .svelte-kit bazel-bin bazel-out bazel-testlogs bazel-scheduling-kit .pnpm-store bazel-pkg.tgz MODULE.bazel.lock"
       prepare_command: pnpm exec svelte-kit sync
       metadata_check_command: pnpm check:release-metadata
       lint_command: pnpm lint


### PR DESCRIPTION
## What changed
- switched the shared package workflow call to the V2 branch in `ci-templates`
- declared `runner_mode: repo_owned`
- declared `workspace_mode: isolated`
- declared `publish_mode: same_runner`
- removed the legacy cleanup-path dependency from this repo's package lane

## Why
`scheduling-kit` is already the cleanest dedicated-lane consumer in the rollout. The missing piece was explicit contract language in the workflow itself. This patch makes the repo state match the real adoption claim.

## Impact
- the package path now declares repo-owned self-hosted intent directly
- workspace isolation is part of the contract instead of a persistent-runner assumption
- this repo becomes the first clean pilot for the shared template V2 contract

## Validation
- `git diff --check`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml"); YAML.load_file(".github/workflows/publish.yml")'`

## Notes
- this depends on the companion `ci-templates` V2 branch being merged or kept available while testing
