### PR TITLE
Clear DateTimePicker selection on month navigation

### DIFF
--- a/src/components/DateTimePicker.svelte
+++ b/src/components/DateTimePicker.svelte
@@ -95,14 +95,21 @@
     onMonthChange?.(formatDate(start), formatDate(end));
   };
 
+  const clearDateTimeSelection = () => {
+    selectedDate = undefined;
+    selectedTime = undefined;
+  };
+
   // Navigate months
   const prevMonth = () => {
     currentMonth = new Date(currentMonth.getFullYear(), currentMonth.getMonth() - 1, 1);
+    clearDateTimeSelection();
     emitMonthRange(currentMonth);
   };
 
   const nextMonth = () => {
     currentMonth = new Date(currentMonth.getFullYear(), currentMonth.getMonth() + 1, 1);
+    clearDateTimeSelection();
     emitMonthRange(currentMonth);
   };
 


### PR DESCRIPTION
## Summary
- clear selected date/time when DateTimePicker moves to another month
- prevents stale time-slot panels from remaining visible under a new month header

## Validation
- pnpm exec vitest run src/tests/components/date-time-picker.test.ts
- pnpm check
- pnpm build