### PR TITLE
ci: prove shared package runner lane

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,10 +9,10 @@ on:
 
 jobs:
   package:
-    uses: tinyland-inc/ci-templates/.github/workflows/js-bazel-package.yml@f2e12c10580f17d54ac48434e2577fbcfe502a05
+    uses: tinyland-inc/ci-templates/.github/workflows/js-bazel-package.yml@c9e81f802fe9520260a5389121f8291049e030e1
     with:
       runner_mode: shared
-      shared_runner_labels_json: '["tinyland-nix"]'
+      shared_runner_labels_json: ${{ vars.PRIMARY_LINUX_RUNNER_LABELS_JSON }}
       runner_labels_json: ${{ vars.PRIMARY_LINUX_RUNNER_LABELS_JSON }}
       workspace_mode: isolated
       publish_mode: same_runner

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,8 @@ jobs:
   package:
     uses: tinyland-inc/ci-templates/.github/workflows/js-bazel-package.yml@f2e12c10580f17d54ac48434e2577fbcfe502a05
     with:
-      runner_mode: repo_owned
+      runner_mode: shared
+      shared_runner_labels_json: '["tinyland-nix"]'
       runner_labels_json: ${{ vars.PRIMARY_LINUX_RUNNER_LABELS_JSON }}
       workspace_mode: isolated
       publish_mode: same_runner

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,10 +13,10 @@ on:
 
 jobs:
   package:
-    uses: tinyland-inc/ci-templates/.github/workflows/js-bazel-package.yml@f2e12c10580f17d54ac48434e2577fbcfe502a05
+    uses: tinyland-inc/ci-templates/.github/workflows/js-bazel-package.yml@c9e81f802fe9520260a5389121f8291049e030e1
     with:
       runner_mode: shared
-      shared_runner_labels_json: '["tinyland-nix"]'
+      shared_runner_labels_json: ${{ vars.PRIMARY_LINUX_RUNNER_LABELS_JSON }}
       runner_labels_json: ${{ vars.PRIMARY_LINUX_RUNNER_LABELS_JSON }}
       workspace_mode: isolated
       publish_mode: same_runner

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
     inputs:
       dry_run:
-        description: 'Dry run (no actual publish)'
+        description: "Dry run (no actual publish)"
         required: false
         type: boolean
         default: true
@@ -15,7 +15,8 @@ jobs:
   package:
     uses: tinyland-inc/ci-templates/.github/workflows/js-bazel-package.yml@f2e12c10580f17d54ac48434e2577fbcfe502a05
     with:
-      runner_mode: repo_owned
+      runner_mode: shared
+      shared_runner_labels_json: '["tinyland-nix"]'
       runner_labels_json: ${{ vars.PRIMARY_LINUX_RUNNER_LABELS_JSON }}
       workspace_mode: isolated
       publish_mode: same_runner


### PR DESCRIPTION
## Summary
- pin the package workflow caller to ci-templates c9e81f8, which contains the startup-safe shared-runner resolver
- switch package validation/publish policy to runner_mode=shared
- source shared runner labels from PRIMARY_LINUX_RUNNER_LABELS_JSON instead of hard-coding labels in the workflow file

## Validation
- git diff --check
- CI will validate the live shared-runner path on this PR

## Notes
- This remains draft until the live shared-runner checks complete.
- Public workflow files name the policy and repo variable only; private runner topology stays out of this public repo.