### PR TITLE
Support scoped homegrown database execution

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -99,7 +99,7 @@ npm_package(
     ],
     package = "@tummycrypt/scheduling-kit",
     tags = ["manual"],
-    version = "0.7.2",
+    version = "0.7.3",
     visibility = ["//visibility:public"],
 )
 

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -22,7 +22,7 @@ Subpackage targets (finer-grained caching):
 
 module(
     name = "tummycrypt_scheduling_kit",
-    version = "0.7.2",
+    version = "0.7.3",
     compatibility_level = 1,
 )
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tummycrypt/scheduling-kit",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "description": "Backend-agnostic scheduling components with alternative payment support",
   "type": "module",
   "packageManager": "pnpm@9.15.9",
@@ -100,7 +100,7 @@
     }
   },
   "dependencies": {
-    "@tummycrypt/tinyland-auth-pg": "^0.1.1",
+    "@tummycrypt/tinyland-auth-pg": "^0.2.1",
     "drizzle-orm": "0.39.3",
     "effect": "^3.19.14",
     "zod": "^4.3.5"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,11 +15,11 @@ importers:
         specifier: ^4.0.0
         version: 4.13.0(svelte@5.54.1)
       '@tummycrypt/tinyland-auth-pg':
-        specifier: ^0.1.1
-        version: 0.1.1(@tummycrypt/tinyland-auth@0.2.0(@sveltejs/kit@2.55.0(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.54.1)(vite@6.4.1(@types/node@20.19.37)))(svelte@5.54.1)(typescript@5.9.3)(vite@6.4.1(@types/node@20.19.37)))(svelte@5.54.1))(@types/pg@8.11.6)
+        specifier: ^0.2.1
+        version: 0.2.1(@tummycrypt/tinyland-auth@0.2.0(@sveltejs/kit@2.55.0(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.54.1)(vite@6.4.1(@types/node@20.19.37)))(svelte@5.54.1)(typescript@5.9.3)(vite@6.4.1(@types/node@20.19.37)))(svelte@5.54.1))(@types/pg@8.11.6)
       drizzle-orm:
         specifier: 0.39.3
-        version: 0.39.3(@neondatabase/serverless@0.10.4)(@types/pg@8.11.6)
+        version: 0.39.3(@neondatabase/serverless@0.10.4)(@types/pg@8.11.6)(pg@8.20.0)
       effect:
         specifier: ^3.19.14
         version: 3.21.0
@@ -738,8 +738,8 @@ packages:
       vitest:
         optional: true
 
-  '@tummycrypt/tinyland-auth-pg@0.1.1':
-    resolution: {integrity: sha512-ASAeuCRKptgt6c0piTq32FahJgErwo1iQLwcGN3Pzh1EDZh9IB8BEaXHpg5KwaGcM5klrjdgW/hH47agmcC5FQ==}
+  '@tummycrypt/tinyland-auth-pg@0.2.1':
+    resolution: {integrity: sha512-4xzcLu64OmaHKsaVOgXoSJ6oaIrp1+tgDoNvKcqIXuELCaaT14ifXaU00RWQjDJDQOx4iIiPgvAoL8P2pi2j8w==}
     peerDependencies:
       '@tummycrypt/tinyland-auth': ^0.2.0
 
@@ -1742,6 +1742,12 @@ packages:
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
 
+  pg-cloudflare@1.3.0:
+    resolution: {integrity: sha512-6lswVVSztmHiRtD6I8hw4qP/nDm1EJbKMRhf3HCYaqud7frGysPv7FYJ5noZQdhQtN2xJnimfMtvQq21pdbzyQ==}
+
+  pg-connection-string@2.12.0:
+    resolution: {integrity: sha512-U7qg+bpswf3Cs5xLzRqbXbQl85ng0mfSV/J0nnA31MCLgvEaAo7CIhmeyrmJpOr7o+zm0rXK+hNnT5l9RHkCkQ==}
+
   pg-int8@1.0.1:
     resolution: {integrity: sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==}
     engines: {node: '>=4.0.0'}
@@ -1750,12 +1756,33 @@ packages:
     resolution: {integrity: sha512-BM/Thnrw5jm2kKLE5uJkXqqExRUY/toLHda65XgFTBTFYZyopbKjBe29Ii3RbkvlsMoFwD+tHeGaCjjv0gHlyw==}
     engines: {node: '>=4'}
 
+  pg-pool@3.13.0:
+    resolution: {integrity: sha512-gB+R+Xud1gLFuRD/QgOIgGOBE2KCQPaPwkzBBGC9oG69pHTkhQeIuejVIk3/cnDyX39av2AxomQiyPT13WKHQA==}
+    peerDependencies:
+      pg: '>=8.0'
+
   pg-protocol@1.13.0:
     resolution: {integrity: sha512-zzdvXfS6v89r6v7OcFCHfHlyG/wvry1ALxZo4LqgUoy7W9xhBDMaqOuMiF3qEV45VqsN6rdlcehHrfDtlCPc8w==}
+
+  pg-types@2.2.0:
+    resolution: {integrity: sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==}
+    engines: {node: '>=4'}
 
   pg-types@4.1.0:
     resolution: {integrity: sha512-o2XFanIMy/3+mThw69O8d4n1E5zsLhdO+OPqswezu7Z5ekP4hYDqlDjlmOpYMbzY2Br0ufCwJLdDIXeNVwcWFg==}
     engines: {node: '>=10'}
+
+  pg@8.20.0:
+    resolution: {integrity: sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA==}
+    engines: {node: '>= 16.0.0'}
+    peerDependencies:
+      pg-native: '>=3.0.1'
+    peerDependenciesMeta:
+      pg-native:
+        optional: true
+
+  pgpass@1.0.5:
+    resolution: {integrity: sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==}
 
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
@@ -1800,17 +1827,33 @@ packages:
     resolution: {integrity: sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==}
     engines: {node: ^10 || ^12 || >=14}
 
+  postgres-array@2.0.0:
+    resolution: {integrity: sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==}
+    engines: {node: '>=4'}
+
   postgres-array@3.0.4:
     resolution: {integrity: sha512-nAUSGfSDGOaOAEGwqsRY27GPOea7CNipJPOA7lPbdEpx5Kg3qzdP0AaWC5MlhTWV9s4hFX39nomVZ+C4tnGOJQ==}
     engines: {node: '>=12'}
+
+  postgres-bytea@1.0.1:
+    resolution: {integrity: sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==}
+    engines: {node: '>=0.10.0'}
 
   postgres-bytea@3.0.0:
     resolution: {integrity: sha512-CNd4jim9RFPkObHSjVHlVrxoVQXz7quwNFpz7RY1okNNme49+sVyiTvTRobiLV548Hx/hb1BG+iE7h9493WzFw==}
     engines: {node: '>= 6'}
 
+  postgres-date@1.0.7:
+    resolution: {integrity: sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==}
+    engines: {node: '>=0.10.0'}
+
   postgres-date@2.1.0:
     resolution: {integrity: sha512-K7Juri8gtgXVcDfZttFKVmhglp7epKb1K4pgrkLxehjqkrgPhfG6OO8LHLkfaqkbpjNRnra018XwAr1yQFWGcA==}
     engines: {node: '>=12'}
+
+  postgres-interval@1.2.0:
+    resolution: {integrity: sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==}
+    engines: {node: '>=0.10.0'}
 
   postgres-interval@3.0.0:
     resolution: {integrity: sha512-BSNDnbyZCXSxgA+1f5UU2GmwhoI0aU5yMxRGO8CdFEcY2BQF9xm/7MqKnYoM1nJDk8nONNWDk9WeSmePFhQdlw==}
@@ -1946,6 +1989,10 @@ packages:
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
+
+  split2@4.2.0:
+    resolution: {integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==}
+    engines: {node: '>= 10.x'}
 
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
@@ -2227,6 +2274,10 @@ packages:
 
   xmlchars@2.2.0:
     resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
+
+  xtend@4.0.2:
+    resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
+    engines: {node: '>=0.4'}
 
   y18n@4.0.3:
     resolution: {integrity: sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==}
@@ -2814,11 +2865,12 @@ snapshots:
       vite: 6.4.1(@types/node@20.19.37)
       vitest: 4.1.0(@types/node@20.19.37)(jsdom@28.1.0)(msw@2.7.0(@types/node@20.19.37)(typescript@5.9.3))(vite@6.4.1(@types/node@20.19.37))
 
-  '@tummycrypt/tinyland-auth-pg@0.1.1(@tummycrypt/tinyland-auth@0.2.0(@sveltejs/kit@2.55.0(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.54.1)(vite@6.4.1(@types/node@20.19.37)))(svelte@5.54.1)(typescript@5.9.3)(vite@6.4.1(@types/node@20.19.37)))(svelte@5.54.1))(@types/pg@8.11.6)':
+  '@tummycrypt/tinyland-auth-pg@0.2.1(@tummycrypt/tinyland-auth@0.2.0(@sveltejs/kit@2.55.0(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.54.1)(vite@6.4.1(@types/node@20.19.37)))(svelte@5.54.1)(typescript@5.9.3)(vite@6.4.1(@types/node@20.19.37)))(svelte@5.54.1))(@types/pg@8.11.6)':
     dependencies:
       '@neondatabase/serverless': 0.10.4
       '@tummycrypt/tinyland-auth': 0.2.0(@sveltejs/kit@2.55.0(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.54.1)(vite@6.4.1(@types/node@20.19.37)))(svelte@5.54.1)(typescript@5.9.3)(vite@6.4.1(@types/node@20.19.37)))(svelte@5.54.1)
-      drizzle-orm: 0.39.3(@neondatabase/serverless@0.10.4)(@types/pg@8.11.6)
+      drizzle-orm: 0.39.3(@neondatabase/serverless@0.10.4)(@types/pg@8.11.6)(pg@8.20.0)
+      pg: 8.20.0
     transitivePeerDependencies:
       - '@aws-sdk/client-rds-data'
       - '@cloudflare/workers-types'
@@ -2841,7 +2893,7 @@ snapshots:
       - knex
       - kysely
       - mysql2
-      - pg
+      - pg-native
       - postgres
       - prisma
       - sql.js
@@ -3495,10 +3547,11 @@ snapshots:
 
   dotenv@16.6.1: {}
 
-  drizzle-orm@0.39.3(@neondatabase/serverless@0.10.4)(@types/pg@8.11.6):
+  drizzle-orm@0.39.3(@neondatabase/serverless@0.10.4)(@types/pg@8.11.6)(pg@8.20.0):
     optionalDependencies:
       '@neondatabase/serverless': 0.10.4
       '@types/pg': 8.11.6
+      pg: 8.20.0
 
   effect@3.21.0:
     dependencies:
@@ -3970,11 +4023,28 @@ snapshots:
 
   pathe@2.0.3: {}
 
+  pg-cloudflare@1.3.0:
+    optional: true
+
+  pg-connection-string@2.12.0: {}
+
   pg-int8@1.0.1: {}
 
   pg-numeric@1.0.2: {}
 
+  pg-pool@3.13.0(pg@8.20.0):
+    dependencies:
+      pg: 8.20.0
+
   pg-protocol@1.13.0: {}
+
+  pg-types@2.2.0:
+    dependencies:
+      pg-int8: 1.0.1
+      postgres-array: 2.0.0
+      postgres-bytea: 1.0.1
+      postgres-date: 1.0.7
+      postgres-interval: 1.2.0
 
   pg-types@4.1.0:
     dependencies:
@@ -3985,6 +4055,20 @@ snapshots:
       postgres-date: 2.1.0
       postgres-interval: 3.0.0
       postgres-range: 1.1.4
+
+  pg@8.20.0:
+    dependencies:
+      pg-connection-string: 2.12.0
+      pg-pool: 3.13.0(pg@8.20.0)
+      pg-protocol: 1.13.0
+      pg-types: 2.2.0
+      pgpass: 1.0.5
+    optionalDependencies:
+      pg-cloudflare: 1.3.0
+
+  pgpass@1.0.5:
+    dependencies:
+      split2: 4.2.0
 
   picocolors@1.1.1: {}
 
@@ -4018,13 +4102,23 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
+  postgres-array@2.0.0: {}
+
   postgres-array@3.0.4: {}
+
+  postgres-bytea@1.0.1: {}
 
   postgres-bytea@3.0.0:
     dependencies:
       obuf: 1.1.2
 
+  postgres-date@1.0.7: {}
+
   postgres-date@2.1.0: {}
+
+  postgres-interval@1.2.0:
+    dependencies:
+      xtend: 4.0.2
 
   postgres-interval@3.0.0: {}
 
@@ -4155,6 +4249,8 @@ snapshots:
       totalist: 3.0.1
 
   source-map-js@1.2.1: {}
+
+  split2@4.2.0: {}
 
   stackback@0.0.2: {}
 
@@ -4391,6 +4487,8 @@ snapshots:
   xml-name-validator@5.0.0: {}
 
   xmlchars@2.2.0: {}
+
+  xtend@4.0.2: {}
 
   y18n@4.0.3: {}
 

--- a/src/adapters/__tests__/homegrown-adapter.test.ts
+++ b/src/adapters/__tests__/homegrown-adapter.test.ts
@@ -14,31 +14,51 @@
  *   - Provider lookup (solo practice pattern)
  */
 
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { Effect } from 'effect';
-import { createHomegrownAdapter } from '../homegrown.js';
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { Effect } from "effect";
+import { createHomegrownAdapter } from "../homegrown.js";
 
 // ---------------------------------------------------------------------------
 // Mock schemas — minimal shape matching what Drizzle ORM tables expose
 // ---------------------------------------------------------------------------
 
-const mockServicesTable = { id: 'id', name: 'name', active: 'active', displayOrder: 'displayOrder', acuityId: 'acuityId' };
-const mockPractitionersTable = { id: 'id', handle: 'handle', name: 'name' };
-const mockBusinessHoursTable = { dayOfWeek: 'dayOfWeek' };
-const mockBusinessHoursOverridesTable = { date: 'date' };
-const mockBookingsTable = { id: 'id', datetime: 'datetime', endTime: 'endTime', status: 'status', serviceId: 'serviceId', clientId: 'clientId', practitionerId: 'practitionerId' };
-const mockTimeBlocksTable = { startTime: 'startTime', endTime: 'endTime' };
-const mockSlotReservationsTable = { datetime: 'datetime', duration: 'duration', expiresAt: 'expiresAt', releasedAt: 'releasedAt', id: 'id' };
-const mockClientsTable = { id: 'id', email: 'email' };
+const mockServicesTable = {
+  id: "id",
+  name: "name",
+  active: "active",
+  displayOrder: "displayOrder",
+  acuityId: "acuityId",
+};
+const mockPractitionersTable = { id: "id", handle: "handle", name: "name" };
+const mockBusinessHoursTable = { dayOfWeek: "dayOfWeek" };
+const mockBusinessHoursOverridesTable = { date: "date" };
+const mockBookingsTable = {
+  id: "id",
+  datetime: "datetime",
+  endTime: "endTime",
+  status: "status",
+  serviceId: "serviceId",
+  clientId: "clientId",
+  practitionerId: "practitionerId",
+};
+const mockTimeBlocksTable = { startTime: "startTime", endTime: "endTime" };
+const mockSlotReservationsTable = {
+  datetime: "datetime",
+  duration: "duration",
+  expiresAt: "expiresAt",
+  releasedAt: "releasedAt",
+  id: "id",
+};
+const mockClientsTable = { id: "id", email: "email" };
 
 // Mock dynamic imports for schema modules
-vi.mock('@tummycrypt/tinyland-auth-pg/content-schema', () => ({
+vi.mock("@tummycrypt/tinyland-auth-pg/content-schema", () => ({
   services: mockServicesTable,
   practitioners: mockPractitionersTable,
   businessHours: mockBusinessHoursTable,
 }));
 
-vi.mock('@tummycrypt/tinyland-auth-pg/booking-schema', () => ({
+vi.mock("@tummycrypt/tinyland-auth-pg/booking-schema", () => ({
   bookings: mockBookingsTable,
   timeBlocks: mockTimeBlocksTable,
   slotReservations: mockSlotReservationsTable,
@@ -47,16 +67,16 @@ vi.mock('@tummycrypt/tinyland-auth-pg/booking-schema', () => ({
 }));
 
 // Mock drizzle-orm operators — return identity functions for where-clause building
-vi.mock('drizzle-orm', () => ({
-  eq: (col: string, val: unknown) => ({ op: 'eq', col, val }),
-  or: (...args: unknown[]) => ({ op: 'or', args }),
-  and: (...args: unknown[]) => ({ op: 'and', args }),
-  asc: (col: string) => ({ op: 'asc', col }),
-  ne: (col: string, val: unknown) => ({ op: 'ne', col, val }),
-  gte: (col: string, val: unknown) => ({ op: 'gte', col, val }),
-  lte: (col: string, val: unknown) => ({ op: 'lte', col, val }),
-  gt: (col: string, val: unknown) => ({ op: 'gt', col, val }),
-  isNull: (col: string) => ({ op: 'isNull', col }),
+vi.mock("drizzle-orm", () => ({
+  eq: (col: string, val: unknown) => ({ op: "eq", col, val }),
+  or: (...args: unknown[]) => ({ op: "or", args }),
+  and: (...args: unknown[]) => ({ op: "and", args }),
+  asc: (col: string) => ({ op: "asc", col }),
+  ne: (col: string, val: unknown) => ({ op: "ne", col, val }),
+  gte: (col: string, val: unknown) => ({ op: "gte", col, val }),
+  lte: (col: string, val: unknown) => ({ op: "lte", col, val }),
+  gt: (col: string, val: unknown) => ({ op: "gt", col, val }),
+  isNull: (col: string) => ({ op: "isNull", col }),
 }));
 
 // ---------------------------------------------------------------------------
@@ -65,7 +85,13 @@ vi.mock('drizzle-orm', () => ({
 
 type MockRow = Record<string, unknown>;
 
-const createMockDb = (responses: { select?: MockRow[]; insert?: MockRow[]; update?: MockRow[] } = {}) => {
+const createMockDb = (
+  responses: {
+    select?: MockRow[];
+    insert?: MockRow[];
+    update?: MockRow[];
+  } = {},
+) => {
   const selectRows = responses.select ?? [];
   const insertRows = responses.insert ?? [];
 
@@ -138,7 +164,11 @@ const createSequencedMockDb = (
   };
 
   return {
-    select: vi.fn().mockImplementation(() => ({ from: vi.fn().mockImplementation(makeSelectChain) })),
+    select: vi
+      .fn()
+      .mockImplementation(() => ({
+        from: vi.fn().mockImplementation(makeSelectChain),
+      })),
     insert: vi.fn().mockImplementation(makeInsertChain),
     update: vi.fn().mockReturnValue({
       set: vi.fn().mockReturnValue({
@@ -153,90 +183,101 @@ const createSequencedMockDb = (
 // ---------------------------------------------------------------------------
 
 const SERVICE_ROW = {
-  id: 'svc-uuid-1',
-  name: 'Deep Tissue Massage',
-  description: '60-minute therapeutic session',
+  id: "svc-uuid-1",
+  name: "Deep Tissue Massage",
+  description: "60-minute therapeutic session",
   durationMinutes: 60,
   priceCents: 9500,
-  currency: 'USD',
-  category: 'therapeutic',
+  currency: "USD",
+  category: "therapeutic",
   active: true,
   displayOrder: 1,
-  acuityId: '12345',
+  acuityId: "12345",
 };
 
 const PRACTITIONER_ROW = {
-  id: 'prac-uuid-1',
-  handle: 'jen',
-  name: 'Jen Sullivan',
-  title: 'Licensed Massage Therapist',
-  photoUrl: 'https://example.com/jen.jpg',
+  id: "prac-uuid-1",
+  handle: "jen",
+  name: "Jen Sullivan",
+  title: "Licensed Massage Therapist",
+  photoUrl: "https://example.com/jen.jpg",
 };
 
 const CLIENT_ROW = {
-  id: 'client-uuid-1',
-  firstName: 'Alice',
-  lastName: 'Smith',
-  email: 'alice@example.com',
-  phone: '607-555-1234',
+  id: "client-uuid-1",
+  firstName: "Alice",
+  lastName: "Smith",
+  email: "alice@example.com",
+  phone: "607-555-1234",
   notes: null,
-  createdAt: '2026-04-10T12:00:00Z',
-  updatedAt: '2026-04-10T12:00:00Z',
+  createdAt: "2026-04-10T12:00:00Z",
+  updatedAt: "2026-04-10T12:00:00Z",
 };
 
 const BOOKING_ROW = {
-  id: 'booking-uuid-1',
-  confirmationCode: 'ABC123',
-  serviceId: 'svc-uuid-1',
-  practitionerId: 'prac-uuid-1',
-  clientId: 'client-uuid-1',
-  datetime: '2026-04-20T14:00:00.000Z',
-  endTime: '2026-04-20T15:00:00.000Z',
+  id: "booking-uuid-1",
+  confirmationCode: "ABC123",
+  serviceId: "svc-uuid-1",
+  practitionerId: "prac-uuid-1",
+  clientId: "client-uuid-1",
+  datetime: "2026-04-20T14:00:00.000Z",
+  endTime: "2026-04-20T15:00:00.000Z",
   duration: 60,
-  status: 'confirmed',
-  paymentStatus: 'pending',
+  status: "confirmed",
+  paymentStatus: "pending",
   paymentMethod: null,
   amountCents: 9500,
   paymentRef: null,
-  createdAt: '2026-04-18T10:00:00.000Z',
+  createdAt: "2026-04-18T10:00:00.000Z",
   cancelledAt: null,
   cancelReason: null,
   updatedAt: null,
 };
 
 const RESERVATION_ROW = {
-  id: 'res-uuid-1',
-  datetime: '2026-04-20T14:00:00.000Z',
+  id: "res-uuid-1",
+  datetime: "2026-04-20T14:00:00.000Z",
   duration: 60,
-  expiresAt: '2026-04-20T14:10:00.000Z',
+  expiresAt: "2026-04-20T14:10:00.000Z",
 };
 
-const TEST_CLIENT: { firstName: string; lastName: string; email: string; phone: string } = {
-  firstName: 'Alice',
-  lastName: 'Smith',
-  email: 'alice@example.com',
-  phone: '607-555-1234',
+const TEST_CLIENT: {
+  firstName: string;
+  lastName: string;
+  email: string;
+  phone: string;
+} = {
+  firstName: "Alice",
+  lastName: "Smith",
+  email: "alice@example.com",
+  phone: "607-555-1234",
 };
 
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
 
-describe('HomegrownAdapter', () => {
-  describe('creation and configuration', () => {
+describe("HomegrownAdapter", () => {
+  describe("creation and configuration", () => {
     it('creates an adapter with name "homegrown"', () => {
       const adapter = createHomegrownAdapter({ getDb: async () => ({}) });
-      expect(adapter.name).toBe('homegrown');
+      expect(adapter.name).toBe("homegrown");
     });
 
-    it('creates an adapter with a scoped database executor only', () => {
+    it("creates an adapter with a scoped database executor only", () => {
       const adapter = createHomegrownAdapter({
         withDb: async (fn) => fn({}),
       });
-      expect(adapter.name).toBe('homegrown');
+      expect(adapter.name).toBe("homegrown");
     });
 
-    it('uses scoped database executor when provided', async () => {
+    it("throws immediately when no database accessor is configured", () => {
+      expect(() => createHomegrownAdapter({})).toThrow(
+        "HomegrownAdapter requires either getDb or withDb",
+      );
+    });
+
+    it("uses scoped database executor when provided", async () => {
       const mockDb = createMockDb();
       mockDb._terminals.orderBy.mockResolvedValue([SERVICE_ROW]);
       const getDb = vi.fn(async () => mockDb);
@@ -250,32 +291,42 @@ describe('HomegrownAdapter', () => {
       expect(getDb).not.toHaveBeenCalled();
     });
 
-    it('exposes all 16+1 SchedulingAdapter methods', () => {
+    it("exposes all 16+1 SchedulingAdapter methods", () => {
       const adapter = createHomegrownAdapter({ getDb: async () => ({}) });
       const methods = [
-        'getServices', 'getService',
-        'getProviders', 'getProvider', 'getProvidersForService',
-        'getAvailableDates', 'getAvailableSlots', 'checkSlotAvailability',
-        'createReservation', 'releaseReservation',
-        'createBooking', 'createBookingWithPaymentRef', 'getBooking',
-        'cancelBooking', 'rescheduleBooking',
-        'findOrCreateClient', 'getClientByEmail',
+        "getServices",
+        "getService",
+        "getProviders",
+        "getProvider",
+        "getProvidersForService",
+        "getAvailableDates",
+        "getAvailableSlots",
+        "checkSlotAvailability",
+        "createReservation",
+        "releaseReservation",
+        "createBooking",
+        "createBookingWithPaymentRef",
+        "getBooking",
+        "cancelBooking",
+        "rescheduleBooking",
+        "findOrCreateClient",
+        "getClientByEmail",
       ];
       for (const m of methods) {
-        expect(typeof (adapter as any)[m]).toBe('function');
+        expect(typeof (adapter as any)[m]).toBe("function");
       }
     });
 
-    it('accepts custom configuration', () => {
+    it("accepts custom configuration", () => {
       const adapter = createHomegrownAdapter({
         getDb: async () => ({}),
-        timezone: 'America/Chicago',
+        timezone: "America/Chicago",
         slotInterval: 15,
         bufferMinutes: 10,
         minAdvanceHours: 4,
-        defaultPractitionerHandle: 'jess',
+        defaultPractitionerHandle: "jess",
       });
-      expect(adapter.name).toBe('homegrown');
+      expect(adapter.name).toBe("homegrown");
     });
   });
 
@@ -283,8 +334,8 @@ describe('HomegrownAdapter', () => {
   // Services
   // -------------------------------------------------------------------------
 
-  describe('getServices', () => {
-    it('returns active services mapped to Service domain type', async () => {
+  describe("getServices", () => {
+    it("returns active services mapped to Service domain type", async () => {
       const mockDb = createMockDb();
       // orderBy terminal returns the service rows
       mockDb._terminals.orderBy.mockResolvedValue([SERVICE_ROW]);
@@ -292,19 +343,21 @@ describe('HomegrownAdapter', () => {
       const adapter = createHomegrownAdapter({ getDb: async () => mockDb });
       const result = await Effect.runPromise(adapter.getServices());
 
-      expect(result).toEqual([{
-        id: 'svc-uuid-1',
-        name: 'Deep Tissue Massage',
-        description: '60-minute therapeutic session',
-        duration: 60,
-        price: 9500,
-        currency: 'USD',
-        category: 'therapeutic',
-        active: true,
-      }]);
+      expect(result).toEqual([
+        {
+          id: "svc-uuid-1",
+          name: "Deep Tissue Massage",
+          description: "60-minute therapeutic session",
+          duration: 60,
+          price: 9500,
+          currency: "USD",
+          category: "therapeutic",
+          active: true,
+        },
+      ]);
     });
 
-    it('returns empty array when no active services exist', async () => {
+    it("returns empty array when no active services exist", async () => {
       const mockDb = createMockDb();
       mockDb._terminals.orderBy.mockResolvedValue([]);
 
@@ -314,7 +367,7 @@ describe('HomegrownAdapter', () => {
       expect(result).toEqual([]);
     });
 
-    it('maps null description to undefined', async () => {
+    it("maps null description to undefined", async () => {
       const mockDb = createMockDb();
       mockDb._terminals.orderBy.mockResolvedValue([
         { ...SERVICE_ROW, description: null, category: null },
@@ -327,57 +380,59 @@ describe('HomegrownAdapter', () => {
       expect(result[0].category).toBeUndefined();
     });
 
-    it('surfaces DB errors as InfrastructureError via Effect', async () => {
+    it("surfaces DB errors as InfrastructureError via Effect", async () => {
       const mockDb = createMockDb();
       mockDb.select.mockReturnValue({
         from: vi.fn().mockReturnValue({
           where: vi.fn().mockReturnValue({
-            orderBy: vi.fn().mockRejectedValue(new Error('connection refused')),
-            limit: vi.fn().mockRejectedValue(new Error('connection refused')),
+            orderBy: vi.fn().mockRejectedValue(new Error("connection refused")),
+            limit: vi.fn().mockRejectedValue(new Error("connection refused")),
           }),
-          orderBy: vi.fn().mockRejectedValue(new Error('connection refused')),
+          orderBy: vi.fn().mockRejectedValue(new Error("connection refused")),
         }),
       });
 
       const adapter = createHomegrownAdapter({ getDb: async () => mockDb });
       const result = await Effect.runPromiseExit(adapter.getServices());
 
-      expect(result._tag).toBe('Failure');
+      expect(result._tag).toBe("Failure");
     });
   });
 
-  describe('getService', () => {
-    it('resolves service by UUID', async () => {
+  describe("getService", () => {
+    it("resolves service by UUID", async () => {
       const mockDb = createMockDb({ select: [SERVICE_ROW] });
       const adapter = createHomegrownAdapter({ getDb: async () => mockDb });
 
       const result = await Effect.runPromise(
-        adapter.getService('a1b2c3d4-e5f6-7890-abcd-ef1234567890'),
+        adapter.getService("a1b2c3d4-e5f6-7890-abcd-ef1234567890"),
       );
 
-      expect(result.id).toBe('svc-uuid-1');
-      expect(result.name).toBe('Deep Tissue Massage');
+      expect(result.id).toBe("svc-uuid-1");
+      expect(result.name).toBe("Deep Tissue Massage");
       expect(result.duration).toBe(60);
       expect(result.price).toBe(9500);
     });
 
-    it('resolves service by acuityId (non-UUID string)', async () => {
+    it("resolves service by acuityId (non-UUID string)", async () => {
       const mockDb = createMockDb({ select: [SERVICE_ROW] });
       const adapter = createHomegrownAdapter({ getDb: async () => mockDb });
 
-      const result = await Effect.runPromise(adapter.getService('12345'));
+      const result = await Effect.runPromise(adapter.getService("12345"));
 
-      expect(result.id).toBe('svc-uuid-1');
+      expect(result.id).toBe("svc-uuid-1");
     });
 
-    it('fails when service not found', async () => {
+    it("fails when service not found", async () => {
       const mockDb = createMockDb({ select: [] });
       mockDb._terminals.limit.mockResolvedValue([]);
 
       const adapter = createHomegrownAdapter({ getDb: async () => mockDb });
-      const result = await Effect.runPromiseExit(adapter.getService('nonexistent'));
+      const result = await Effect.runPromiseExit(
+        adapter.getService("nonexistent"),
+      );
 
-      expect(result._tag).toBe('Failure');
+      expect(result._tag).toBe("Failure");
     });
   });
 
@@ -385,8 +440,8 @@ describe('HomegrownAdapter', () => {
   // Providers
   // -------------------------------------------------------------------------
 
-  describe('getProviders', () => {
-    it('returns the default practitioner as a Provider', async () => {
+  describe("getProviders", () => {
+    it("returns the default practitioner as a Provider", async () => {
       const mockDb = createMockDb({ select: [PRACTITIONER_ROW] });
       const adapter = createHomegrownAdapter({ getDb: async () => mockDb });
 
@@ -394,16 +449,16 @@ describe('HomegrownAdapter', () => {
 
       expect(result).toHaveLength(1);
       expect(result[0]).toEqual({
-        id: 'prac-uuid-1',
-        name: 'Jen Sullivan',
+        id: "prac-uuid-1",
+        name: "Jen Sullivan",
         email: undefined,
-        description: 'Licensed Massage Therapist',
-        image: 'https://example.com/jen.jpg',
-        timezone: 'America/New_York',
+        description: "Licensed Massage Therapist",
+        image: "https://example.com/jen.jpg",
+        timezone: "America/New_York",
       });
     });
 
-    it('returns empty array when no practitioner found', async () => {
+    it("returns empty array when no practitioner found", async () => {
       const mockDb = createMockDb({ select: [] });
       mockDb._terminals.limit.mockResolvedValue([]);
 
@@ -413,49 +468,55 @@ describe('HomegrownAdapter', () => {
       expect(result).toEqual([]);
     });
 
-    it('uses custom timezone from config', async () => {
+    it("uses custom timezone from config", async () => {
       const mockDb = createMockDb({ select: [PRACTITIONER_ROW] });
       const adapter = createHomegrownAdapter({
         getDb: async () => mockDb,
-        timezone: 'America/Chicago',
+        timezone: "America/Chicago",
       });
 
       const result = await Effect.runPromise(adapter.getProviders());
-      expect(result[0].timezone).toBe('America/Chicago');
+      expect(result[0].timezone).toBe("America/Chicago");
     });
   });
 
-  describe('getProvider', () => {
-    it('returns a specific provider by ID', async () => {
+  describe("getProvider", () => {
+    it("returns a specific provider by ID", async () => {
       const mockDb = createMockDb({ select: [PRACTITIONER_ROW] });
       const adapter = createHomegrownAdapter({ getDb: async () => mockDb });
 
-      const result = await Effect.runPromise(adapter.getProvider('prac-uuid-1'));
+      const result = await Effect.runPromise(
+        adapter.getProvider("prac-uuid-1"),
+      );
 
-      expect(result.id).toBe('prac-uuid-1');
-      expect(result.name).toBe('Jen Sullivan');
+      expect(result.id).toBe("prac-uuid-1");
+      expect(result.name).toBe("Jen Sullivan");
     });
 
-    it('fails when provider not found', async () => {
+    it("fails when provider not found", async () => {
       const mockDb = createMockDb({ select: [] });
       mockDb._terminals.limit.mockResolvedValue([]);
 
       const adapter = createHomegrownAdapter({ getDb: async () => mockDb });
-      const result = await Effect.runPromiseExit(adapter.getProvider('nonexistent'));
+      const result = await Effect.runPromiseExit(
+        adapter.getProvider("nonexistent"),
+      );
 
-      expect(result._tag).toBe('Failure');
+      expect(result._tag).toBe("Failure");
     });
   });
 
-  describe('getProvidersForService', () => {
-    it('delegates to getProviders (solo practice)', async () => {
+  describe("getProvidersForService", () => {
+    it("delegates to getProviders (solo practice)", async () => {
       const mockDb = createMockDb({ select: [PRACTITIONER_ROW] });
       const adapter = createHomegrownAdapter({ getDb: async () => mockDb });
 
-      const result = await Effect.runPromise(adapter.getProvidersForService('any-service'));
+      const result = await Effect.runPromise(
+        adapter.getProvidersForService("any-service"),
+      );
 
       expect(result).toHaveLength(1);
-      expect(result[0].id).toBe('prac-uuid-1');
+      expect(result[0].id).toBe("prac-uuid-1");
     });
   });
 
@@ -463,52 +524,56 @@ describe('HomegrownAdapter', () => {
   // Reservations
   // -------------------------------------------------------------------------
 
-  describe('createReservation', () => {
-    it('inserts a reservation and returns SlotReservation', async () => {
+  describe("createReservation", () => {
+    it("inserts a reservation and returns SlotReservation", async () => {
       const mockDb = createMockDb({ insert: [RESERVATION_ROW] });
       const adapter = createHomegrownAdapter({ getDb: async () => mockDb });
 
-      const result = await Effect.runPromise(adapter.createReservation({
-        serviceId: 'svc-uuid-1',
-        providerId: 'prac-uuid-1',
-        datetime: '2026-04-20T14:00:00.000Z',
-        duration: 60,
-        expirationMinutes: 10,
-      }));
+      const result = await Effect.runPromise(
+        adapter.createReservation({
+          serviceId: "svc-uuid-1",
+          providerId: "prac-uuid-1",
+          datetime: "2026-04-20T14:00:00.000Z",
+          duration: 60,
+          expirationMinutes: 10,
+        }),
+      );
 
       expect(result).toEqual({
-        id: 'res-uuid-1',
-        datetime: '2026-04-20T14:00:00.000Z',
+        id: "res-uuid-1",
+        datetime: "2026-04-20T14:00:00.000Z",
         duration: 60,
-        expiresAt: '2026-04-20T14:10:00.000Z',
-        providerId: 'prac-uuid-1',
+        expiresAt: "2026-04-20T14:10:00.000Z",
+        providerId: "prac-uuid-1",
       });
     });
 
-    it('defaults expiration to 10 minutes when not specified', async () => {
+    it("defaults expiration to 10 minutes when not specified", async () => {
       const mockDb = createMockDb({ insert: [RESERVATION_ROW] });
       const adapter = createHomegrownAdapter({ getDb: async () => mockDb });
 
       // The adapter calculates expiresAt internally — we just verify the
       // insert goes through and returns the DB row
-      const result = await Effect.runPromise(adapter.createReservation({
-        serviceId: 'svc-uuid-1',
-        datetime: '2026-04-20T14:00:00.000Z',
-        duration: 60,
-      }));
+      const result = await Effect.runPromise(
+        adapter.createReservation({
+          serviceId: "svc-uuid-1",
+          datetime: "2026-04-20T14:00:00.000Z",
+          duration: 60,
+        }),
+      );
 
-      expect(result.id).toBe('res-uuid-1');
+      expect(result.id).toBe("res-uuid-1");
     });
   });
 
-  describe('releaseReservation', () => {
-    it('sets releasedAt on the reservation', async () => {
+  describe("releaseReservation", () => {
+    it("sets releasedAt on the reservation", async () => {
       const mockDb = createMockDb();
       const adapter = createHomegrownAdapter({ getDb: async () => mockDb });
 
       // releaseReservation returns void — just ensure no throw
       await expect(
-        Effect.runPromise(adapter.releaseReservation('res-uuid-1')),
+        Effect.runPromise(adapter.releaseReservation("res-uuid-1")),
       ).resolves.toBeUndefined();
 
       expect(mockDb.update).toHaveBeenCalled();
@@ -519,8 +584,8 @@ describe('HomegrownAdapter', () => {
   // Clients
   // -------------------------------------------------------------------------
 
-  describe('findOrCreateClient', () => {
-    it('returns existing client with isNew=false and updates info', async () => {
+  describe("findOrCreateClient", () => {
+    it("returns existing client with isNew=false and updates info", async () => {
       const mockDb = createMockDb({ select: [CLIENT_ROW] });
       const adapter = createHomegrownAdapter({ getDb: async () => mockDb });
 
@@ -528,17 +593,19 @@ describe('HomegrownAdapter', () => {
         adapter.findOrCreateClient(TEST_CLIENT),
       );
 
-      expect(result).toEqual({ id: 'client-uuid-1', isNew: false });
+      expect(result).toEqual({ id: "client-uuid-1", isNew: false });
       // Should have called update to refresh name/phone
       expect(mockDb.update).toHaveBeenCalled();
     });
 
-    it('creates new client when email not found', async () => {
+    it("creates new client when email not found", async () => {
       const mockDb = createMockDb();
       // First select (find by email) returns empty
       mockDb._terminals.limit.mockResolvedValue([]);
       // Insert returns new row
-      mockDb._terminals.returning.mockResolvedValue([{ id: 'client-uuid-new' }]);
+      mockDb._terminals.returning.mockResolvedValue([
+        { id: "client-uuid-new" },
+      ]);
 
       const adapter = createHomegrownAdapter({ getDb: async () => mockDb });
 
@@ -546,50 +613,50 @@ describe('HomegrownAdapter', () => {
         adapter.findOrCreateClient(TEST_CLIENT),
       );
 
-      expect(result).toEqual({ id: 'client-uuid-new', isNew: true });
+      expect(result).toEqual({ id: "client-uuid-new", isNew: true });
       expect(mockDb.insert).toHaveBeenCalled();
     });
   });
 
-  describe('getClientByEmail', () => {
-    it('returns ClientInfo when client exists', async () => {
+  describe("getClientByEmail", () => {
+    it("returns ClientInfo when client exists", async () => {
       const mockDb = createMockDb({ select: [CLIENT_ROW] });
       const adapter = createHomegrownAdapter({ getDb: async () => mockDb });
 
       const result = await Effect.runPromise(
-        adapter.getClientByEmail('alice@example.com'),
+        adapter.getClientByEmail("alice@example.com"),
       );
 
       expect(result).toEqual({
-        firstName: 'Alice',
-        lastName: 'Smith',
-        email: 'alice@example.com',
-        phone: '607-555-1234',
+        firstName: "Alice",
+        lastName: "Smith",
+        email: "alice@example.com",
+        phone: "607-555-1234",
         notes: undefined,
       });
     });
 
-    it('returns null when client not found', async () => {
+    it("returns null when client not found", async () => {
       const mockDb = createMockDb({ select: [] });
       mockDb._terminals.limit.mockResolvedValue([]);
 
       const adapter = createHomegrownAdapter({ getDb: async () => mockDb });
 
       const result = await Effect.runPromise(
-        adapter.getClientByEmail('nobody@example.com'),
+        adapter.getClientByEmail("nobody@example.com"),
       );
 
       expect(result).toBeNull();
     });
 
-    it('maps null phone/notes to undefined', async () => {
+    it("maps null phone/notes to undefined", async () => {
       const mockDb = createMockDb({
         select: [{ ...CLIENT_ROW, phone: null, notes: null }],
       });
       const adapter = createHomegrownAdapter({ getDb: async () => mockDb });
 
       const result = await Effect.runPromise(
-        adapter.getClientByEmail('alice@example.com'),
+        adapter.getClientByEmail("alice@example.com"),
       );
 
       expect(result?.phone).toBeUndefined();
@@ -601,24 +668,26 @@ describe('HomegrownAdapter', () => {
   // Bookings
   // -------------------------------------------------------------------------
 
-  describe('cancelBooking', () => {
-    it('sets status to cancelled', async () => {
+  describe("cancelBooking", () => {
+    it("sets status to cancelled", async () => {
       const mockDb = createMockDb();
       const adapter = createHomegrownAdapter({ getDb: async () => mockDb });
 
       await expect(
-        Effect.runPromise(adapter.cancelBooking('booking-uuid-1', 'schedule conflict')),
+        Effect.runPromise(
+          adapter.cancelBooking("booking-uuid-1", "schedule conflict"),
+        ),
       ).resolves.toBeUndefined();
 
       expect(mockDb.update).toHaveBeenCalled();
     });
 
-    it('works without a reason', async () => {
+    it("works without a reason", async () => {
       const mockDb = createMockDb();
       const adapter = createHomegrownAdapter({ getDb: async () => mockDb });
 
       await expect(
-        Effect.runPromise(adapter.cancelBooking('booking-uuid-1')),
+        Effect.runPromise(adapter.cancelBooking("booking-uuid-1")),
       ).resolves.toBeUndefined();
     });
   });
@@ -627,8 +696,8 @@ describe('HomegrownAdapter', () => {
   // Bookings — multi-step (sequenced mock)
   // -------------------------------------------------------------------------
 
-  describe('createBooking', () => {
-    it('resolves service, finds client, gets practitioner, inserts booking', async () => {
+  describe("createBooking", () => {
+    it("resolves service, finds client, gets practitioner, inserts booking", async () => {
       // createBooking internally calls:
       //   1. resolveService (select)
       //   2. findOrCreateClient → find by email (select) → update if exists
@@ -636,137 +705,155 @@ describe('HomegrownAdapter', () => {
       //   4. insert booking
       const mockDb = createSequencedMockDb(
         [
-          [SERVICE_ROW],       // resolveService
-          [CLIENT_ROW],        // findOrCreateClient email lookup
-          [PRACTITIONER_ROW],  // getDefaultPractitioner
+          [SERVICE_ROW], // resolveService
+          [CLIENT_ROW], // findOrCreateClient email lookup
+          [PRACTITIONER_ROW], // getDefaultPractitioner
         ],
         [
-          [BOOKING_ROW],       // insert booking
+          [BOOKING_ROW], // insert booking
         ],
       );
 
       const adapter = createHomegrownAdapter({ getDb: async () => mockDb });
-      const result = await Effect.runPromise(adapter.createBooking({
-        serviceId: 'svc-uuid-1',
-        datetime: '2026-04-20T14:00:00.000Z',
-        client: TEST_CLIENT,
-        idempotencyKey: 'idem-001',
-      }));
+      const result = await Effect.runPromise(
+        adapter.createBooking({
+          serviceId: "svc-uuid-1",
+          datetime: "2026-04-20T14:00:00.000Z",
+          client: TEST_CLIENT,
+          idempotencyKey: "idem-001",
+        }),
+      );
 
-      expect(result.id).toBe('booking-uuid-1');
-      expect(result.serviceId).toBe('svc-uuid-1');
-      expect(result.serviceName).toBe('Deep Tissue Massage');
-      expect(result.confirmationCode).toBe('ABC123');
-      expect(result.status).toBe('confirmed');
-      expect(result.paymentStatus).toBe('pending');
+      expect(result.id).toBe("booking-uuid-1");
+      expect(result.serviceId).toBe("svc-uuid-1");
+      expect(result.serviceName).toBe("Deep Tissue Massage");
+      expect(result.confirmationCode).toBe("ABC123");
+      expect(result.status).toBe("confirmed");
+      expect(result.paymentStatus).toBe("pending");
       expect(result.client).toEqual(TEST_CLIENT);
     });
 
-    it('fails when service not found during booking', async () => {
+    it("fails when service not found during booking", async () => {
       const mockDb = createSequencedMockDb([
-        [],  // resolveService returns empty
+        [], // resolveService returns empty
       ]);
 
       const adapter = createHomegrownAdapter({ getDb: async () => mockDb });
-      const exit = await Effect.runPromiseExit(adapter.createBooking({
-        serviceId: 'nonexistent',
-        datetime: '2026-04-20T14:00:00.000Z',
-        client: TEST_CLIENT,
-        idempotencyKey: 'idem-002',
-      }));
+      const exit = await Effect.runPromiseExit(
+        adapter.createBooking({
+          serviceId: "nonexistent",
+          datetime: "2026-04-20T14:00:00.000Z",
+          client: TEST_CLIENT,
+          idempotencyKey: "idem-002",
+        }),
+      );
 
-      expect(exit._tag).toBe('Failure');
+      expect(exit._tag).toBe("Failure");
     });
 
-    it('creates new client when email not found during booking', async () => {
+    it("creates new client when email not found during booking", async () => {
       const mockDb = createSequencedMockDb(
         [
-          [SERVICE_ROW],       // resolveService
-          [],                  // findOrCreateClient: email not found
-          [PRACTITIONER_ROW],  // getDefaultPractitioner
+          [SERVICE_ROW], // resolveService
+          [], // findOrCreateClient: email not found
+          [PRACTITIONER_ROW], // getDefaultPractitioner
         ],
         [
-          [{ id: 'client-uuid-new' }],  // insert client
-          [BOOKING_ROW],                 // insert booking
+          [{ id: "client-uuid-new" }], // insert client
+          [BOOKING_ROW], // insert booking
         ],
       );
 
       const adapter = createHomegrownAdapter({ getDb: async () => mockDb });
-      const result = await Effect.runPromise(adapter.createBooking({
-        serviceId: 'svc-uuid-1',
-        datetime: '2026-04-20T14:00:00.000Z',
-        client: TEST_CLIENT,
-        idempotencyKey: 'idem-003',
-      }));
+      const result = await Effect.runPromise(
+        adapter.createBooking({
+          serviceId: "svc-uuid-1",
+          datetime: "2026-04-20T14:00:00.000Z",
+          client: TEST_CLIENT,
+          idempotencyKey: "idem-003",
+        }),
+      );
 
-      expect(result.id).toBe('booking-uuid-1');
+      expect(result.id).toBe("booking-uuid-1");
     });
   });
 
-  describe('getBooking', () => {
-    it('joins booking, service, client, and practitioner data', async () => {
+  describe("getBooking", () => {
+    it("joins booking, service, client, and practitioner data", async () => {
       // getBooking does 4 sequential selects:
       //   1. booking by ID
       //   2. service by booking.serviceId
       //   3. client by booking.clientId
       //   4. practitioner by booking.practitionerId (conditional)
       const mockDb = createSequencedMockDb([
-        [BOOKING_ROW],        // booking
-        [SERVICE_ROW],        // service
-        [CLIENT_ROW],         // client
-        [PRACTITIONER_ROW],   // practitioner
+        [BOOKING_ROW], // booking
+        [SERVICE_ROW], // service
+        [CLIENT_ROW], // client
+        [PRACTITIONER_ROW], // practitioner
       ]);
 
       const adapter = createHomegrownAdapter({ getDb: async () => mockDb });
-      const result = await Effect.runPromise(adapter.getBooking('booking-uuid-1'));
+      const result = await Effect.runPromise(
+        adapter.getBooking("booking-uuid-1"),
+      );
 
-      expect(result.id).toBe('booking-uuid-1');
-      expect(result.serviceName).toBe('Deep Tissue Massage');
-      expect(result.providerName).toBe('Jen Sullivan');
-      expect(result.client.firstName).toBe('Alice');
-      expect(result.client.email).toBe('alice@example.com');
+      expect(result.id).toBe("booking-uuid-1");
+      expect(result.serviceName).toBe("Deep Tissue Massage");
+      expect(result.providerName).toBe("Jen Sullivan");
+      expect(result.client.firstName).toBe("Alice");
+      expect(result.client.email).toBe("alice@example.com");
       expect(result.duration).toBe(60);
       expect(result.price).toBe(9500);
-      expect(result.currency).toBe('USD');
+      expect(result.currency).toBe("USD");
     });
 
-    it('fails when booking not found', async () => {
+    it("fails when booking not found", async () => {
       const mockDb = createSequencedMockDb([
-        [],  // booking not found
+        [], // booking not found
       ]);
 
       const adapter = createHomegrownAdapter({ getDb: async () => mockDb });
-      const exit = await Effect.runPromiseExit(adapter.getBooking('nonexistent'));
+      const exit = await Effect.runPromiseExit(
+        adapter.getBooking("nonexistent"),
+      );
 
-      expect(exit._tag).toBe('Failure');
+      expect(exit._tag).toBe("Failure");
     });
 
-    it('handles missing service gracefully', async () => {
+    it("handles missing service gracefully", async () => {
       const mockDb = createSequencedMockDb([
-        [BOOKING_ROW],  // booking exists
-        [],              // service not found
-        [CLIENT_ROW],   // client
+        [BOOKING_ROW], // booking exists
+        [], // service not found
+        [CLIENT_ROW], // client
       ]);
 
       const adapter = createHomegrownAdapter({ getDb: async () => mockDb });
-      const result = await Effect.runPromise(adapter.getBooking('booking-uuid-1'));
+      const result = await Effect.runPromise(
+        adapter.getBooking("booking-uuid-1"),
+      );
 
       // Falls back to 'Unknown' for service name, 'USD' for currency
-      expect(result.serviceName).toBe('Unknown');
-      expect(result.currency).toBe('USD');
+      expect(result.serviceName).toBe("Unknown");
+      expect(result.currency).toBe("USD");
     });
   });
 
-  describe('rescheduleBooking', () => {
-    it('updates datetime and returns refreshed booking', async () => {
+  describe("rescheduleBooking", () => {
+    it("updates datetime and returns refreshed booking", async () => {
       // rescheduleBooking:
       //   1. select existing booking
       //   2. update with new datetime/endTime
       //   3. calls getBooking internally (4 more selects)
       const mockDb = createSequencedMockDb([
-        [BOOKING_ROW],        // 1. select existing
+        [BOOKING_ROW], // 1. select existing
         // getBooking selects (called via adapter.getBooking):
-        [{ ...BOOKING_ROW, datetime: '2026-04-21T10:00:00.000Z', endTime: '2026-04-21T11:00:00.000Z' }],
+        [
+          {
+            ...BOOKING_ROW,
+            datetime: "2026-04-21T10:00:00.000Z",
+            endTime: "2026-04-21T11:00:00.000Z",
+          },
+        ],
         [SERVICE_ROW],
         [CLIENT_ROW],
         [PRACTITIONER_ROW],
@@ -774,24 +861,49 @@ describe('HomegrownAdapter', () => {
 
       const adapter = createHomegrownAdapter({ getDb: async () => mockDb });
       const result = await Effect.runPromise(
-        adapter.rescheduleBooking('booking-uuid-1', '2026-04-21T10:00:00.000Z'),
+        adapter.rescheduleBooking("booking-uuid-1", "2026-04-21T10:00:00.000Z"),
       );
 
-      expect(result.id).toBe('booking-uuid-1');
-      expect(result.datetime).toBe('2026-04-21T10:00:00.000Z');
+      expect(result.id).toBe("booking-uuid-1");
+      expect(result.datetime).toBe("2026-04-21T10:00:00.000Z");
     });
 
-    it('fails when booking not found', async () => {
+    it("fails when booking not found", async () => {
       const mockDb = createSequencedMockDb([
-        [],  // existing booking not found
+        [], // existing booking not found
       ]);
 
       const adapter = createHomegrownAdapter({ getDb: async () => mockDb });
       const exit = await Effect.runPromiseExit(
-        adapter.rescheduleBooking('nonexistent', '2026-04-21T10:00:00.000Z'),
+        adapter.rescheduleBooking("nonexistent", "2026-04-21T10:00:00.000Z"),
       );
 
-      expect(exit._tag).toBe('Failure');
+      expect(exit._tag).toBe("Failure");
+    });
+
+    it("keeps read, update, and refreshed fetch in one scoped executor call", async () => {
+      const mockDb = createSequencedMockDb([
+        [BOOKING_ROW],
+        [
+          {
+            ...BOOKING_ROW,
+            datetime: "2026-04-21T10:00:00.000Z",
+            endTime: "2026-04-21T11:00:00.000Z",
+          },
+        ],
+        [SERVICE_ROW],
+        [CLIENT_ROW],
+        [PRACTITIONER_ROW],
+      ]);
+      const withDb = vi.fn(async (fn) => fn(mockDb));
+
+      const adapter = createHomegrownAdapter({ withDb });
+      const result = await Effect.runPromise(
+        adapter.rescheduleBooking("booking-uuid-1", "2026-04-21T10:00:00.000Z"),
+      );
+
+      expect(result.datetime).toBe("2026-04-21T10:00:00.000Z");
+      expect(withDb).toHaveBeenCalledOnce();
     });
   });
 
@@ -799,23 +911,27 @@ describe('HomegrownAdapter', () => {
   // Effect error wrapping
   // -------------------------------------------------------------------------
 
-  describe('Effect error wrapping', () => {
-    it('wraps DB connection errors as InfrastructureError', async () => {
+  describe("Effect error wrapping", () => {
+    it("wraps DB connection errors as InfrastructureError", async () => {
       const adapter = createHomegrownAdapter({
-        getDb: async () => { throw new Error('ECONNREFUSED'); },
+        getDb: async () => {
+          throw new Error("ECONNREFUSED");
+        },
       });
 
       const exit = await Effect.runPromiseExit(adapter.getServices());
-      expect(exit._tag).toBe('Failure');
+      expect(exit._tag).toBe("Failure");
     });
 
-    it('wraps non-Error throws as InfrastructureError with UNKNOWN code', async () => {
+    it("wraps non-Error throws as InfrastructureError with UNKNOWN code", async () => {
       const adapter = createHomegrownAdapter({
-        getDb: async () => { throw 'string error'; },
+        getDb: async () => {
+          throw "string error";
+        },
       });
 
       const exit = await Effect.runPromiseExit(adapter.getServices());
-      expect(exit._tag).toBe('Failure');
+      expect(exit._tag).toBe("Failure");
     });
   });
 });

--- a/src/adapters/__tests__/homegrown-adapter.test.ts
+++ b/src/adapters/__tests__/homegrown-adapter.test.ts
@@ -229,6 +229,27 @@ describe('HomegrownAdapter', () => {
       expect(adapter.name).toBe('homegrown');
     });
 
+    it('creates an adapter with a scoped database executor only', () => {
+      const adapter = createHomegrownAdapter({
+        withDb: async (fn) => fn({}),
+      });
+      expect(adapter.name).toBe('homegrown');
+    });
+
+    it('uses scoped database executor when provided', async () => {
+      const mockDb = createMockDb();
+      mockDb._terminals.orderBy.mockResolvedValue([SERVICE_ROW]);
+      const getDb = vi.fn(async () => mockDb);
+      const withDb = vi.fn(async (fn) => fn(mockDb));
+
+      const adapter = createHomegrownAdapter({ getDb, withDb });
+      const result = await Effect.runPromise(adapter.getServices());
+
+      expect(result).toHaveLength(1);
+      expect(withDb).toHaveBeenCalledOnce();
+      expect(getDb).not.toHaveBeenCalled();
+    });
+
     it('exposes all 16+1 SchedulingAdapter methods', () => {
       const adapter = createHomegrownAdapter({ getDb: async () => ({}) });
       const methods = [

--- a/src/adapters/homegrown.ts
+++ b/src/adapters/homegrown.ts
@@ -41,8 +41,17 @@ import {
 // ---------------------------------------------------------------------------
 
 export interface HomegrownAdapterConfig {
-  /** Drizzle database instance (lazy, to avoid import-time DB connection) */
-  getDb: () => Promise<any>;
+  /** Drizzle database instance (lazy, to avoid import-time DB connection). */
+  getDb?: () => Promise<any>;
+  /**
+   * Optional scoped database executor.
+   *
+   * Consumers with transaction-local RLS, tenant pinning, or connection
+   * middleware should provide this instead of exposing a raw database handle.
+   * The callback receives a Drizzle database/transaction object and the adapter
+   * awaits the callback result before leaving the scope.
+   */
+  withDb?: <T>(fn: (db: any) => Promise<T>) => Promise<T>;
   /** Timezone for availability calculations */
   timezone?: string;
   /** Slot interval in minutes */
@@ -66,8 +75,13 @@ export const createHomegrownAdapter = (config: HomegrownAdapterConfig): Scheduli
   const minAdvance = config.minAdvanceHours ?? 2;
   const practitionerHandle = config.defaultPractitionerHandle ?? 'jen';
 
-  // Lazy DB access — imports done at call time to avoid bundling Drizzle in client
-  const db = () => config.getDb();
+  const withDb = async <T>(fn: (db: any) => Promise<T>): Promise<T> => {
+    if (config.withDb) return config.withDb(fn);
+    if (!config.getDb) {
+      throw new Error('HomegrownAdapter requires either getDb or withDb');
+    }
+    return fn(await config.getDb());
+  };
 
   // ---------------------------------------------------------------------------
   // Helpers
@@ -91,7 +105,6 @@ export const createHomegrownAdapter = (config: HomegrownAdapterConfig): Scheduli
       '@tummycrypt/tinyland-auth-pg/content-schema'
     );
     const { eq, or } = await import('drizzle-orm');
-    const d = await db();
 
     // UUID regex — only compare against UUID column if input looks like one
     const isUuid = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(serviceId);
@@ -100,47 +113,51 @@ export const createHomegrownAdapter = (config: HomegrownAdapterConfig): Scheduli
       ? or(eq(servicesTable.id, serviceId), eq(servicesTable.acuityId, serviceId))
       : eq(servicesTable.acuityId, serviceId);
 
-    const [row] = await d
-      .select()
-      .from(servicesTable)
-      .where(condition)
-      .limit(1);
+    return withDb(async (d) => {
+      const [row] = await d
+        .select()
+        .from(servicesTable)
+        .where(condition)
+        .limit(1);
 
-    return row ?? null;
+      return row ?? null;
+    });
   };
 
   /** Load business hours as a Map<dayOfWeek, HoursWindow> */
   const loadHoursMap = async (): Promise<Map<number, HoursWindow>> => {
     const { businessHours } = await import('@tummycrypt/tinyland-auth-pg/content-schema');
     const { asc } = await import('drizzle-orm');
-    const d = await db();
-    const rows = await d.select().from(businessHours).orderBy(asc(businessHours.dayOfWeek));
-    const map = new Map<number, HoursWindow>();
-    for (const row of rows) {
-      map.set(row.dayOfWeek, { opens: row.opens, closes: row.closes });
-    }
-    return map;
+    return withDb(async (d) => {
+      const rows = await d.select().from(businessHours).orderBy(asc(businessHours.dayOfWeek));
+      const map = new Map<number, HoursWindow>();
+      for (const row of rows) {
+        map.set(row.dayOfWeek, { opens: row.opens, closes: row.closes });
+      }
+      return map;
+    });
   };
 
   /** Load overrides for a date range */
   const loadOverrides = async (startDate: string, endDate: string): Promise<HoursOverride[]> => {
     const { businessHoursOverrides } = await import('@tummycrypt/tinyland-auth-pg/booking-schema');
     const { gte, lte, and } = await import('drizzle-orm');
-    const d = await db();
-    const rows = await d
-      .select()
-      .from(businessHoursOverrides)
-      .where(
-        and(
-          gte(businessHoursOverrides.date, startDate),
-          lte(businessHoursOverrides.date, endDate),
-        ),
-      );
-    return rows.map((r: any) => ({
-      date: r.date,
-      opens: r.opens,
-      closes: r.closes,
-    }));
+    return withDb(async (d) => {
+      const rows = await d
+        .select()
+        .from(businessHoursOverrides)
+        .where(
+          and(
+            gte(businessHoursOverrides.date, startDate),
+            lte(businessHoursOverrides.date, endDate),
+          ),
+        );
+      return rows.map((r: any) => ({
+        date: r.date,
+        opens: r.opens,
+        closes: r.closes,
+      }));
+    });
   };
 
   /** Load occupied blocks (bookings + time_blocks + active reservations) for a date range */
@@ -149,80 +166,82 @@ export const createHomegrownAdapter = (config: HomegrownAdapterConfig): Scheduli
       '@tummycrypt/tinyland-auth-pg/booking-schema'
     );
     const { gte, lte, and, ne, isNull, or, gt } = await import('drizzle-orm');
-    const d = await db();
 
     const startIso = `${startDate}T00:00:00Z`;
     const endIso = `${endDate}T23:59:59Z`;
 
-    // Active bookings (not cancelled)
-    const bookingRows = await d
-      .select({ datetime: bookingsTable.datetime, endTime: bookingsTable.endTime })
-      .from(bookingsTable)
-      .where(
-        and(
-          gte(bookingsTable.datetime, startIso),
-          lte(bookingsTable.datetime, endIso),
-          ne(bookingsTable.status, 'cancelled'),
-        ),
-      );
+    return withDb(async (d) => {
+      // Active bookings (not cancelled)
+      const bookingRows = await d
+        .select({ datetime: bookingsTable.datetime, endTime: bookingsTable.endTime })
+        .from(bookingsTable)
+        .where(
+          and(
+            gte(bookingsTable.datetime, startIso),
+            lte(bookingsTable.datetime, endIso),
+            ne(bookingsTable.status, 'cancelled'),
+          ),
+        );
 
-    // Time blocks
-    const blockRows = await d
-      .select({ startTime: timeBlocks.startTime, endTime: timeBlocks.endTime })
-      .from(timeBlocks)
-      .where(
-        and(
-          gte(timeBlocks.startTime, startIso),
-          lte(timeBlocks.startTime, endIso),
-        ),
-      );
+      // Time blocks
+      const blockRows = await d
+        .select({ startTime: timeBlocks.startTime, endTime: timeBlocks.endTime })
+        .from(timeBlocks)
+        .where(
+          and(
+            gte(timeBlocks.startTime, startIso),
+            lte(timeBlocks.startTime, endIso),
+          ),
+        );
 
-    // Active reservations (not expired, not released)
-    const reservationRows = await d
-      .select({
-        datetime: slotReservations.datetime,
-        duration: slotReservations.duration,
-      })
-      .from(slotReservations)
-      .where(
-        and(
-          gte(slotReservations.datetime, startIso),
-          lte(slotReservations.datetime, endIso),
-          gt(slotReservations.expiresAt, new Date().toISOString()),
-          isNull(slotReservations.releasedAt),
-        ),
-      );
+      // Active reservations (not expired, not released)
+      const reservationRows = await d
+        .select({
+          datetime: slotReservations.datetime,
+          duration: slotReservations.duration,
+        })
+        .from(slotReservations)
+        .where(
+          and(
+            gte(slotReservations.datetime, startIso),
+            lte(slotReservations.datetime, endIso),
+            gt(slotReservations.expiresAt, new Date().toISOString()),
+            isNull(slotReservations.releasedAt),
+          ),
+        );
 
-    const occupied: OccupiedBlock[] = [];
+      const occupied: OccupiedBlock[] = [];
 
-    for (const r of bookingRows) {
-      occupied.push({ start: new Date(r.datetime), end: new Date(r.endTime) });
-    }
-    for (const r of blockRows) {
-      occupied.push({ start: new Date(r.startTime), end: new Date(r.endTime) });
-    }
-    for (const r of reservationRows) {
-      const start = new Date(r.datetime);
-      occupied.push({
-        start,
-        end: new Date(start.getTime() + r.duration * 60_000),
-      });
-    }
+      for (const r of bookingRows) {
+        occupied.push({ start: new Date(r.datetime), end: new Date(r.endTime) });
+      }
+      for (const r of blockRows) {
+        occupied.push({ start: new Date(r.startTime), end: new Date(r.endTime) });
+      }
+      for (const r of reservationRows) {
+        const start = new Date(r.datetime);
+        occupied.push({
+          start,
+          end: new Date(start.getTime() + r.duration * 60_000),
+        });
+      }
 
-    return occupied;
+      return occupied;
+    });
   };
 
   /** Get the default practitioner */
   const getDefaultPractitioner = async (): Promise<any> => {
     const { practitioners } = await import('@tummycrypt/tinyland-auth-pg/content-schema');
     const { eq } = await import('drizzle-orm');
-    const d = await db();
-    const [row] = await d
-      .select()
-      .from(practitioners)
-      .where(eq(practitioners.handle, practitionerHandle))
-      .limit(1);
-    return row ?? null;
+    return withDb(async (d) => {
+      const [row] = await d
+        .select()
+        .from(practitioners)
+        .where(eq(practitioners.handle, practitionerHandle))
+        .limit(1);
+      return row ?? null;
+    });
   };
 
   // ---------------------------------------------------------------------------
@@ -240,12 +259,13 @@ export const createHomegrownAdapter = (config: HomegrownAdapterConfig): Scheduli
           '@tummycrypt/tinyland-auth-pg/content-schema'
         );
         const { asc, eq } = await import('drizzle-orm');
-        const d = await db();
-        const rows = await d
-          .select()
-          .from(servicesTable)
-          .where(eq(servicesTable.active, true))
-          .orderBy(asc(servicesTable.displayOrder));
+        const rows = await withDb<any[]>((d) =>
+          d
+            .select()
+            .from(servicesTable)
+            .where(eq(servicesTable.active, true))
+            .orderBy(asc(servicesTable.displayOrder)),
+        );
 
         return rows.map(
           (r: any): Service => ({
@@ -302,12 +322,13 @@ export const createHomegrownAdapter = (config: HomegrownAdapterConfig): Scheduli
           '@tummycrypt/tinyland-auth-pg/content-schema'
         );
         const { eq } = await import('drizzle-orm');
-        const d = await db();
-        const [row] = await d
-          .select()
-          .from(practitioners)
-          .where(eq(practitioners.id, providerId))
-          .limit(1);
+        const [row] = await withDb<any[]>((d) =>
+          d
+            .select()
+            .from(practitioners)
+            .where(eq(practitioners.id, providerId))
+            .limit(1),
+        );
 
         if (!row) throw new Error(`Provider ${providerId} not found`);
 
@@ -425,20 +446,21 @@ export const createHomegrownAdapter = (config: HomegrownAdapterConfig): Scheduli
         const { slotReservations } = await import(
           '@tummycrypt/tinyland-auth-pg/booking-schema'
         );
-        const d = await db();
         const expirationMinutes = params.expirationMinutes ?? 10;
         const expiresAt = new Date(
           Date.now() + expirationMinutes * 60_000,
         ).toISOString();
 
-        const [row] = await d
-          .insert(slotReservations)
-          .values({
-            datetime: params.datetime,
-            duration: params.duration,
-            expiresAt,
-          })
-          .returning();
+        const [row] = await withDb<any[]>((d) =>
+          d
+            .insert(slotReservations)
+            .values({
+              datetime: params.datetime,
+              duration: params.duration,
+              expiresAt,
+            })
+            .returning(),
+        );
 
         return {
           id: row.id,
@@ -455,11 +477,12 @@ export const createHomegrownAdapter = (config: HomegrownAdapterConfig): Scheduli
           '@tummycrypt/tinyland-auth-pg/booking-schema'
         );
         const { eq } = await import('drizzle-orm');
-        const d = await db();
-        await d
-          .update(slotReservations)
-          .set({ releasedAt: new Date().toISOString() })
-          .where(eq(slotReservations.id, reservationId));
+        await withDb((d) =>
+          d
+            .update(slotReservations)
+            .set({ releasedAt: new Date().toISOString() })
+            .where(eq(slotReservations.id, reservationId)),
+        );
       }),
 
     // --- Bookings ---
@@ -485,24 +508,25 @@ export const createHomegrownAdapter = (config: HomegrownAdapterConfig): Scheduli
         const endDt = new Date(startDt.getTime() + svc.durationMinutes * 60_000);
         const confirmationCode = generateConfirmationCode();
 
-        const d = await db();
-        const [row] = await d
-          .insert(bookingsTable)
-          .values({
-            confirmationCode,
-            serviceId: svc.id,
-            practitionerId: prac?.id,
-            clientId,
-            datetime: startDt.toISOString(),
-            endTime: endDt.toISOString(),
-            duration: svc.durationMinutes,
-            status: 'confirmed',
-            paymentStatus: 'pending',
-            paymentMethod: request.paymentMethod ?? null,
-            amountCents: svc.priceCents,
-            idempotencyKey: request.idempotencyKey,
-          })
-          .returning();
+        const [row] = await withDb<any[]>((d) =>
+          d
+            .insert(bookingsTable)
+            .values({
+              confirmationCode,
+              serviceId: svc.id,
+              practitionerId: prac?.id,
+              clientId,
+              datetime: startDt.toISOString(),
+              endTime: endDt.toISOString(),
+              duration: svc.durationMinutes,
+              status: 'confirmed',
+              paymentStatus: 'pending',
+              paymentMethod: request.paymentMethod ?? null,
+              amountCents: svc.priceCents,
+              idempotencyKey: request.idempotencyKey,
+            })
+            .returning(),
+        );
 
         return {
           id: row.id,
@@ -536,16 +560,17 @@ export const createHomegrownAdapter = (config: HomegrownAdapterConfig): Scheduli
               '@tummycrypt/tinyland-auth-pg/booking-schema'
             );
             const { eq } = await import('drizzle-orm');
-            const d = await db();
 
-            await d
-              .update(bookingsTable)
-              .set({
-                paymentRef,
-                paymentMethod: paymentProcessor,
-                paymentStatus: 'paid',
-              })
-              .where(eq(bookingsTable.id, booking.id));
+            await withDb((d) =>
+              d
+                .update(bookingsTable)
+                .set({
+                  paymentRef,
+                  paymentMethod: paymentProcessor,
+                  paymentStatus: 'paid',
+                })
+                .where(eq(bookingsTable.id, booking.id)),
+            );
 
             return {
               ...booking,
@@ -564,62 +589,62 @@ export const createHomegrownAdapter = (config: HomegrownAdapterConfig): Scheduli
           '@tummycrypt/tinyland-auth-pg/content-schema'
         );
         const { eq } = await import('drizzle-orm');
-        const d = await db();
-
-        const [row] = await d
-          .select()
-          .from(bookingsTable)
-          .where(eq(bookingsTable.id, bookingId))
-          .limit(1);
-
-        if (!row) throw new Error(`Booking ${bookingId} not found`);
-
-        // Load related data
-        const [svc] = await d
-          .select()
-          .from(servicesTable)
-          .where(eq(servicesTable.id, row.serviceId))
-          .limit(1);
-
-        const [client] = await d
-          .select()
-          .from(clientsTable)
-          .where(eq(clientsTable.id, row.clientId))
-          .limit(1);
-
-        let providerName: string | undefined;
-        if (row.practitionerId) {
-          const [prac] = await d
+        return withDb(async (d) => {
+          const [row] = await d
             .select()
-            .from(practitioners)
-            .where(eq(practitioners.id, row.practitionerId))
+            .from(bookingsTable)
+            .where(eq(bookingsTable.id, bookingId))
             .limit(1);
-          providerName = prac?.name;
-        }
 
-        return {
-          id: row.id,
-          serviceId: row.serviceId,
-          serviceName: svc?.name ?? 'Unknown',
-          providerId: row.practitionerId ?? undefined,
-          providerName,
-          datetime: row.datetime,
-          endTime: row.endTime,
-          duration: row.duration,
-          price: row.amountCents,
-          currency: svc?.currency ?? 'USD',
-          client: {
-            firstName: client?.firstName ?? '',
-            lastName: client?.lastName ?? '',
-            email: client?.email ?? '',
-            phone: client?.phone ?? undefined,
-          },
-          status: row.status as BookingStatus,
-          confirmationCode: row.confirmationCode,
-          paymentStatus: row.paymentStatus as PaymentStatus,
-          paymentRef: row.paymentRef ?? undefined,
-          createdAt: row.createdAt,
-        } satisfies Booking;
+          if (!row) throw new Error(`Booking ${bookingId} not found`);
+
+          // Load related data
+          const [svc] = await d
+            .select()
+            .from(servicesTable)
+            .where(eq(servicesTable.id, row.serviceId))
+            .limit(1);
+
+          const [client] = await d
+            .select()
+            .from(clientsTable)
+            .where(eq(clientsTable.id, row.clientId))
+            .limit(1);
+
+          let providerName: string | undefined;
+          if (row.practitionerId) {
+            const [prac] = await d
+              .select()
+              .from(practitioners)
+              .where(eq(practitioners.id, row.practitionerId))
+              .limit(1);
+            providerName = prac?.name;
+          }
+
+          return {
+            id: row.id,
+            serviceId: row.serviceId,
+            serviceName: svc?.name ?? 'Unknown',
+            providerId: row.practitionerId ?? undefined,
+            providerName,
+            datetime: row.datetime,
+            endTime: row.endTime,
+            duration: row.duration,
+            price: row.amountCents,
+            currency: svc?.currency ?? 'USD',
+            client: {
+              firstName: client?.firstName ?? '',
+              lastName: client?.lastName ?? '',
+              email: client?.email ?? '',
+              phone: client?.phone ?? undefined,
+            },
+            status: row.status as BookingStatus,
+            confirmationCode: row.confirmationCode,
+            paymentStatus: row.paymentStatus as PaymentStatus,
+            paymentRef: row.paymentRef ?? undefined,
+            createdAt: row.createdAt,
+          } satisfies Booking;
+        });
       }),
 
     cancelBooking: (bookingId: string, reason?: string) =>
@@ -628,17 +653,18 @@ export const createHomegrownAdapter = (config: HomegrownAdapterConfig): Scheduli
           '@tummycrypt/tinyland-auth-pg/booking-schema'
         );
         const { eq } = await import('drizzle-orm');
-        const d = await db();
 
-        await d
-          .update(bookingsTable)
-          .set({
-            status: 'cancelled',
-            cancelledAt: new Date().toISOString(),
-            cancelReason: reason ?? null,
-            updatedAt: new Date().toISOString(),
-          })
-          .where(eq(bookingsTable.id, bookingId));
+        await withDb((d) =>
+          d
+            .update(bookingsTable)
+            .set({
+              status: 'cancelled',
+              cancelledAt: new Date().toISOString(),
+              cancelReason: reason ?? null,
+              updatedAt: new Date().toISOString(),
+            })
+            .where(eq(bookingsTable.id, bookingId)),
+        );
       }),
 
     rescheduleBooking: (bookingId: string, newDatetime: string) =>
@@ -647,27 +673,31 @@ export const createHomegrownAdapter = (config: HomegrownAdapterConfig): Scheduli
           '@tummycrypt/tinyland-auth-pg/booking-schema'
         );
         const { eq } = await import('drizzle-orm');
-        const d = await db();
 
-        const [existing] = await d
-          .select()
-          .from(bookingsTable)
-          .where(eq(bookingsTable.id, bookingId))
-          .limit(1);
+        const existing = await withDb(async (d) => {
+          const [row] = await d
+            .select()
+            .from(bookingsTable)
+            .where(eq(bookingsTable.id, bookingId))
+            .limit(1);
+          return row ?? null;
+        });
 
         if (!existing) throw new Error(`Booking ${bookingId} not found`);
 
         const newStart = new Date(newDatetime);
         const newEnd = new Date(newStart.getTime() + existing.duration * 60_000);
 
-        await d
-          .update(bookingsTable)
-          .set({
-            datetime: newStart.toISOString(),
-            endTime: newEnd.toISOString(),
-            updatedAt: new Date().toISOString(),
-          })
-          .where(eq(bookingsTable.id, bookingId));
+        await withDb((d) =>
+          d
+            .update(bookingsTable)
+            .set({
+              datetime: newStart.toISOString(),
+              endTime: newEnd.toISOString(),
+              updatedAt: new Date().toISOString(),
+            })
+            .where(eq(bookingsTable.id, bookingId)),
+        );
 
         // Return updated booking
         return await Effect.runPromise(adapter.getBooking(bookingId));
@@ -681,44 +711,44 @@ export const createHomegrownAdapter = (config: HomegrownAdapterConfig): Scheduli
           '@tummycrypt/tinyland-auth-pg/booking-schema'
         );
         const { eq } = await import('drizzle-orm');
-        const d = await db();
+        return withDb(async (d) => {
+          // Try to find existing
+          const [existing] = await d
+            .select()
+            .from(clientsTable)
+            .where(eq(clientsTable.email, client.email))
+            .limit(1);
 
-        // Try to find existing
-        const [existing] = await d
-          .select()
-          .from(clientsTable)
-          .where(eq(clientsTable.email, client.email))
-          .limit(1);
+          if (existing) {
+            // Update name/phone if changed
+            await d
+              .update(clientsTable)
+              .set({
+                firstName: client.firstName,
+                lastName: client.lastName,
+                phone: client.phone ?? existing.phone,
+                updatedAt: new Date().toISOString(),
+              })
+              .where(eq(clientsTable.id, existing.id));
 
-        if (existing) {
-          // Update name/phone if changed
-          await d
-            .update(clientsTable)
-            .set({
+            return { id: existing.id, isNew: false };
+          }
+
+          // Create new
+          const [row] = await d
+            .insert(clientsTable)
+            .values({
               firstName: client.firstName,
               lastName: client.lastName,
-              phone: client.phone ?? existing.phone,
-              updatedAt: new Date().toISOString(),
+              email: client.email,
+              phone: client.phone ?? null,
+              notes: client.notes ?? null,
+              customFields: client.customFields ?? {},
             })
-            .where(eq(clientsTable.id, existing.id));
+            .returning();
 
-          return { id: existing.id, isNew: false };
-        }
-
-        // Create new
-        const [row] = await d
-          .insert(clientsTable)
-          .values({
-            firstName: client.firstName,
-            lastName: client.lastName,
-            email: client.email,
-            phone: client.phone ?? null,
-            notes: client.notes ?? null,
-            customFields: client.customFields ?? {},
-          })
-          .returning();
-
-        return { id: row.id, isNew: true };
+          return { id: row.id, isNew: true };
+        });
       }),
 
     getClientByEmail: (email: string) =>
@@ -727,13 +757,13 @@ export const createHomegrownAdapter = (config: HomegrownAdapterConfig): Scheduli
           '@tummycrypt/tinyland-auth-pg/booking-schema'
         );
         const { eq } = await import('drizzle-orm');
-        const d = await db();
-
-        const [row] = await d
-          .select()
-          .from(clientsTable)
-          .where(eq(clientsTable.email, email))
-          .limit(1);
+        const [row] = await withDb<any[]>((d) =>
+          d
+            .select()
+            .from(clientsTable)
+            .where(eq(clientsTable.email, email))
+            .limit(1),
+        );
 
         if (!row) return null;
 

--- a/src/adapters/homegrown.ts
+++ b/src/adapters/homegrown.ts
@@ -8,9 +8,9 @@
  * Feature-flagged: only active when SCHEDULING_BACKEND=homegrown
  */
 
-import { Effect } from 'effect';
+import { Effect } from "effect";
 
-import type { SchedulingAdapter } from './types.js';
+import type { SchedulingAdapter } from "./types.js";
 import type {
   Service,
   Provider,
@@ -23,8 +23,8 @@ import type {
   SchedulingResult,
   BookingStatus,
   PaymentStatus,
-} from '../core/types.js';
-import { Errors } from '../core/types.js';
+} from "../core/types.js";
+import { Errors } from "../core/types.js";
 import {
   getAvailableSlots as computeSlots,
   isSlotAvailable,
@@ -34,7 +34,7 @@ import {
   type HoursOverride,
   type OccupiedBlock,
   type SlotConfig,
-} from './availability-engine.js';
+} from "./availability-engine.js";
 
 // ---------------------------------------------------------------------------
 // Config
@@ -68,19 +68,22 @@ export interface HomegrownAdapterConfig {
 // Factory
 // ---------------------------------------------------------------------------
 
-export const createHomegrownAdapter = (config: HomegrownAdapterConfig): SchedulingAdapter => {
-  const tz = config.timezone ?? 'America/New_York';
+export const createHomegrownAdapter = (
+  config: HomegrownAdapterConfig,
+): SchedulingAdapter => {
+  if (!config.getDb && !config.withDb) {
+    throw new Error("HomegrownAdapter requires either getDb or withDb");
+  }
+
+  const tz = config.timezone ?? "America/New_York";
   const interval = config.slotInterval ?? 30;
   const buffer = config.bufferMinutes ?? 0;
   const minAdvance = config.minAdvanceHours ?? 2;
-  const practitionerHandle = config.defaultPractitionerHandle ?? 'jen';
+  const practitionerHandle = config.defaultPractitionerHandle ?? "jen";
 
   const withDb = async <T>(fn: (db: any) => Promise<T>): Promise<T> => {
     if (config.withDb) return config.withDb(fn);
-    if (!config.getDb) {
-      throw new Error('HomegrownAdapter requires either getDb or withDb');
-    }
-    return fn(await config.getDb());
+    return fn(await config.getDb!());
   };
 
   // ---------------------------------------------------------------------------
@@ -93,24 +96,29 @@ export const createHomegrownAdapter = (config: HomegrownAdapterConfig): Scheduli
       try: fn,
       catch: (e) =>
         Errors.infrastructure(
-          'UNKNOWN',
-          e instanceof Error ? e.message : 'Unknown error',
+          "UNKNOWN",
+          e instanceof Error ? e.message : "Unknown error",
           e instanceof Error ? e : undefined,
         ),
     });
 
   /** Resolve a service by UUID or acuityId */
   const resolveService = async (serviceId: string): Promise<any> => {
-    const { services: servicesTable } = await import(
-      '@tummycrypt/tinyland-auth-pg/content-schema'
-    );
-    const { eq, or } = await import('drizzle-orm');
+    const { services: servicesTable } =
+      await import("@tummycrypt/tinyland-auth-pg/content-schema");
+    const { eq, or } = await import("drizzle-orm");
 
     // UUID regex — only compare against UUID column if input looks like one
-    const isUuid = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(serviceId);
+    const isUuid =
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(
+        serviceId,
+      );
 
     const condition = isUuid
-      ? or(eq(servicesTable.id, serviceId), eq(servicesTable.acuityId, serviceId))
+      ? or(
+          eq(servicesTable.id, serviceId),
+          eq(servicesTable.acuityId, serviceId),
+        )
       : eq(servicesTable.acuityId, serviceId);
 
     return withDb(async (d) => {
@@ -126,10 +134,14 @@ export const createHomegrownAdapter = (config: HomegrownAdapterConfig): Scheduli
 
   /** Load business hours as a Map<dayOfWeek, HoursWindow> */
   const loadHoursMap = async (): Promise<Map<number, HoursWindow>> => {
-    const { businessHours } = await import('@tummycrypt/tinyland-auth-pg/content-schema');
-    const { asc } = await import('drizzle-orm');
+    const { businessHours } =
+      await import("@tummycrypt/tinyland-auth-pg/content-schema");
+    const { asc } = await import("drizzle-orm");
     return withDb(async (d) => {
-      const rows = await d.select().from(businessHours).orderBy(asc(businessHours.dayOfWeek));
+      const rows = await d
+        .select()
+        .from(businessHours)
+        .orderBy(asc(businessHours.dayOfWeek));
       const map = new Map<number, HoursWindow>();
       for (const row of rows) {
         map.set(row.dayOfWeek, { opens: row.opens, closes: row.closes });
@@ -139,9 +151,13 @@ export const createHomegrownAdapter = (config: HomegrownAdapterConfig): Scheduli
   };
 
   /** Load overrides for a date range */
-  const loadOverrides = async (startDate: string, endDate: string): Promise<HoursOverride[]> => {
-    const { businessHoursOverrides } = await import('@tummycrypt/tinyland-auth-pg/booking-schema');
-    const { gte, lte, and } = await import('drizzle-orm');
+  const loadOverrides = async (
+    startDate: string,
+    endDate: string,
+  ): Promise<HoursOverride[]> => {
+    const { businessHoursOverrides } =
+      await import("@tummycrypt/tinyland-auth-pg/booking-schema");
+    const { gte, lte, and } = await import("drizzle-orm");
     return withDb(async (d) => {
       const rows = await d
         .select()
@@ -161,11 +177,16 @@ export const createHomegrownAdapter = (config: HomegrownAdapterConfig): Scheduli
   };
 
   /** Load occupied blocks (bookings + time_blocks + active reservations) for a date range */
-  const loadOccupied = async (startDate: string, endDate: string): Promise<OccupiedBlock[]> => {
-    const { bookings: bookingsTable, timeBlocks, slotReservations } = await import(
-      '@tummycrypt/tinyland-auth-pg/booking-schema'
-    );
-    const { gte, lte, and, ne, isNull, or, gt } = await import('drizzle-orm');
+  const loadOccupied = async (
+    startDate: string,
+    endDate: string,
+  ): Promise<OccupiedBlock[]> => {
+    const {
+      bookings: bookingsTable,
+      timeBlocks,
+      slotReservations,
+    } = await import("@tummycrypt/tinyland-auth-pg/booking-schema");
+    const { gte, lte, and, ne, isNull, or, gt } = await import("drizzle-orm");
 
     const startIso = `${startDate}T00:00:00Z`;
     const endIso = `${endDate}T23:59:59Z`;
@@ -173,19 +194,25 @@ export const createHomegrownAdapter = (config: HomegrownAdapterConfig): Scheduli
     return withDb(async (d) => {
       // Active bookings (not cancelled)
       const bookingRows = await d
-        .select({ datetime: bookingsTable.datetime, endTime: bookingsTable.endTime })
+        .select({
+          datetime: bookingsTable.datetime,
+          endTime: bookingsTable.endTime,
+        })
         .from(bookingsTable)
         .where(
           and(
             gte(bookingsTable.datetime, startIso),
             lte(bookingsTable.datetime, endIso),
-            ne(bookingsTable.status, 'cancelled'),
+            ne(bookingsTable.status, "cancelled"),
           ),
         );
 
       // Time blocks
       const blockRows = await d
-        .select({ startTime: timeBlocks.startTime, endTime: timeBlocks.endTime })
+        .select({
+          startTime: timeBlocks.startTime,
+          endTime: timeBlocks.endTime,
+        })
         .from(timeBlocks)
         .where(
           and(
@@ -213,10 +240,16 @@ export const createHomegrownAdapter = (config: HomegrownAdapterConfig): Scheduli
       const occupied: OccupiedBlock[] = [];
 
       for (const r of bookingRows) {
-        occupied.push({ start: new Date(r.datetime), end: new Date(r.endTime) });
+        occupied.push({
+          start: new Date(r.datetime),
+          end: new Date(r.endTime),
+        });
       }
       for (const r of blockRows) {
-        occupied.push({ start: new Date(r.startTime), end: new Date(r.endTime) });
+        occupied.push({
+          start: new Date(r.startTime),
+          end: new Date(r.endTime),
+        });
       }
       for (const r of reservationRows) {
         const start = new Date(r.datetime);
@@ -232,8 +265,9 @@ export const createHomegrownAdapter = (config: HomegrownAdapterConfig): Scheduli
 
   /** Get the default practitioner */
   const getDefaultPractitioner = async (): Promise<any> => {
-    const { practitioners } = await import('@tummycrypt/tinyland-auth-pg/content-schema');
-    const { eq } = await import('drizzle-orm');
+    const { practitioners } =
+      await import("@tummycrypt/tinyland-auth-pg/content-schema");
+    const { eq } = await import("drizzle-orm");
     return withDb(async (d) => {
       const [row] = await d
         .select()
@@ -244,21 +278,85 @@ export const createHomegrownAdapter = (config: HomegrownAdapterConfig): Scheduli
     });
   };
 
+  const loadBookingById = async (
+    d: any,
+    bookingId: string,
+  ): Promise<Booking> => {
+    const { bookings: bookingsTable, clients: clientsTable } =
+      await import("@tummycrypt/tinyland-auth-pg/booking-schema");
+    const { services: servicesTable, practitioners } =
+      await import("@tummycrypt/tinyland-auth-pg/content-schema");
+    const { eq } = await import("drizzle-orm");
+
+    const [row] = await d
+      .select()
+      .from(bookingsTable)
+      .where(eq(bookingsTable.id, bookingId))
+      .limit(1);
+
+    if (!row) throw new Error(`Booking ${bookingId} not found`);
+
+    const [svc] = await d
+      .select()
+      .from(servicesTable)
+      .where(eq(servicesTable.id, row.serviceId))
+      .limit(1);
+
+    const [client] = await d
+      .select()
+      .from(clientsTable)
+      .where(eq(clientsTable.id, row.clientId))
+      .limit(1);
+
+    let providerName: string | undefined;
+    if (row.practitionerId) {
+      const [prac] = await d
+        .select()
+        .from(practitioners)
+        .where(eq(practitioners.id, row.practitionerId))
+        .limit(1);
+      providerName = prac?.name;
+    }
+
+    return {
+      id: row.id,
+      serviceId: row.serviceId,
+      serviceName: svc?.name ?? "Unknown",
+      providerId: row.practitionerId ?? undefined,
+      providerName,
+      datetime: row.datetime,
+      endTime: row.endTime,
+      duration: row.duration,
+      price: row.amountCents,
+      currency: svc?.currency ?? "USD",
+      client: {
+        firstName: client?.firstName ?? "",
+        lastName: client?.lastName ?? "",
+        email: client?.email ?? "",
+        phone: client?.phone ?? undefined,
+      },
+      status: row.status as BookingStatus,
+      confirmationCode: row.confirmationCode,
+      paymentStatus: row.paymentStatus as PaymentStatus,
+      paymentRef: row.paymentRef ?? undefined,
+      createdAt: row.createdAt,
+    } satisfies Booking;
+  };
+
   // ---------------------------------------------------------------------------
   // SchedulingAdapter implementation
   // ---------------------------------------------------------------------------
 
   const adapter: SchedulingAdapter = {
-    name: 'homegrown',
+    name: "homegrown",
 
     // --- Services ---
 
     getServices: () =>
       fromAsync(async () => {
-        const { services: servicesTable } = await import(
-          '@tummycrypt/tinyland-auth-pg/content-schema'
-        );
-        const { asc, eq } = await import('drizzle-orm');
+        const { services: servicesTable } =
+          await import("@tummycrypt/tinyland-auth-pg/content-schema");
+        const { asc, eq } = await import("drizzle-orm");
         const rows = await withDb<any[]>((d) =>
           d
             .select()
@@ -318,10 +416,9 @@ export const createHomegrownAdapter = (config: HomegrownAdapterConfig): Scheduli
 
     getProvider: (providerId: string) =>
       fromAsync(async () => {
-        const { practitioners } = await import(
-          '@tummycrypt/tinyland-auth-pg/content-schema'
-        );
-        const { eq } = await import('drizzle-orm');
+        const { practitioners } =
+          await import("@tummycrypt/tinyland-auth-pg/content-schema");
+        const { eq } = await import("drizzle-orm");
         const [row] = await withDb<any[]>((d) =>
           d
             .select()
@@ -383,7 +480,7 @@ export const createHomegrownAdapter = (config: HomegrownAdapterConfig): Scheduli
     getAvailableSlots: (params) =>
       fromAsync(async () => {
         const hoursMap = await loadHoursMap();
-        const dayOfWeek = new Date(params.date + 'T12:00:00Z').getDay();
+        const dayOfWeek = new Date(params.date + "T12:00:00Z").getDay();
         const dayHours = hoursMap.get(dayOfWeek) ?? null;
         const overrides = await loadOverrides(params.date, params.date);
         const override = overrides[0] ?? null;
@@ -400,7 +497,13 @@ export const createHomegrownAdapter = (config: HomegrownAdapterConfig): Scheduli
           timezone: tz,
         };
 
-        const slots = computeSlots(params.date, dayHours, override, occupied, slotConfig);
+        const slots = computeSlots(
+          params.date,
+          dayHours,
+          override,
+          occupied,
+          slotConfig,
+        );
 
         return slots.map(
           (s): TimeSlot => ({
@@ -415,7 +518,7 @@ export const createHomegrownAdapter = (config: HomegrownAdapterConfig): Scheduli
       fromAsync(async () => {
         const date = params.datetime.slice(0, 10);
         const hoursMap = await loadHoursMap();
-        const dayOfWeek = new Date(date + 'T12:00:00Z').getDay();
+        const dayOfWeek = new Date(date + "T12:00:00Z").getDay();
         const dayHours = hoursMap.get(dayOfWeek) ?? null;
         const overrides = await loadOverrides(date, date);
         const override = overrides[0] ?? null;
@@ -424,28 +527,21 @@ export const createHomegrownAdapter = (config: HomegrownAdapterConfig): Scheduli
         const svc = await resolveService(params.serviceId);
         if (!svc) throw new Error(`Service ${params.serviceId} not found`);
 
-        return isSlotAvailable(
-          params.datetime,
-          dayHours,
-          override,
-          occupied,
-          {
-            duration: svc.durationMinutes,
-            interval,
-            buffer,
-            minAdvanceHours: minAdvance,
-            timezone: tz,
-          },
-        );
+        return isSlotAvailable(params.datetime, dayHours, override, occupied, {
+          duration: svc.durationMinutes,
+          interval,
+          buffer,
+          minAdvanceHours: minAdvance,
+          timezone: tz,
+        });
       }),
 
     // --- Reservations ---
 
     createReservation: (params) =>
       fromAsync(async () => {
-        const { slotReservations } = await import(
-          '@tummycrypt/tinyland-auth-pg/booking-schema'
-        );
+        const { slotReservations } =
+          await import("@tummycrypt/tinyland-auth-pg/booking-schema");
         const expirationMinutes = params.expirationMinutes ?? 10;
         const expiresAt = new Date(
           Date.now() + expirationMinutes * 60_000,
@@ -473,10 +569,9 @@ export const createHomegrownAdapter = (config: HomegrownAdapterConfig): Scheduli
 
     releaseReservation: (reservationId: string) =>
       fromAsync(async () => {
-        const { slotReservations } = await import(
-          '@tummycrypt/tinyland-auth-pg/booking-schema'
-        );
-        const { eq } = await import('drizzle-orm');
+        const { slotReservations } =
+          await import("@tummycrypt/tinyland-auth-pg/booking-schema");
+        const { eq } = await import("drizzle-orm");
         await withDb((d) =>
           d
             .update(slotReservations)
@@ -489,23 +584,26 @@ export const createHomegrownAdapter = (config: HomegrownAdapterConfig): Scheduli
 
     createBooking: (request: BookingRequest) =>
       fromAsync(async () => {
-        const { bookings: bookingsTable } = await import(
-          '@tummycrypt/tinyland-auth-pg/booking-schema'
-        );
+        const { bookings: bookingsTable } =
+          await import("@tummycrypt/tinyland-auth-pg/booking-schema");
 
         // Resolve service (by UUID or acuityId)
         const svc = await resolveService(request.serviceId);
         if (!svc) throw new Error(`Service ${request.serviceId} not found`);
 
         // Find or create client
-        const clientResult = await Effect.runPromise(adapter.findOrCreateClient(request.client));
+        const clientResult = await Effect.runPromise(
+          adapter.findOrCreateClient(request.client),
+        );
         const clientId = clientResult.id;
 
         // Get practitioner
         const prac = await getDefaultPractitioner();
 
         const startDt = new Date(request.datetime);
-        const endDt = new Date(startDt.getTime() + svc.durationMinutes * 60_000);
+        const endDt = new Date(
+          startDt.getTime() + svc.durationMinutes * 60_000,
+        );
         const confirmationCode = generateConfirmationCode();
 
         const [row] = await withDb<any[]>((d) =>
@@ -519,8 +617,8 @@ export const createHomegrownAdapter = (config: HomegrownAdapterConfig): Scheduli
               datetime: startDt.toISOString(),
               endTime: endDt.toISOString(),
               duration: svc.durationMinutes,
-              status: 'confirmed',
-              paymentStatus: 'pending',
+              status: "confirmed",
+              paymentStatus: "pending",
               paymentMethod: request.paymentMethod ?? null,
               amountCents: svc.priceCents,
               idempotencyKey: request.idempotencyKey,
@@ -552,113 +650,47 @@ export const createHomegrownAdapter = (config: HomegrownAdapterConfig): Scheduli
       paymentRef: string,
       paymentProcessor: string,
     ) =>
-      Effect.flatMap(
-        adapter.createBooking(request),
-        (booking) =>
-          fromAsync(async () => {
-            const { bookings: bookingsTable } = await import(
-              '@tummycrypt/tinyland-auth-pg/booking-schema'
-            );
-            const { eq } = await import('drizzle-orm');
+      Effect.flatMap(adapter.createBooking(request), (booking) =>
+        fromAsync(async () => {
+          const { bookings: bookingsTable } =
+            await import("@tummycrypt/tinyland-auth-pg/booking-schema");
+          const { eq } = await import("drizzle-orm");
 
-            await withDb((d) =>
-              d
-                .update(bookingsTable)
-                .set({
-                  paymentRef,
-                  paymentMethod: paymentProcessor,
-                  paymentStatus: 'paid',
-                })
-                .where(eq(bookingsTable.id, booking.id)),
-            );
+          await withDb((d) =>
+            d
+              .update(bookingsTable)
+              .set({
+                paymentRef,
+                paymentMethod: paymentProcessor,
+                paymentStatus: "paid",
+              })
+              .where(eq(bookingsTable.id, booking.id)),
+          );
 
-            return {
-              ...booking,
-              paymentRef,
-              paymentStatus: 'paid' as const,
-            };
-          }),
+          return {
+            ...booking,
+            paymentRef,
+            paymentStatus: "paid" as const,
+          };
+        }),
       ),
 
     getBooking: (bookingId: string) =>
       fromAsync(async () => {
-        const { bookings: bookingsTable, clients: clientsTable } = await import(
-          '@tummycrypt/tinyland-auth-pg/booking-schema'
-        );
-        const { services: servicesTable, practitioners } = await import(
-          '@tummycrypt/tinyland-auth-pg/content-schema'
-        );
-        const { eq } = await import('drizzle-orm');
-        return withDb(async (d) => {
-          const [row] = await d
-            .select()
-            .from(bookingsTable)
-            .where(eq(bookingsTable.id, bookingId))
-            .limit(1);
-
-          if (!row) throw new Error(`Booking ${bookingId} not found`);
-
-          // Load related data
-          const [svc] = await d
-            .select()
-            .from(servicesTable)
-            .where(eq(servicesTable.id, row.serviceId))
-            .limit(1);
-
-          const [client] = await d
-            .select()
-            .from(clientsTable)
-            .where(eq(clientsTable.id, row.clientId))
-            .limit(1);
-
-          let providerName: string | undefined;
-          if (row.practitionerId) {
-            const [prac] = await d
-              .select()
-              .from(practitioners)
-              .where(eq(practitioners.id, row.practitionerId))
-              .limit(1);
-            providerName = prac?.name;
-          }
-
-          return {
-            id: row.id,
-            serviceId: row.serviceId,
-            serviceName: svc?.name ?? 'Unknown',
-            providerId: row.practitionerId ?? undefined,
-            providerName,
-            datetime: row.datetime,
-            endTime: row.endTime,
-            duration: row.duration,
-            price: row.amountCents,
-            currency: svc?.currency ?? 'USD',
-            client: {
-              firstName: client?.firstName ?? '',
-              lastName: client?.lastName ?? '',
-              email: client?.email ?? '',
-              phone: client?.phone ?? undefined,
-            },
-            status: row.status as BookingStatus,
-            confirmationCode: row.confirmationCode,
-            paymentStatus: row.paymentStatus as PaymentStatus,
-            paymentRef: row.paymentRef ?? undefined,
-            createdAt: row.createdAt,
-          } satisfies Booking;
-        });
+        return withDb((d) => loadBookingById(d, bookingId));
       }),
 
     cancelBooking: (bookingId: string, reason?: string) =>
       fromAsync(async () => {
-        const { bookings: bookingsTable } = await import(
-          '@tummycrypt/tinyland-auth-pg/booking-schema'
-        );
-        const { eq } = await import('drizzle-orm');
+        const { bookings: bookingsTable } =
+          await import("@tummycrypt/tinyland-auth-pg/booking-schema");
+        const { eq } = await import("drizzle-orm");
 
         await withDb((d) =>
           d
             .update(bookingsTable)
             .set({
-              status: 'cancelled',
+              status: "cancelled",
               cancelledAt: new Date().toISOString(),
               cancelReason: reason ?? null,
               updatedAt: new Date().toISOString(),
@@ -669,48 +701,42 @@ export const createHomegrownAdapter = (config: HomegrownAdapterConfig): Scheduli
 
     rescheduleBooking: (bookingId: string, newDatetime: string) =>
       fromAsync(async () => {
-        const { bookings: bookingsTable } = await import(
-          '@tummycrypt/tinyland-auth-pg/booking-schema'
-        );
-        const { eq } = await import('drizzle-orm');
+        const { bookings: bookingsTable } =
+          await import("@tummycrypt/tinyland-auth-pg/booking-schema");
+        const { eq } = await import("drizzle-orm");
 
-        const existing = await withDb(async (d) => {
+        return withDb(async (d) => {
           const [row] = await d
             .select()
             .from(bookingsTable)
             .where(eq(bookingsTable.id, bookingId))
             .limit(1);
-          return row ?? null;
-        });
 
-        if (!existing) throw new Error(`Booking ${bookingId} not found`);
+          if (!row) throw new Error(`Booking ${bookingId} not found`);
 
-        const newStart = new Date(newDatetime);
-        const newEnd = new Date(newStart.getTime() + existing.duration * 60_000);
+          const newStart = new Date(newDatetime);
+          const newEnd = new Date(newStart.getTime() + row.duration * 60_000);
 
-        await withDb((d) =>
-          d
+          await d
             .update(bookingsTable)
             .set({
               datetime: newStart.toISOString(),
               endTime: newEnd.toISOString(),
               updatedAt: new Date().toISOString(),
             })
-            .where(eq(bookingsTable.id, bookingId)),
-        );
+            .where(eq(bookingsTable.id, bookingId));
 
-        // Return updated booking
-        return await Effect.runPromise(adapter.getBooking(bookingId));
+          return loadBookingById(d, bookingId);
+        });
       }),
 
     // --- Clients ---
 
     findOrCreateClient: (client: ClientInfo) =>
       fromAsync(async () => {
-        const { clients: clientsTable } = await import(
-          '@tummycrypt/tinyland-auth-pg/booking-schema'
-        );
-        const { eq } = await import('drizzle-orm');
+        const { clients: clientsTable } =
+          await import("@tummycrypt/tinyland-auth-pg/booking-schema");
+        const { eq } = await import("drizzle-orm");
         return withDb(async (d) => {
           // Try to find existing
           const [existing] = await d
@@ -753,10 +779,9 @@ export const createHomegrownAdapter = (config: HomegrownAdapterConfig): Scheduli
 
     getClientByEmail: (email: string) =>
       fromAsync(async () => {
-        const { clients: clientsTable } = await import(
-          '@tummycrypt/tinyland-auth-pg/booking-schema'
-        );
-        const { eq } = await import('drizzle-orm');
+        const { clients: clientsTable } =
+          await import("@tummycrypt/tinyland-auth-pg/booking-schema");
+        const { eq } = await import("drizzle-orm");
         const [row] = await withDb<any[]>((d) =>
           d
             .select()


### PR DESCRIPTION
## Summary

- Adds an optional `withDb(fn)` executor to `createHomegrownAdapter` so consumers can run adapter queries inside their own tenant/RLS transaction scope.
- Keeps `getDb()` backwards-compatible for existing consumers.
- Bumps package metadata to `0.7.3` and aligns the package dependency on `@tummycrypt/tinyland-auth-pg` to `^0.2.1`.

## Why

MassageIthaca K8s shadow environments use local PostgreSQL with tenant-scoped RLS. The old HomegrownAdapter accepted only a raw Drizzle handle, which let direct queries bypass the app-owned `withTenant` boundary and return empty rows under the runtime role.

## Validation

- `pnpm check`
- `pnpm exec vitest run src/adapters/__tests__/homegrown-adapter.test.ts`
- `pnpm test:unit`
- `pnpm build`
- `pnpm exec publint`
