### PR TITLE
test: guard package release provenance

### DIFF
--- a/scripts/check-release-metadata.mjs
+++ b/scripts/check-release-metadata.mjs
@@ -6,6 +6,8 @@ const read = (relativePath) =>
 const packageJson = JSON.parse(read('../package.json'));
 const moduleBazel = read('../MODULE.bazel');
 const buildBazel = read('../BUILD.bazel');
+const ciWorkflow = read('../.github/workflows/ci.yml');
+const publishWorkflow = read('../.github/workflows/publish.yml');
 
 const extract = (source, pattern, label) => {
 	const match = source.match(pattern);
@@ -18,6 +20,14 @@ const extract = (source, pattern, label) => {
 const expectedVersion = packageJson.version;
 const expectedPackageName = packageJson.name;
 const expectedPnpmVersion = packageJson.packageManager?.replace(/^pnpm@/, '');
+const expectedGitHubPackageName = '@jesssullivan/scheduling-kit';
+const expectedRepositoryUrl = 'git+https://github.com/Jesssullivan/scheduling-kit.git';
+
+const includes = (source, needle) => source.includes(needle);
+const usesPinnedPackageWorkflow = (workflow) =>
+	/uses:\s*tinyland-inc\/ci-templates\/\.github\/workflows\/js-bazel-package\.yml@[0-9a-f]{40}/.test(
+		workflow,
+	);
 
 const checks = [
 	{
@@ -40,6 +50,73 @@ const checks = [
 		actual: extract(moduleBazel, /pnpm_version = "([^"]+)"/, 'pnpm_version'),
 		expected: expectedPnpmVersion,
 	},
+	{
+		label: 'package.json repository',
+		actual: packageJson.repository?.url,
+		expected: expectedRepositoryUrl,
+	},
+	{
+		label: 'CI reusable workflow pin',
+		actual: String(usesPinnedPackageWorkflow(ciWorkflow)),
+		expected: 'true',
+	},
+	{
+		label: 'CI runner mode',
+		actual: extract(ciWorkflow, /runner_mode:\s*([^\n]+)/, 'CI runner_mode').trim(),
+		expected: 'shared',
+	},
+	{
+		label: 'CI publish mode',
+		actual: extract(ciWorkflow, /publish_mode:\s*([^\n]+)/, 'CI publish_mode').trim(),
+		expected: 'same_runner',
+	},
+	{
+		label: 'CI package artifact path',
+		actual: extract(ciWorkflow, /package_dir:\s*([^\n]+)/, 'CI package_dir').trim(),
+		expected: './bazel-bin/pkg',
+	},
+	{
+		label: 'CI Bazel package target',
+		actual: String(
+			includes(extract(ciWorkflow, /bazel_targets:\s*"([^"]+)"/, 'CI bazel_targets'), '//:pkg'),
+		),
+		expected: 'true',
+	},
+	{
+		label: 'CI GitHub Packages name',
+		actual: extract(ciWorkflow, /github_package_name:\s*"([^"]+)"/, 'CI github_package_name'),
+		expected: expectedGitHubPackageName,
+	},
+	{
+		label: 'publish reusable workflow pin',
+		actual: String(usesPinnedPackageWorkflow(publishWorkflow)),
+		expected: 'true',
+	},
+	{
+		label: 'publish packages permission',
+		actual: extract(publishWorkflow, /packages:\s*([^\n]+)/, 'publish packages permission').trim(),
+		expected: 'write',
+	},
+	{
+		label: 'publish package artifact path',
+		actual: extract(publishWorkflow, /package_dir:\s*([^\n]+)/, 'publish package_dir').trim(),
+		expected: './bazel-bin/pkg',
+	},
+	{
+		label: 'publish Bazel package target',
+		actual: String(
+			includes(
+				extract(publishWorkflow, /bazel_targets:\s*"([^"]+)"/, 'publish bazel_targets'),
+				'//:pkg',
+			),
+		),
+		expected: 'true',
+	},
+	{
+		label: 'publish GitHub Packages name',
+		actual: extract(publishWorkflow, /github_package_name:\s*"([^"]+)"/, 'publish github_package_name'),
+		expected: expectedGitHubPackageName,
+	},
 ];
 
 const failures = checks.filter((check) => check.actual !== check.expected);
@@ -54,5 +131,5 @@ if (failures.length > 0) {
 }
 
 console.log(
-	`release metadata aligned for ${expectedPackageName}@${expectedVersion} (pnpm ${expectedPnpmVersion})`,
+	`release metadata aligned for ${expectedPackageName}@${expectedVersion} (pnpm ${expectedPnpmVersion}, ${expectedGitHubPackageName})`,
 );

--- a/scripts/check-release-metadata.mjs
+++ b/scripts/check-release-metadata.mjs
@@ -20,12 +20,23 @@ const extract = (source, pattern, label) => {
 const expectedVersion = packageJson.version;
 const expectedPackageName = packageJson.name;
 const expectedPnpmVersion = packageJson.packageManager?.replace(/^pnpm@/, '');
-const expectedGitHubPackageName = '@jesssullivan/scheduling-kit';
 const expectedRepositoryUrl = 'git+https://github.com/Jesssullivan/scheduling-kit.git';
+const expectedPackageBasename = expectedPackageName.split('/').at(-1);
+const expectedRepositoryOwner = new URL(expectedRepositoryUrl.replace(/^git\+/, ''))
+	.pathname.split('/')
+	.filter(Boolean)[0]
+	.toLowerCase();
+const expectedGitHubPackageName = `@${expectedRepositoryOwner}/${expectedPackageBasename}`;
 
 const includes = (source, needle) => source.includes(needle);
+const scalar = (value) =>
+	value
+		.trim()
+		.replace(/^(['"])(.*)\1\s*(?:#.*)?$/, '$2')
+		.replace(/\s+#.*$/, '')
+		.trim();
 const usesPinnedPackageWorkflow = (workflow) =>
-	/uses:\s*tinyland-inc\/ci-templates\/\.github\/workflows\/js-bazel-package\.yml@[0-9a-f]{40}/.test(
+	/uses:\s*tinyland-inc\/ci-templates\/\.github\/workflows\/js-bazel-package\.yml@[0-9a-fA-F]{40}/.test(
 		workflow,
 	);
 
@@ -62,17 +73,17 @@ const checks = [
 	},
 	{
 		label: 'CI runner mode',
-		actual: extract(ciWorkflow, /runner_mode:\s*([^\n]+)/, 'CI runner_mode').trim(),
+		actual: scalar(extract(ciWorkflow, /runner_mode:\s*([^\n]+)/, 'CI runner_mode')),
 		expected: 'shared',
 	},
 	{
 		label: 'CI publish mode',
-		actual: extract(ciWorkflow, /publish_mode:\s*([^\n]+)/, 'CI publish_mode').trim(),
+		actual: scalar(extract(ciWorkflow, /publish_mode:\s*([^\n]+)/, 'CI publish_mode')),
 		expected: 'same_runner',
 	},
 	{
 		label: 'CI package artifact path',
-		actual: extract(ciWorkflow, /package_dir:\s*([^\n]+)/, 'CI package_dir').trim(),
+		actual: scalar(extract(ciWorkflow, /package_dir:\s*([^\n]+)/, 'CI package_dir')),
 		expected: './bazel-bin/pkg',
 	},
 	{
@@ -94,12 +105,14 @@ const checks = [
 	},
 	{
 		label: 'publish packages permission',
-		actual: extract(publishWorkflow, /packages:\s*([^\n]+)/, 'publish packages permission').trim(),
+		actual: scalar(
+			extract(publishWorkflow, /packages:\s*([^\n]+)/, 'publish packages permission'),
+		),
 		expected: 'write',
 	},
 	{
 		label: 'publish package artifact path',
-		actual: extract(publishWorkflow, /package_dir:\s*([^\n]+)/, 'publish package_dir').trim(),
+		actual: scalar(extract(publishWorkflow, /package_dir:\s*([^\n]+)/, 'publish package_dir')),
 		expected: './bazel-bin/pkg',
 	},
 	{


### PR DESCRIPTION
## Summary
- extend `check-release-metadata` beyond package/Bazel version checks
- guard canonical repository metadata, pinned shared package workflow usage, shared/same-runner mode, `//:pkg`, `./bazel-bin/pkg`, and GitHub Packages package name
- keep this as a repo-local provenance guard without private runner topology

## Validation
- `pnpm check:release-metadata`
- `git diff --check`

Refs: #73, #75, TIN-89, TIN-557