### PR TITLE
chore: harden workflow authority guardrails

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,13 @@ on:
     branches: [main]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   package:
     uses: tinyland-inc/ci-templates/.github/workflows/js-bazel-package.yml@21e0093a7586931ee69d716387e00556c6da7738
@@ -30,6 +37,6 @@ jobs:
       bazel_targets: "//:typecheck //:pkg //:test"
       package_dir: ./bazel-bin/pkg
       npm_access: public
+      npm_publish_provenance: true
       github_package_name: "@jesssullivan/scheduling-kit"
       dry_run: true
-    secrets: inherit

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,7 +14,12 @@ on:
 permissions:
   actions: read
   contents: read
+  id-token: write
   packages: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.release.tag_name || github.ref }}
+  cancel-in-progress: false
 
 jobs:
   package:
@@ -39,6 +44,7 @@ jobs:
       bazel_targets: "//:typecheck //:pkg //:test"
       package_dir: ./bazel-bin/pkg
       npm_access: public
+      npm_publish_provenance: true
       github_package_name: "@jesssullivan/scheduling-kit"
       dry_run: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run || false }}
     secrets:

--- a/docs/build-and-release.md
+++ b/docs/build-and-release.md
@@ -34,6 +34,22 @@ That split is intentional. Nix bootstraps the tools, Bazel models the artifact
 graph, and the shared `js-bazel-package` workflow publishes from
 `./bazel-bin/pkg`.
 
+## Bazel Cache Contract
+
+Local Bazel use defaults to the repo-local disk cache in `.bazelrc`:
+
+```bash
+bazel build //:pkg
+bazel test //:test
+```
+
+Contributor machines can opt into a remote cache by adding a private
+`user.bazelrc`; this repository intentionally keeps private cache topology out
+of public source. CI remote-cache behavior is owned by the shared
+`js-bazel-package` workflow and its runner environment. The public contract is
+that CI must still publish the Bazel package artifact from `./bazel-bin/pkg`
+with local fallback available when the remote cache is unavailable.
+
 ## Core commands
 
 ```bash
@@ -56,6 +72,20 @@ When you change release metadata, keep these aligned:
 - `BUILD.bazel`
 
 Version drift across those files is a bug.
+
+## Release Checklist
+
+Before cutting a package release, verify these surfaces together:
+
+- npm package: `@tummycrypt/scheduling-kit`
+- GitHub Packages package: `@jesssullivan/scheduling-kit`
+- tag and GitHub release for the package version
+- Bazel package artifact from `./bazel-bin/pkg`
+- consumer dependency range in bridge and app repos
+
+Historical releases before this checklist may have npm versions without matching
+GitHub Releases. Document or backfill those explicitly instead of treating the
+latest GitHub Release as complete package truth.
 
 ## Docs and LLM surfaces
 

--- a/scripts/check-release-metadata.mjs
+++ b/scripts/check-release-metadata.mjs
@@ -39,6 +39,8 @@ const usesPinnedPackageWorkflow = (workflow) =>
 	/uses:\s*tinyland-inc\/ci-templates\/\.github\/workflows\/js-bazel-package\.yml@[0-9a-fA-F]{40}/.test(
 		workflow,
 	);
+const hasWorkflowConcurrency = (workflow) => /\nconcurrency:\n/.test(workflow);
+const doesNotInheritAllSecrets = (workflow) => !/secrets:\s*inherit/.test(workflow);
 
 const checks = [
 	{
@@ -72,6 +74,21 @@ const checks = [
 		expected: 'true',
 	},
 	{
+		label: 'CI contents permission',
+		actual: scalar(extract(ciWorkflow, /contents:\s*([^\n]+)/, 'CI contents permission')),
+		expected: 'read',
+	},
+	{
+		label: 'CI concurrency',
+		actual: String(hasWorkflowConcurrency(ciWorkflow)),
+		expected: 'true',
+	},
+	{
+		label: 'CI least privilege secrets',
+		actual: String(doesNotInheritAllSecrets(ciWorkflow)),
+		expected: 'true',
+	},
+	{
 		label: 'CI runner mode',
 		actual: scalar(extract(ciWorkflow, /runner_mode:\s*([^\n]+)/, 'CI runner_mode')),
 		expected: 'shared',
@@ -85,6 +102,13 @@ const checks = [
 		label: 'CI package artifact path',
 		actual: scalar(extract(ciWorkflow, /package_dir:\s*([^\n]+)/, 'CI package_dir')),
 		expected: './bazel-bin/pkg',
+	},
+	{
+		label: 'CI npm provenance intent',
+		actual: scalar(
+			extract(ciWorkflow, /npm_publish_provenance:\s*([^\n]+)/, 'CI npm provenance'),
+		),
+		expected: 'true',
 	},
 	{
 		label: 'CI Bazel package target',
@@ -104,6 +128,11 @@ const checks = [
 		expected: 'true',
 	},
 	{
+		label: 'publish concurrency',
+		actual: String(hasWorkflowConcurrency(publishWorkflow)),
+		expected: 'true',
+	},
+	{
 		label: 'publish packages permission',
 		actual: scalar(
 			extract(publishWorkflow, /packages:\s*([^\n]+)/, 'publish packages permission'),
@@ -111,9 +140,27 @@ const checks = [
 		expected: 'write',
 	},
 	{
+		label: 'publish provenance permission',
+		actual: scalar(
+			extract(publishWorkflow, /id-token:\s*([^\n]+)/, 'publish id-token permission'),
+		),
+		expected: 'write',
+	},
+	{
 		label: 'publish package artifact path',
 		actual: scalar(extract(publishWorkflow, /package_dir:\s*([^\n]+)/, 'publish package_dir')),
 		expected: './bazel-bin/pkg',
+	},
+	{
+		label: 'publish npm provenance',
+		actual: scalar(
+			extract(
+				publishWorkflow,
+				/npm_publish_provenance:\s*([^\n]+)/,
+				'publish npm provenance',
+			),
+		),
+		expected: 'true',
 	},
 	{
 		label: 'publish Bazel package target',


### PR DESCRIPTION
## Summary
- add explicit workflow permissions and concurrency to CI and publish lanes
- require npm provenance intent and publish id-token permission in release metadata checks
- document the public Bazel cache contract and package release checklist without private cache topology

Refs #75.
Refs #73.

## Validation
- pnpm check:release-metadata
- git diff --check
- actionlint .github/workflows/ci.yml .github/workflows/publish.yml
- nix develop -c bazel build //:typecheck //:pkg
- nix develop -c bazel test //:test