### PR TITLE
ci: pin Bazel command retry template

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   package:
-    uses: tinyland-inc/ci-templates/.github/workflows/js-bazel-package.yml@0d3a9c1fb5198d0670b773e78d9dad6cc5867a98
+    uses: tinyland-inc/ci-templates/.github/workflows/js-bazel-package.yml@21e0093a7586931ee69d716387e00556c6da7738
     with:
       runner_mode: shared
       shared_runner_labels_json: ${{ vars.PRIMARY_LINUX_RUNNER_LABELS_JSON }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,7 +18,7 @@ permissions:
 
 jobs:
   package:
-    uses: tinyland-inc/ci-templates/.github/workflows/js-bazel-package.yml@0d3a9c1fb5198d0670b773e78d9dad6cc5867a98
+    uses: tinyland-inc/ci-templates/.github/workflows/js-bazel-package.yml@21e0093a7586931ee69d716387e00556c6da7738
     with:
       runner_mode: shared
       shared_runner_labels_json: ${{ vars.PRIMARY_LINUX_RUNNER_LABELS_JSON }}


### PR DESCRIPTION
## Summary

Pins `tinyland-inc/ci-templates/.github/workflows/js-bazel-package.yml` to merge commit `21e0093a7586931ee69d716387e00556c6da7738` from ci-templates#19.

This makes the shared transient Bazel external-fetch retry wrapper active for consumer-supplied package commands, not only explicit Bazel validation.

## Validation

- Ruby YAML parse for all workflows
- `git diff --check`
- scoped `actionlint` on changed workflows

Refs: tinyland-inc/ci-templates#19, tinyland-inc/ci-templates#16, TIN-558, TIN-557
