### PR TITLE
[codex] fix downstream Bazel package consumption

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,7 +38,7 @@ The package should be reusable across multiple businesses. Avoid app-specific as
 
 ## Current Tracking
 
-As of `2026-04-25`, the active structural work is no longer just downstream
+As of `2026-05-02`, the active structural work is no longer just downstream
 contract cleanup. It is release-authority, artifact-truth, and runner-contract
 convergence.
 
@@ -49,6 +49,7 @@ Active threads:
 - `TIN-165` bazel-registry generation from standalone package truth
 - release, tag, npm, and GitHub release authority cleanup tracked in GitHub
   issue `#73`
+- downstream Bzlmod consumer builds of `//:pkg` from the active registry
 - runner reachability and shared-runner proof before treating package CI as a
   stable public workflow contract
 
@@ -56,10 +57,12 @@ Current operational truth:
 
 - local development should default to `jesssullivan/main`
 - that branch is the current functional release line
-- current package metadata on `main` is `@tummycrypt/scheduling-kit` `0.7.2`
-- as of `2026-04-25`, npm `latest` is `0.7.2`; the matching GitHub release
-  was not present when checked, so keep `#73` open until tag/release authority
-  is reconciled
+- current published package truth is `@tummycrypt/scheduling-kit` `0.7.5`
+  on npm, GitHub Releases, and the active tinyland Bazel registry
+- the `0.7.6` lane fixes downstream Bzlmod `//:pkg` consumption by making the
+  Svelte package build independent of main-workspace-relative `src` paths
+- keep `#73` open until the next package release/tag/registry pass proves the
+  updated Bazel consumer path end to end
 - `tinyland-inc/origin/main` is now a downstream mirror/validation surface,
   not an equally authoritative release surface
 - package metadata, git tags, npm dist-tags, and GitHub releases are separate

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -16,7 +16,8 @@ Subpackage structure:
   //src/testing      - Mock helpers, MSW handlers
 """
 
-load("@aspect_rules_js//js:defs.bzl", "js_library", "js_run_binary")
+load("@aspect_bazel_lib//lib:copy_to_directory.bzl", "copy_to_directory")
+load("@aspect_rules_js//js:defs.bzl", "js_binary", "js_library", "js_run_binary")
 load("@aspect_rules_js//npm:defs.bzl", "npm_package")
 load("@aspect_rules_ts//ts:defs.bzl", "ts_project")
 load("@tummycrypt_scheduling_kit_npm//:defs.bzl", "npm_link_all_packages")
@@ -46,12 +47,23 @@ svelte_kit.svelte_kit_binary(
     visibility = ["//visibility:public"],
 )
 
+js_binary(
+    name = "bazel_svelte_package",
+    entry_point = "scripts/svelte-package-bazel-wrapper.mjs",
+    data = [
+        ":node_modules/@sveltejs/package",
+        ":node_modules/svelte",
+        ":node_modules/typescript",
+    ],
+)
+
 # svelte-check and Vitest both read tsconfig.json, which extends the generated
 # .svelte-kit/tsconfig.json. Mirror the pnpm scripts' required sync step.
 js_run_binary(
     name = "svelte_kit_sync",
     tags = ["manual"],
     tool = ":svelte_kit",
+    chdir = ".",
     srcs = glob([
         "src/**/*.ts",
         "src/**/*.svelte",
@@ -74,22 +86,32 @@ js_run_binary(
 # components, .svelte.ts stores, and plain .ts files in one pass.
 # =============================================================================
 
+SCHEDULING_KIT_PACKAGE_SOURCES = glob(
+    [
+        "src/**/*.ts",
+        "src/**/*.svelte",
+        "src/**/*.svelte.ts",
+    ],
+    exclude = [
+        "src/**/*.test.ts",
+        "src/**/*.spec.ts",
+        "src/tests/**",
+    ],
+)
+
+copy_to_directory(
+    name = "scheduling_kit_src",
+    srcs = SCHEDULING_KIT_PACKAGE_SOURCES,
+    out = "scheduling_kit_src",
+    root_paths = ["src"],
+)
+
 js_run_binary(
     name = "scheduling_kit_build",
     tags = ["manual"],
-    tool = ":svelte_package",
-    srcs = glob(
-        [
-            "src/**/*.ts",
-            "src/**/*.svelte",
-            "src/**/*.svelte.ts",
-        ],
-        exclude = [
-            "src/**/*.test.ts",
-            "src/**/*.spec.ts",
-            "src/tests/**",
-        ],
-    ) + [
+    tool = ":bazel_svelte_package",
+    srcs = [
+        ":scheduling_kit_src",
         "package.json",
         "svelte.config.js",
         "tsconfig.json",
@@ -98,7 +120,7 @@ js_run_binary(
     ],
     args = [
         "-i",
-        "src",
+        "$(execpath :scheduling_kit_src)",
         "-o",
         "dist",
     ],
@@ -127,7 +149,7 @@ npm_package(
     ],
     package = "@tummycrypt/scheduling-kit",
     tags = ["manual"],
-    version = "0.7.5",
+    version = "0.7.6",
     visibility = ["//visibility:public"],
 )
 
@@ -283,6 +305,7 @@ js_run_binary(
     name = "typecheck",
     tags = ["manual"],
     tool = ":svelte_check",
+    chdir = ".",
     srcs = glob(
         [
             "src/**/*.ts",

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -22,7 +22,7 @@ Subpackage targets (finer-grained caching):
 
 module(
     name = "tummycrypt_scheduling_kit",
-    version = "0.7.5",
+    version = "0.7.6",
     compatibility_level = 1,
 )
 

--- a/docs/generated/package-surface.md
+++ b/docs/generated/package-surface.md
@@ -11,7 +11,7 @@ Generated from `package.json` and the current `src/` tree.
 | Field | Value |
 | --- | --- |
 | Package | `@tummycrypt/scheduling-kit` |
-| Version | `0.7.5` |
+| Version | `0.7.6` |
 | Description | Backend-agnostic scheduling components with alternative payment support |
 | Node range | `>=20 <25` |
 | Repository | https://github.com/Jesssullivan/scheduling-kit.git |

--- a/docs/generated/release-metadata.md
+++ b/docs/generated/release-metadata.md
@@ -11,9 +11,9 @@ Generated from `package.json`, `MODULE.bazel`, `BUILD.bazel`,
 
 | Surface | Value |
 | --- | --- |
-| package.json version | `0.7.5` |
-| MODULE.bazel version | `0.7.5` |
-| BUILD.bazel npm_package version | `0.7.5` |
+| package.json version | `0.7.6` |
+| MODULE.bazel version | `0.7.6` |
+| BUILD.bazel npm_package version | `0.7.6` |
 | BUILD.bazel package name | `@tummycrypt/scheduling-kit` |
 | .bazelversion | `8.1.1` |
 | pnpm packageManager | `pnpm@9.15.9` |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tummycrypt/scheduling-kit",
-  "version": "0.7.5",
+  "version": "0.7.6",
   "description": "Backend-agnostic scheduling components with alternative payment support",
   "type": "module",
   "packageManager": "pnpm@9.15.9",

--- a/scripts/svelte-package-bazel-wrapper.mjs
+++ b/scripts/svelte-package-bazel-wrapper.mjs
@@ -1,0 +1,181 @@
+#!/usr/bin/env node
+import { spawnSync } from "node:child_process";
+import {
+  chmodSync,
+  cpSync,
+  existsSync,
+  mkdtempSync,
+  mkdirSync,
+  readdirSync,
+  rmSync,
+  statSync,
+  symlinkSync,
+} from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import process from "node:process";
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const packageRoot = path.resolve(scriptDir, "..");
+const originalCwd = process.cwd();
+
+function resolveExistingPath(value) {
+  if (path.isAbsolute(value)) {
+    return value;
+  }
+
+  const candidates = [
+    path.join(packageRoot, value),
+    value,
+    path.join(originalCwd, value),
+    process.env.JS_BINARY__EXECROOT
+      ? path.join(process.env.JS_BINARY__EXECROOT, value)
+      : undefined,
+    path.resolve(value),
+  ].filter(Boolean);
+
+  return candidates.find((candidate) => existsSync(candidate)) ?? value;
+}
+
+function resolvePackageCli() {
+  const candidates = [
+    path.join(
+      packageRoot,
+      "node_modules",
+      "@sveltejs",
+      "package",
+      "src",
+      "cli.js",
+    ),
+    path.join(
+      originalCwd,
+      "node_modules",
+      "@sveltejs",
+      "package",
+      "src",
+      "cli.js",
+    ),
+    process.env.JS_BINARY__EXECROOT
+      ? path.join(
+          process.env.JS_BINARY__EXECROOT,
+          "node_modules",
+          "@sveltejs",
+          "package",
+          "src",
+          "cli.js",
+        )
+      : undefined,
+  ].filter(Boolean);
+
+  const cli = candidates.find((candidate) => existsSync(candidate));
+  if (!cli) {
+    throw new Error("Unable to locate @sveltejs/package CLI in Bazel runfiles");
+  }
+  return cli;
+}
+
+function linkOrCopy(source, destination, copy = false) {
+  rmSync(destination, { recursive: true, force: true });
+  if (copy) {
+    cpSync(source, destination, { recursive: true });
+    return;
+  }
+  symlinkSync(source, destination);
+}
+
+function makeWritable(target) {
+  const stats = statSync(target);
+  chmodSync(target, stats.isDirectory() ? 0o700 : 0o600);
+
+  if (!stats.isDirectory()) {
+    return;
+  }
+
+  for (const entry of readdirSync(target)) {
+    makeWritable(path.join(target, entry));
+  }
+}
+
+function prepareWritableProject(inputDir) {
+  const tempRoot = mkdtempSync(
+    path.join(os.tmpdir(), "scheduling-kit-package-"),
+  );
+  const workDir = mkdirSync(path.join(tempRoot, "work"), { recursive: true });
+
+  linkOrCopy(inputDir, path.join(workDir, "src"));
+  for (const file of ["package.json", "svelte.config.js", "tsconfig.json"]) {
+    linkOrCopy(resolveExistingPath(file), path.join(workDir, file));
+  }
+
+  const svelteKitDir = resolveExistingPath(".svelte-kit");
+  if (existsSync(svelteKitDir)) {
+    linkOrCopy(svelteKitDir, path.join(workDir, ".svelte-kit"), true);
+    makeWritable(path.join(workDir, ".svelte-kit"));
+  }
+
+  const nodeModulesDir = resolveExistingPath("node_modules");
+  if (existsSync(nodeModulesDir)) {
+    linkOrCopy(nodeModulesDir, path.join(workDir, "node_modules"));
+  }
+
+  return { tempRoot, workDir };
+}
+
+const forwardedArgs = [];
+let resolvedInput;
+let outputDir = "dist";
+for (let index = 0; index < process.argv.length - 2; index += 1) {
+  const arg = process.argv[index + 2];
+
+  if (arg === "-i" || arg === "--input") {
+    resolvedInput = resolveExistingPath(process.argv[index + 3]);
+    forwardedArgs.push(arg, "src");
+    index += 1;
+    continue;
+  }
+
+  if (arg.startsWith("--input=")) {
+    resolvedInput = resolveExistingPath(arg.slice("--input=".length));
+    forwardedArgs.push("--input=src");
+    continue;
+  }
+
+  if (arg === "-o" || arg === "--output") {
+    outputDir = process.argv[index + 3];
+    forwardedArgs.push(arg, path.resolve(originalCwd, outputDir));
+    index += 1;
+    continue;
+  }
+
+  if (arg.startsWith("--output=")) {
+    outputDir = arg.slice("--output=".length);
+    forwardedArgs.push(`--output=${path.resolve(originalCwd, outputDir)}`);
+    continue;
+  }
+
+  forwardedArgs.push(arg);
+}
+
+if (!resolvedInput) {
+  throw new Error("Missing required svelte-package input directory");
+}
+
+const { tempRoot, workDir } = prepareWritableProject(resolvedInput);
+const result = spawnSync(
+  process.execPath,
+  [resolvePackageCli(), ...forwardedArgs],
+  {
+    cwd: workDir,
+    stdio: "inherit",
+    env: process.env,
+  },
+);
+rmSync(tempRoot, { recursive: true, force: true });
+
+if (result.error) {
+  console.error(result.error.message);
+  process.exit(1);
+}
+
+process.exit(result.status ?? 1);


### PR DESCRIPTION
## Summary
- bump `@tummycrypt/scheduling-kit` metadata to `0.7.6`
- make the Bazel `//:pkg` Svelte package action safe when kit is consumed as an external Bzlmod module
- add a wrapper that packages from a declared source tree in a writable temp project instead of relying on main-workspace-relative `src`
- refresh generated package/release docs and AGENTS package-authority truth

## Root Cause
`bazel build @tummycrypt_scheduling_kit//:pkg` from a downstream registry consumer failed because the Svelte package action assumed `src` existed relative to the main workspace/action cwd. After fixing that, the action also needed a writable `.svelte-kit` mirror because external module inputs are read-only inside the sandbox.

## Validation
- `pnpm docs:generate`
- `pnpm check:release-metadata`
- `pnpm exec prettier --check AGENTS.md scripts/svelte-package-bazel-wrapper.mjs`
- `git diff --check`
- `npm exec --yes @bazel/bazelisk -- build //:pkg //:typecheck`
- downstream Bzlmod smoke: temp consumer built `@tummycrypt_scheduling_kit//:pkg` and `@tummycrypt_scheduling_bridge//:pkg` via the local tinyland registry with `--override_module=tummycrypt_scheduling_kit=/private/tmp/scheduling-kit-consumer-bazel`
