### PR TITLE
chore: bump scheduling-kit to 0.7.4 for release authority

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -127,7 +127,7 @@ npm_package(
     ],
     package = "@tummycrypt/scheduling-kit",
     tags = ["manual"],
-    version = "0.7.3",
+    version = "0.7.4",
     visibility = ["//visibility:public"],
 )
 

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -22,7 +22,7 @@ Subpackage targets (finer-grained caching):
 
 module(
     name = "tummycrypt_scheduling_kit",
-    version = "0.7.3",
+    version = "0.7.4",
     compatibility_level = 1,
 )
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tummycrypt/scheduling-kit",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "description": "Backend-agnostic scheduling components with alternative payment support",
   "type": "module",
   "packageManager": "pnpm@9.15.9",


### PR DESCRIPTION
## Summary\n- Bump package.json, MODULE.bazel, and BUILD.bazel package metadata to 0.7.4.\n- Keep this intentionally narrow so a fresh tag/release/registry entry can represent the post-#83/#85 Bazel source truth instead of retro-tagging 0.7.3.\n\n## Why\n- npm latest 0.7.3 was published from 67f6eb before the Bazel scoped-npm and module-edge changes.\n- Current main includes those Bazel changes, so tagging it as v0.7.3 would create false provenance.\n- tinyland-inc/bazel-registry needs a Git source archive with MODULE.bazel/BUILD.bazel; the npm tarball does not include them.\n\n## Validation\n- pnpm check:release-metadata\n- git diff --check\n\nRefs: #73, TIN-678, TIN-679