### PR TITLE
ci: fix publish credential forwarding

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,6 +11,11 @@ on:
         type: boolean
         default: true
 
+permissions:
+  actions: read
+  contents: read
+  packages: write
+
 jobs:
   package:
     uses: tinyland-inc/ci-templates/.github/workflows/js-bazel-package.yml@c9e81f802fe9520260a5389121f8291049e030e1
@@ -36,4 +41,5 @@ jobs:
       npm_access: public
       github_package_name: "@jesssullivan/scheduling-kit"
       dry_run: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run || false }}
-    secrets: inherit
+    secrets:
+      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary
- grant publish workflow package-write permission for the GitHub Packages mirror
- pass NPM_TOKEN explicitly into the reusable js-bazel-package workflow instead of relying on cross-repo secrets: inherit

## Why
The same reusable publish path is used here; bridge v0.4.3 proved that cross-repo secrets: inherit does not deliver NPM_TOKEN into the reusable workflow publish job.

## Validation
- git diff --check
- publish workflow fix only; PR CI will validate the package lane