### PR TITLE
[codex] Bump scheduling-kit to 0.7.5

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -127,7 +127,7 @@ npm_package(
     ],
     package = "@tummycrypt/scheduling-kit",
     tags = ["manual"],
-    version = "0.7.4",
+    version = "0.7.5",
     visibility = ["//visibility:public"],
 )
 

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -22,7 +22,7 @@ Subpackage targets (finer-grained caching):
 
 module(
     name = "tummycrypt_scheduling_kit",
-    version = "0.7.4",
+    version = "0.7.5",
     compatibility_level = 1,
 )
 

--- a/docs/generated/package-surface.md
+++ b/docs/generated/package-surface.md
@@ -11,7 +11,7 @@ Generated from `package.json` and the current `src/` tree.
 | Field | Value |
 | --- | --- |
 | Package | `@tummycrypt/scheduling-kit` |
-| Version | `0.7.2` |
+| Version | `0.7.5` |
 | Description | Backend-agnostic scheduling components with alternative payment support |
 | Node range | `>=20 <25` |
 | Repository | https://github.com/Jesssullivan/scheduling-kit.git |

--- a/docs/generated/release-metadata.md
+++ b/docs/generated/release-metadata.md
@@ -11,9 +11,9 @@ Generated from `package.json`, `MODULE.bazel`, `BUILD.bazel`,
 
 | Surface | Value |
 | --- | --- |
-| package.json version | `0.7.2` |
-| MODULE.bazel version | `0.7.2` |
-| BUILD.bazel npm_package version | `0.7.2` |
+| package.json version | `0.7.5` |
+| MODULE.bazel version | `0.7.5` |
+| BUILD.bazel npm_package version | `0.7.5` |
 | BUILD.bazel package name | `@tummycrypt/scheduling-kit` |
 | .bazelversion | `8.1.1` |
 | pnpm packageManager | `pnpm@9.15.9` |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tummycrypt/scheduling-kit",
-  "version": "0.7.4",
+  "version": "0.7.5",
   "description": "Backend-agnostic scheduling components with alternative payment support",
   "type": "module",
   "packageManager": "pnpm@9.15.9",


### PR DESCRIPTION
## Summary

Bumps `@tummycrypt/scheduling-kit` to `0.7.5` so the DateTimePicker month-navigation reset fix can be released and consumed downstream by MassageIthaca.

## Changes

- Aligns `package.json`, `MODULE.bazel`, and `BUILD.bazel` on version `0.7.5`.
- Regenerates package surface and release metadata docs.

## Validation

- `node scripts/check-release-metadata.mjs`
- `pnpm check`
- `pnpm lint`
- `pnpm test:unit`
- `pnpm test:integration`
- `pnpm build`
- `pnpm exec publint`
- `nix develop . --command bazel test //:test //:typecheck //:pkg`
