### PR TITLE
fix(nix): align devShell to Node 22 LTS

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -14,7 +14,7 @@
       {
         devShells.default = pkgs.mkShell {
           buildInputs = with pkgs; [
-            nodejs_20
+            nodejs_22
             nodePackages.pnpm
             nodePackages.typescript
             nodePackages.typescript-language-server


### PR DESCRIPTION
## Summary
- Dev shell pinned to Node 20, now Node 22 LTS
- Aligns with acuity-middleware (Node 22) and MassageIthaca (requires >=22)
- CI already tests both Node 20 and 22 — this only changes the local dev shell default

## Tracked
- TIN-101 (toolchain convergence — align Nix devShells with CI toolchains)