### PR TITLE
fix(ci): update ci-templates SHA to fix startup_failure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   package:
-    uses: tinyland-inc/ci-templates/.github/workflows/js-bazel-package.yml@0e13cc4e50b191f48191f08b3db081307d3447ce
+    uses: tinyland-inc/ci-templates/.github/workflows/js-bazel-package.yml@7dddffb9969ccd3e0f2d9105e95cd834d3050685
     with:
       runner_mode: repo_owned
       runner_labels_json: ${{ vars.PRIMARY_LINUX_RUNNER_LABELS_JSON }}


### PR DESCRIPTION
## Summary
- Updates `js-bazel-package.yml` SHA from `@0e13cc4` (broken) to `@7dddffb` (fixed)
- ci-templates PR #10 simplified the `runs-on` expression that caused `startup_failure` on all callers
- Tracked: ci-templates #9

## Context
The `@0e13cc4` version of `js-bazel-package.yml` used a complex 5-term `&&`/`||` chain in `runs-on` that GitHub Actions couldn't evaluate, causing `startup_failure` (zero jobs created). The fix (ci-templates PR #10, merged) simplified it to `fromJson(inputs.runner_labels_json || '["ubuntu-latest"]')`.

## Test plan
- [ ] Trigger `workflow_dispatch` after merge and confirm CI jobs are created (no `startup_failure`)
- [ ] Verify unit tests pass on the repo-owned runner