### PR TITLE
feat(bazel): wire scheduling-kit into tinyland building-block ecosystem

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -3,6 +3,8 @@
 # =============================================================================
 
 common --enable_bzlmod
+common --registry=https://raw.githubusercontent.com/tinyland-inc/bazel-registry/main
+common --registry=https://bcr.bazel.build
 
 # Build performance
 build --jobs=auto

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -30,8 +30,8 @@ module(
 # Core Bazel dependencies
 # =============================================================================
 
-bazel_dep(name = "bazel_skylib", version = "1.8.1")
-bazel_dep(name = "platforms", version = "0.0.11")
+bazel_dep(name = "bazel_skylib", version = "1.8.2")
+bazel_dep(name = "platforms", version = "1.0.0")
 bazel_dep(name = "aspect_bazel_lib", version = "2.22.5")
 
 # =============================================================================
@@ -42,6 +42,14 @@ bazel_dep(name = "rules_nodejs", version = "6.7.3")
 bazel_dep(name = "aspect_rules_js", version = "2.9.1")
 bazel_dep(name = "aspect_rules_ts", version = "3.8.4")
 bazel_dep(name = "aspect_rules_swc", version = "2.6.1")
+
+# =============================================================================
+# Inter-module dependencies (tinyland building blocks)
+# =============================================================================
+
+# HomegrownAdapter uses @tummycrypt/tinyland-auth-pg's drizzle schema and
+# storage primitives. The bazel_dep edge mirrors the npm dependency.
+bazel_dep(name = "tummycrypt_tinyland_auth_pg", version = "0.2.2")
 
 # =============================================================================
 # Node.js toolchain


### PR DESCRIPTION
## Summary

Part of TIN-678. Adds the missing inter-module `bazel_dep` edges so scheduling-kit's Bazel module graph can resolve `@tummycrypt/tinyland-auth-pg` as a real building-block dependency.

## Changes

- `MODULE.bazel`: `bazel_dep(tummycrypt_tinyland_auth_pg@0.2.2)` (HomegrownAdapter uses the auth-pg schema and adapter primitives)
- `.bazelrc`: add `tinyland-inc/bazel-registry` so the dep resolves
- bump `bazel_skylib` 1.8.1 → 1.8.2 and `platforms` 0.0.11 → 1.0.0 for registry consistency

## Validation

- pnpm install ✓
- pnpm check ✓ (0 errors)
- pnpm test (614/614) ✓

## Next

After merge + tag (v0.7.2), register `tummycrypt_scheduling_kit` in `tinyland-inc/bazel-registry` so `scheduling-bridge` can declare its `bazel_dep` on it.