### PR TITLE
Document runner authority truth

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,11 +22,13 @@ It should **not** own:
 - Acuity browser automation infrastructure
 - Modal deployment control
 
-For browser automation and remote Acuity scraping, use `@tummycrypt/scheduling-bridge`.
+For browser automation and remote Acuity scraping, use
+`@tummycrypt/scheduling-bridge`.
 
 ## Strategic Goal
 
-This package is the reusable migration layer for businesses moving away from Acuity, GlossGenius, and similar closed platforms toward a controlled path:
+This package is the reusable migration layer for businesses moving away from
+Acuity, GlossGenius, and similar closed platforms toward a controlled path:
 
 1. keep the live business running
 2. introduce a middleware-backed off-ramp
@@ -124,7 +126,9 @@ Primary checks:
 - `pnpm build`
 - `publint`
 
-Typecheck/lint may be tolerated temporarily in CI if they are marked `continue-on-error`, but that should not be treated as a steady-state quality bar.
+Typecheck/lint may be tolerated temporarily in CI if they are marked
+`continue-on-error`, but that should not be treated as a steady-state quality
+bar.
 
 ### Publishing
 
@@ -133,11 +137,20 @@ Current publish flows target:
 - npmjs as `@tummycrypt/scheduling-kit`
 - GitHub Packages as `@jesssullivan/scheduling-kit`
 
-That GitHub Packages rename is operationally real. Do not break it accidentally when editing the publish flow.
+That GitHub Packages rename is operationally real. Do not break it
+accidentally when editing the publish flow.
 
 Release/publish changes should be made against the functional release line
 first, then ported deliberately into the mirror when needed. Do not split
 package truth across both remotes by accident.
+
+Current Phase 2 runner truth:
+
+- canonical package CI/publish authority is repo-owned on GloriousFlywheel
+- the current proven runner contract is the plain repo label
+  `["scheduling-kit"]`
+- do not describe richer repo-owned self-hosted label arrays as current truth
+  unless the live workflow contract is explicitly reproven
 
 ## Effect / Architecture Notes
 
@@ -150,7 +163,8 @@ Use Effect where it improves:
 
 Do not overcomplicate simple library code with gratuitous Effect wrapping.
 
-The package’s real value is in clear contracts and composable flows, not ideological FP maximalism.
+The package's real value is in clear contracts and composable flows, not
+ideological FP maximalism.
 
 ## Adapter Boundary Rules
 
@@ -161,7 +175,9 @@ These boundaries matter:
 - App-specific admin UI does **not** belong here.
 - Payment adapters should stay business-agnostic and site-agnostic.
 
-If a feature requires Playwright, remote HTTP bridge calls, Modal deployment details, or selector maintenance, it almost certainly belongs in `acuity-middleware`, not here.
+If a feature requires Playwright, remote HTTP bridge calls, Modal deployment
+details, or selector maintenance, it almost certainly belongs in
+`acuity-middleware`, not here.
 
 ## Testing Strategy
 
@@ -192,7 +208,8 @@ Do not turn live-provider tests into the default CI path.
 - Keep adapters small and explicit.
 - Preserve backend-agnostic abstractions.
 - Avoid hard-coding MassageIthaca-specific behavior.
-- Keep payment adapter semantics clear about who receives funds and who owns platform state.
+- Keep payment adapter semantics clear about who receives funds and who owns
+  platform state.
 - Prefer deterministic tests with fixtures/cassettes over flaky live reads.
 
 ## Important Files

--- a/README.md
+++ b/README.md
@@ -73,8 +73,8 @@ Longer term, the intended publish shape is:
 
 ## Runner Authority
 
-Canonical package CI and publish now run on a repo-owned GloriousFlywheel lane.
-The current proven workflow contract is the plain repo label
+Canonical GitHub Actions package CI and publish now run on the repo-owned
+GloriousFlywheel self-hosted runner lane with the plain repo label
 `["scheduling-kit"]`.
 
 Treat that label as the active truth surface for package authority. Do not

--- a/README.md
+++ b/README.md
@@ -1,17 +1,24 @@
 # @tummycrypt/scheduling-kit
 
-Backend-agnostic scheduling system with Svelte 5 components, multiple scheduling adapters, and alternative payment support. Built with Effect for typed workflows and Zod for runtime validation.
+Backend-agnostic scheduling system with Svelte 5 components, multiple
+scheduling adapters, and alternative payment support. Built with Effect for
+typed workflows and Zod for runtime validation.
 
-Docs, prebuilts, packages and blog post to come later.  Another tinyland artifact it is time to publish.  This package powers scheduling transactions for small buisnesses in the eastern US for whom I've done contracting work. 
+Docs, prebuilts, packages and blog post to come later. Another tinyland
+artifact it is time to publish. This package powers scheduling transactions
+for small buisnesses in the eastern US for whom I've done contracting work.
 
 ## Features
 
-- **Multiple scheduling backends** -- Acuity REST API, Cal.com, or bring-your-own PostgreSQL (HomegrownAdapter)
-- **Svelte 5 components** -- ServicePicker, DateTimePicker, ClientForm, CheckoutDrawer, and more
+- **Multiple scheduling backends** -- Acuity REST API, Cal.com, or
+  bring-your-own PostgreSQL (HomegrownAdapter)
+- **Svelte 5 components** -- ServicePicker, DateTimePicker, ClientForm,
+  CheckoutDrawer, and more
 - **Payment adapters** -- Stripe, Venmo/PayPal SDK, cash, Zelle, check
 - **Availability engine** -- Pure-function slot generation, DST-safe via `Intl.DateTimeFormat`
 - **Reconciliation** -- Alt-payment matching and webhook handling
-- **Test infrastructure** -- Cassette-based API recording/playback, MSW mocking, property-based tests
+- **Test infrastructure** -- Cassette-based API recording/playback, MSW
+  mocking, property-based tests
 - **Functional core** -- Effect-powered scheduling flows and typed error handling
 
 ## Installation
@@ -63,6 +70,16 @@ Longer term, the intended publish shape is:
 2. Bazel validates/builds the publishable artifact
 3. GitHub Actions publishes that artifact to npm
 4. downstream apps consume the published package only
+
+## Runner Authority
+
+Canonical package CI and publish now run on a repo-owned GloriousFlywheel lane.
+The current proven workflow contract is the plain repo label
+`["scheduling-kit"]`.
+
+Treat that label as the active truth surface for package authority. Do not
+describe broader repo-owned self-hosted label arrays as live contract unless
+they are reproven from current runs.
 
 ## Quick Start
 
@@ -124,7 +141,8 @@ adopter app that wires the handoff.
 
 ### HomegrownAdapter
 
-Direct PostgreSQL adapter using Drizzle ORM. Replaces third-party scheduling APIs entirely.
+Direct PostgreSQL adapter using Drizzle ORM. Replaces third-party scheduling
+APIs entirely.
 
 ```typescript
 import { createHomegrownAdapter } from '@tummycrypt/scheduling-kit/adapters';
@@ -134,13 +152,15 @@ const adapter = createHomegrownAdapter({
   timezone: 'America/New_York',
 });
 
-// 16 methods: getServices, getAvailability, getSlots, book, cancel, reschedule, ...
+// 16 methods: getServices, getAvailability, getSlots, book, cancel,
+// reschedule, ...
 ```
 
 ### AcuityAdapter
 
 API-based adapter for Acuity Scheduling (requires Powerhouse plan).
-For browser automation and no-API migration flows, use `@tummycrypt/scheduling-bridge`.
+For browser automation and no-API migration flows, use
+`@tummycrypt/scheduling-bridge`.
 
 ```typescript
 import { createAcuityAdapter } from '@tummycrypt/scheduling-kit/adapters';
@@ -195,7 +215,7 @@ const slots = getAvailableSlots({
 Svelte 5 components using runes syntax. Optional Skeleton 4 integration for styling.
 
 | Component | Description |
-|-----------|-------------|
+| ----------- | ----------- |
 | `ServicePicker` | Service/appointment type selector |
 | `DateTimePicker` | Calendar date + time slot picker |
 | `ClientForm` | Client info form with Zod validation |
@@ -203,15 +223,19 @@ Svelte 5 components using runes syntax. Optional Skeleton 4 integration for styl
 | `ProviderPicker` | Practitioner/provider selector |
 | `BookingConfirmation` | Post-booking confirmation display |
 | `CheckoutDrawer` | Full checkout flow in a slide-out drawer |
-| `HybridCheckoutDrawer` | Checkout UI that hands booking off to adopter-provided Acuity flow |
+| `HybridCheckoutDrawer` | Checkout UI for adopter-provided Acuity handoff |
 | `VenmoButton` | Venmo/PayPal payment button |
 | `VenmoCheckout` | Full Venmo checkout flow |
 | `StripeCheckout` | Stripe Elements checkout |
-| `AcuityEmbedHandoff` | Prefilled Acuity iframe primitive with postMessage integration |
+| `AcuityEmbedHandoff` | Prefilled Acuity iframe handoff with postMessage |
 
 ```svelte
 <script lang="ts">
-  import { ServicePicker, DateTimePicker, ClientForm } from '@tummycrypt/scheduling-kit/components';
+  import {
+    ServicePicker,
+    DateTimePicker,
+    ClientForm,
+  } from '@tummycrypt/scheduling-kit/components';
 </script>
 
 <ServicePicker services={data.services} onselect={handleSelect} />
@@ -233,7 +257,7 @@ import {
 ```
 
 | Adapter | Type | Description |
-|---------|------|-------------|
+| --------- | ------ | ------------- |
 | `createStripeAdapter` | `stripe` | Stripe Connect with Payment Intents |
 | `createVenmoAdapter` | `venmo` | PayPal SDK with Venmo button |
 | `createCashAdapter` | `cash` | Cash/in-person manual payment |
@@ -246,7 +270,9 @@ import {
 Match alt-payment transactions (Venmo, Zelle, cash) to bookings.
 
 ```typescript
-import { createReconciliationMatcher } from '@tummycrypt/scheduling-kit/reconciliation';
+import {
+  createReconciliationMatcher,
+} from '@tummycrypt/scheduling-kit/reconciliation';
 ```
 
 ## Stores
@@ -293,7 +319,8 @@ RUN_LIVE_TESTS=true pnpm test:live
 
 ### Test Utilities
 
-The `@tummycrypt/scheduling-kit/testing` export provides cassette-based API recording and playback for deterministic integration tests.
+The `@tummycrypt/scheduling-kit/testing` export provides cassette-based API
+recording and playback for deterministic integration tests.
 
 ```typescript
 import { CassetteRecorder, CassettePlayer } from '@tummycrypt/scheduling-kit/testing';


### PR DESCRIPTION
## Summary
- add the Phase 2 runner-authority truth to AGENTS.md
- add matching runner-authority guidance to README.md
- normalize markdown formatting so the required doc checks pass

## Verification
- git diff --check
- pnpm dlx markdownlint-cli2 AGENTS.md README.md