### PR TITLE
fix: make Bazel package authority composable

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -285,10 +285,6 @@ js_run_binary(
     tool = ":svelte_check",
     srcs = glob(
         [
-            ".svelte-kit/**/*.d.ts",
-            ".svelte-kit/**/*.json",
-            ".svelte-kit/**/*.js",
-            ".svelte-kit/**/*.ts",
             "src/**/*.ts",
             "src/**/*.svelte",
             "src/**/*.svelte.ts",

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -19,10 +19,11 @@ Subpackage structure:
 load("@aspect_rules_js//js:defs.bzl", "js_library", "js_run_binary")
 load("@aspect_rules_js//npm:defs.bzl", "npm_package")
 load("@aspect_rules_ts//ts:defs.bzl", "ts_project")
-load("@npm//:defs.bzl", "npm_link_all_packages")
-load("@npm//:svelte-check/package_json.bzl", svelte_check = "bin")
-load("@npm//:@sveltejs/package/package_json.bzl", svelte_package = "bin")
-load("@npm//:vitest/package_json.bzl", vitest_bin = "bin")
+load("@tummycrypt_scheduling_kit_npm//:defs.bzl", "npm_link_all_packages")
+load("@tummycrypt_scheduling_kit_npm//:@sveltejs/kit/package_json.bzl", svelte_kit = "bin")
+load("@tummycrypt_scheduling_kit_npm//:svelte-check/package_json.bzl", svelte_check = "bin")
+load("@tummycrypt_scheduling_kit_npm//:@sveltejs/package/package_json.bzl", svelte_package = "bin")
+load("@tummycrypt_scheduling_kit_npm//:vitest/package_json.bzl", vitest_bin = "bin")
 
 # =============================================================================
 # npm link - makes node_modules available
@@ -37,6 +38,32 @@ svelte_check.svelte_check_binary(
 
 svelte_package.svelte_package_binary(
     name = "svelte_package",
+    visibility = ["//visibility:public"],
+)
+
+svelte_kit.svelte_kit_binary(
+    name = "svelte_kit",
+    visibility = ["//visibility:public"],
+)
+
+# svelte-check and Vitest both read tsconfig.json, which extends the generated
+# .svelte-kit/tsconfig.json. Mirror the pnpm scripts' required sync step.
+js_run_binary(
+    name = "svelte_kit_sync",
+    tags = ["manual"],
+    tool = ":svelte_kit",
+    srcs = glob([
+        "src/**/*.ts",
+        "src/**/*.svelte",
+        "src/**/*.svelte.ts",
+    ]) + [
+        "package.json",
+        "svelte.config.js",
+        "tsconfig.json",
+        ":node_modules",
+    ],
+    args = ["sync"],
+    out_dirs = [".svelte-kit"],
     visibility = ["//visibility:public"],
 )
 
@@ -66,6 +93,7 @@ js_run_binary(
         "package.json",
         "svelte.config.js",
         "tsconfig.json",
+        ":svelte_kit_sync",
         ":node_modules",
     ],
     args = [
@@ -228,10 +256,15 @@ vitest_bin.vitest_test(
     tags = ["manual"],
     data = [
         ":node_modules",
+        ":svelte_kit_sync",
         "tsconfig.json",
         ":node_modules/vitest",
         "vitest.config.ts",
-    ] + glob(["src/**/*.ts"]),
+    ] + glob([
+        "src/**/*.ts",
+        "src/**/*.svelte",
+        "src/**/*.svelte.ts",
+    ]),
     args = [
         "run",
         "--reporter=verbose",
@@ -264,6 +297,7 @@ js_run_binary(
     ) + [
         "svelte.config.js",
         "tsconfig.json",
+        ":svelte_kit_sync",
         ":node_modules",
     ],
     args = [

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -68,13 +68,13 @@ use_repo(pnpm, "pnpm")
 npm = use_extension("@aspect_rules_js//npm:extensions.bzl", "npm")
 
 npm.npm_translate_lock(
-    name = "npm",
+    name = "tummycrypt_scheduling_kit_npm",
     pnpm_lock = "//:pnpm-lock.yaml",
     data = ["//:package.json"],
     npmrc = "//:.npmrc",
 )
 
-use_repo(npm, "npm")
+use_repo(npm, "tummycrypt_scheduling_kit_npm")
 
 # =============================================================================
 # TypeScript toolchain


### PR DESCRIPTION
## Summary
- Give the Aspect npm extension a package-scoped repository name, `tummycrypt_scheduling_kit_npm`.
- Wire Bazel to run `svelte-kit sync` before package, typecheck, and tests, matching the existing pnpm scripts.
- Include Svelte sources in the Vitest runfiles for tests that inspect component source directly.

## Why
Standalone Bzlmod modules that all export an `npm` repo collide when composed in a consumer graph. This keeps scheduling-kit composable with tinyvectors, tinyland-auth-redis, tinyland-auth-pg, and scheduling-bridge while preserving the Bazel package artifact as the build authority.

The sync/runfiles changes fix the existing Bazel test/typecheck gap where `tsconfig.json` extends `.svelte-kit/tsconfig.json` but the generated `.svelte-kit` directory was absent from the sandbox.

## Validation
- `bazel build //:pkg //:typecheck --verbose_failures`
- `bazel test //:test --verbose_failures`
- `git diff --check`
- Cross-module `bazel mod graph` smoke with local overrides for scheduling-kit, scheduling-bridge, tinyvectors, tinyland-auth-redis, and tinyland-auth-pg

Refs: TIN-678, TIN-679
