### PR TITLE
Harden Venmo redirects and picker lifecycle

### DIFF
--- a/src/payments/venmo.ts
+++ b/src/payments/venmo.ts
@@ -25,7 +25,13 @@ import type {
 
 interface PayPalOrder {
   id: string;
-  status: 'CREATED' | 'SAVED' | 'APPROVED' | 'VOIDED' | 'COMPLETED' | 'PAYER_ACTION_REQUIRED';
+  status:
+    | 'CREATED'
+    | 'SAVED'
+    | 'APPROVED'
+    | 'VOIDED'
+    | 'COMPLETED'
+    | 'PAYER_ACTION_REQUIRED';
   purchase_units: {
     reference_id: string;
     amount: {
@@ -61,10 +67,31 @@ interface PayPalRefund {
 // VENMO ADAPTER IMPLEMENTATION
 // =============================================================================
 
-export const createVenmoAdapter = (config: VenmoAdapterConfig): PaymentAdapter => {
-  const baseUrl = config.environment === 'production'
-    ? 'https://api-m.paypal.com'
-    : 'https://api-m.sandbox.paypal.com';
+const sanitizePayPalRedirectUrl = (url?: string): string | undefined => {
+  const trimmed = url?.trim();
+  if (!trimmed) return undefined;
+
+  try {
+    const parsed = new URL(trimmed);
+    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+      return undefined;
+    }
+
+    return parsed.toString();
+  } catch {
+    return undefined;
+  }
+};
+
+export const createVenmoAdapter = (
+  config: VenmoAdapterConfig,
+): PaymentAdapter => {
+  const baseUrl =
+    config.environment === 'production'
+      ? 'https://api-m.paypal.com'
+      : 'https://api-m.sandbox.paypal.com';
+  const returnUrl = sanitizePayPalRedirectUrl(config.returnUrl);
+  const cancelUrl = sanitizePayPalRedirectUrl(config.cancelUrl);
 
   let accessToken: string | null = null;
   let tokenExpiry: number = 0;
@@ -78,11 +105,13 @@ export const createVenmoAdapter = (config: VenmoAdapterConfig): PaymentAdapter =
       return accessToken;
     }
 
-    const auth = Buffer.from(`${config.clientId}:${config.clientSecret}`).toString('base64');
+    const auth = Buffer.from(
+      `${config.clientId}:${config.clientSecret}`,
+    ).toString('base64');
     const response = await fetch(`${baseUrl}/v1/oauth2/token`, {
       method: 'POST',
       headers: {
-        'Authorization': `Basic ${auth}`,
+        Authorization: `Basic ${auth}`,
         'Content-Type': 'application/x-www-form-urlencoded',
       },
       body: 'grant_type=client_credentials',
@@ -92,7 +121,10 @@ export const createVenmoAdapter = (config: VenmoAdapterConfig): PaymentAdapter =
       throw new Error(`PayPal auth failed: ${response.status}`);
     }
 
-    const data = await response.json() as { access_token: string; expires_in: number };
+    const data = (await response.json()) as {
+      access_token: string;
+      expires_in: number;
+    };
     accessToken = data.access_token;
     tokenExpiry = Date.now() + (data.expires_in - 60) * 1000; // Refresh 1 min early
 
@@ -107,11 +139,11 @@ export const createVenmoAdapter = (config: VenmoAdapterConfig): PaymentAdapter =
     method: string,
     endpoint: string,
     body?: unknown,
-    idempotencyKey?: string
+    idempotencyKey?: string,
   ): Promise<T> => {
     const token = await getAccessToken();
     const headers: Record<string, string> = {
-      'Authorization': `Bearer ${token}`,
+      Authorization: `Bearer ${token}`,
       'Content-Type': 'application/json',
     };
 
@@ -141,16 +173,27 @@ export const createVenmoAdapter = (config: VenmoAdapterConfig): PaymentAdapter =
   // Transformers
   // ---------------------------------------------------------------------------
 
-  const toPaymentIntent = (order: PayPalOrder, requestAmount?: number, requestCurrency?: string): PaymentIntent => ({
+  const toPaymentIntent = (
+    order: PayPalOrder,
+    requestAmount?: number,
+    requestCurrency?: string,
+  ): PaymentIntent => ({
     id: order.id,
     amount: order.purchase_units?.[0]?.amount?.value
       ? Math.round(parseFloat(order.purchase_units[0].amount.value) * 100)
-      : requestAmount ?? 0,
-    currency: order.purchase_units?.[0]?.amount?.currency_code ?? requestCurrency ?? 'USD',
-    status: order.status === 'COMPLETED' ? 'completed'
-      : order.status === 'APPROVED' ? 'processing'
-      : order.status === 'VOIDED' ? 'cancelled'
-      : 'pending',
+      : (requestAmount ?? 0),
+    currency:
+      order.purchase_units?.[0]?.amount?.currency_code ??
+      requestCurrency ??
+      'USD',
+    status:
+      order.status === 'COMPLETED'
+        ? 'completed'
+        : order.status === 'APPROVED'
+          ? 'processing'
+          : order.status === 'VOIDED'
+            ? 'cancelled'
+            : 'pending',
     processor: 'venmo',
     processorTransactionId: order.id,
     createdAt: order.create_time ?? new Date().toISOString(),
@@ -163,8 +206,11 @@ export const createVenmoAdapter = (config: VenmoAdapterConfig): PaymentAdapter =
       success: order.status === 'COMPLETED',
       transactionId: capture?.id ?? order.id,
       processor: 'venmo',
-      amount: Math.round(parseFloat(capture?.amount?.value ?? unitAmount?.value ?? '0') * 100),
-      currency: capture?.amount?.currency_code ?? unitAmount?.currency_code ?? 'USD',
+      amount: Math.round(
+        parseFloat(capture?.amount?.value ?? unitAmount?.value ?? '0') * 100,
+      ),
+      currency:
+        capture?.amount?.currency_code ?? unitAmount?.currency_code ?? 'USD',
       timestamp: new Date().toISOString(),
     };
   };
@@ -180,51 +226,74 @@ export const createVenmoAdapter = (config: VenmoAdapterConfig): PaymentAdapter =
 
     isAvailable: () => Effect.succeed(true),
 
-    createIntent: ({ amount, currency, description, metadata, idempotencyKey }) =>
+    createIntent: ({
+      amount,
+      currency,
+      description,
+      metadata,
+      idempotencyKey,
+    }) =>
       pipe(
         fromPromise(
-          () => request<PayPalOrder>(
-            'POST',
-            '/v2/checkout/orders',
-            {
-              intent: 'CAPTURE',
-              purchase_units: [{
-                reference_id: idempotencyKey,
-                description,
-                amount: {
-                  currency_code: currency,
-                  value: (amount / 100).toFixed(2),
-                },
-                ...(config.payeeEmail ? { payee: { email_address: config.payeeEmail } } : {}),
-                custom_id: metadata ? JSON.stringify(metadata) : undefined,
-              }],
-              payment_source: {
-                venmo: {
-                  experience_context: {
-                    payment_method_preference: 'IMMEDIATE_PAYMENT_REQUIRED',
-                    brand_name: config.brandName ?? 'Business',
-                    shipping_preference: 'NO_SHIPPING',
-                    user_action: 'PAY_NOW',
-                    ...(config.returnUrl ? { return_url: config.returnUrl } : {}),
-                    ...(config.cancelUrl ? { cancel_url: config.cancelUrl } : {}),
+          () =>
+            request<PayPalOrder>(
+              'POST',
+              '/v2/checkout/orders',
+              {
+                intent: 'CAPTURE',
+                purchase_units: [
+                  {
+                    reference_id: idempotencyKey,
+                    description,
+                    amount: {
+                      currency_code: currency,
+                      value: (amount / 100).toFixed(2),
+                    },
+                    ...(config.payeeEmail
+                      ? { payee: { email_address: config.payeeEmail } }
+                      : {}),
+                    custom_id: metadata ? JSON.stringify(metadata) : undefined,
+                  },
+                ],
+                payment_source: {
+                  venmo: {
+                    experience_context: {
+                      payment_method_preference: 'IMMEDIATE_PAYMENT_REQUIRED',
+                      brand_name: config.brandName ?? 'Business',
+                      shipping_preference: 'NO_SHIPPING',
+                      user_action: 'PAY_NOW',
+                      ...(returnUrl ? { return_url: returnUrl } : {}),
+                      ...(cancelUrl ? { cancel_url: cancelUrl } : {}),
+                    },
                   },
                 },
               },
-            },
-            idempotencyKey
-          ),
-          (e) => Errors.payment('CREATE_INTENT_FAILED', String(e), 'venmo', true)
+              idempotencyKey,
+            ),
+          (e) =>
+            Errors.payment('CREATE_INTENT_FAILED', String(e), 'venmo', true),
         ),
-        Effect.map((order) => toPaymentIntent(order, amount, currency))
+        Effect.map((order) => toPaymentIntent(order, amount, currency)),
       ),
 
     capturePayment: (intentId) =>
       pipe(
         fromPromise(
-          () => request<PayPalOrder>('POST', `/v2/checkout/orders/${intentId}/capture`),
-          (e) => Errors.payment('CAPTURE_FAILED', String(e), 'venmo', false, intentId)
+          () =>
+            request<PayPalOrder>(
+              'POST',
+              `/v2/checkout/orders/${intentId}/capture`,
+            ),
+          (e) =>
+            Errors.payment(
+              'CAPTURE_FAILED',
+              String(e),
+              'venmo',
+              false,
+              intentId,
+            ),
         ),
-        Effect.map(toPaymentResult)
+        Effect.map(toPaymentResult),
       ),
 
     cancelIntent: (intentId) =>
@@ -236,15 +305,25 @@ export const createVenmoAdapter = (config: VenmoAdapterConfig): PaymentAdapter =
             // For now, just return success - orders expire automatically
             console.log(`Venmo intent ${intentId} cancellation requested`);
           },
-          (e) => Errors.payment('CANCEL_FAILED', String(e), 'venmo', false, intentId)
-        )
+          (e) =>
+            Errors.payment(
+              'CANCEL_FAILED',
+              String(e),
+              'venmo',
+              false,
+              intentId,
+            ),
+        ),
       ),
 
     refund: ({ transactionId, amount, reason }) =>
       pipe(
         fromPromise(
           async () => {
-            const body: { amount?: { currency_code: string; value: string }; note_to_payer?: string } = {};
+            const body: {
+              amount?: { currency_code: string; value: string };
+              note_to_payer?: string;
+            } = {};
 
             if (amount) {
               body.amount = {
@@ -260,10 +339,17 @@ export const createVenmoAdapter = (config: VenmoAdapterConfig): PaymentAdapter =
             return request<PayPalRefund>(
               'POST',
               `/v2/payments/captures/${transactionId}/refund`,
-              Object.keys(body).length > 0 ? body : undefined
+              Object.keys(body).length > 0 ? body : undefined,
             );
           },
-          (e) => Errors.payment('REFUND_FAILED', String(e), 'venmo', false, transactionId)
+          (e) =>
+            Errors.payment(
+              'REFUND_FAILED',
+              String(e),
+              'venmo',
+              false,
+              transactionId,
+            ),
         ),
         Effect.map((refund) => ({
           success: refund.status === 'COMPLETED',
@@ -272,10 +358,16 @@ export const createVenmoAdapter = (config: VenmoAdapterConfig): PaymentAdapter =
           amount: Math.round(parseFloat(refund.amount.value) * 100),
           currency: refund.amount.currency_code,
           timestamp: refund.create_time,
-        }))
+        })),
       ),
 
-    verifyWebhook: ({ payload, signature, transmissionId, transmissionTime, certUrl }) =>
+    verifyWebhook: ({
+      payload,
+      signature,
+      transmissionId,
+      transmissionTime,
+      certUrl,
+    }) =>
       pipe(
         fromPromise(
           async () => {
@@ -291,13 +383,14 @@ export const createVenmoAdapter = (config: VenmoAdapterConfig): PaymentAdapter =
                 transmission_time: transmissionTime ?? '',
                 webhook_id: config.webhookId,
                 webhook_event: JSON.parse(payload),
-              }
+              },
             );
 
             return response.verification_status === 'SUCCESS';
           },
-          (e) => Errors.payment('WEBHOOK_VERIFY_FAILED', String(e), 'venmo', false)
-        )
+          (e) =>
+            Errors.payment('WEBHOOK_VERIFY_FAILED', String(e), 'venmo', false),
+        ),
       ),
 
     parseWebhook: (payload) =>
@@ -331,7 +424,8 @@ export const createVenmoAdapter = (config: VenmoAdapterConfig): PaymentAdapter =
             raw: event,
           } satisfies PaymentWebhookEvent;
         },
-        catch: (e) => Errors.payment('WEBHOOK_PARSE_FAILED', String(e), 'venmo', false),
+        catch: (e) =>
+          Errors.payment('WEBHOOK_PARSE_FAILED', String(e), 'venmo', false),
       }),
 
     getClientConfig: () => ({

--- a/src/tests/mocks/handlers/paypal.ts
+++ b/src/tests/mocks/handlers/paypal.ts
@@ -34,6 +34,7 @@ interface MockState {
   simulateCaptureFailure: boolean;
   simulateRefundFailure: boolean;
   simulateNetworkDelay: number;
+  lastCreateOrderBody: unknown | null;
 }
 
 const defaultState: MockState = {
@@ -46,6 +47,7 @@ const defaultState: MockState = {
   simulateCaptureFailure: false,
   simulateRefundFailure: false,
   simulateNetworkDelay: 0,
+  lastCreateOrderBody: null,
 };
 
 let state = { ...defaultState };
@@ -64,6 +66,7 @@ export const resetPayPalMockState = () => {
     simulateCaptureFailure: false,
     simulateRefundFailure: false,
     simulateNetworkDelay: 0,
+    lastCreateOrderBody: null,
   };
 };
 
@@ -84,7 +87,7 @@ export const getPayPalMockState = () => ({ ...state });
 // =============================================================================
 
 const withMiddleware = async (
-  handler: () => Response | Promise<Response>
+  handler: () => Response | Promise<Response>,
 ): Promise<Response> => {
   // Simulate network delay
   if (state.simulateNetworkDelay > 0) {
@@ -99,7 +102,7 @@ const withMiddleware = async (
         name: 'INTERNAL_SERVICE_ERROR',
         message: 'An internal service error occurred.',
       },
-      { status: 500 }
+      { status: 500 },
     );
   }
 
@@ -118,8 +121,11 @@ const getAccessToken = http.post(
     return withMiddleware(() => {
       if (!authHeader || !authHeader.startsWith('Basic ')) {
         return HttpResponse.json(
-          { error: 'invalid_client', error_description: 'Client authentication failed' },
-          { status: 401 }
+          {
+            error: 'invalid_client',
+            error_description: 'Client authentication failed',
+          },
+          { status: 401 },
         );
       }
 
@@ -132,111 +138,118 @@ const getAccessToken = http.post(
         nonce: `mock-nonce-${Date.now()}`,
       });
     });
-  }
+  },
 );
 
 // =============================================================================
 // ORDERS (Payment Intents)
 // =============================================================================
 
-const createOrder = http.post(`${PAYPAL_BASE_URL}/v2/checkout/orders`, async ({ request }) => {
-  const body = (await request.json()) as {
-    intent: 'CAPTURE' | 'AUTHORIZE';
-    purchase_units: Array<{
-      amount: {
-        currency_code: string;
-        value: string;
+const createOrder = http.post(
+  `${PAYPAL_BASE_URL}/v2/checkout/orders`,
+  async ({ request }) => {
+    const body = (await request.json()) as {
+      intent: 'CAPTURE' | 'AUTHORIZE';
+      purchase_units: Array<{
+        amount: {
+          currency_code: string;
+          value: string;
+        };
+        description?: string;
+      }>;
+      payment_source?: {
+        venmo?: object;
+        paypal?: object;
       };
-      description?: string;
-    }>;
-    payment_source?: {
-      venmo?: object;
-      paypal?: object;
-    };
-  };
-
-  return withMiddleware(() => {
-    const orderId = `${state.nextOrderId++}MOCK`;
-    const purchaseUnit = body.purchase_units[0];
-
-    const order: MockOrder = {
-      id: orderId,
-      status: 'CREATED',
-      amount: purchaseUnit.amount,
-      paymentSource: body.payment_source?.venmo ? 'venmo' : 'paypal',
-      createTime: new Date().toISOString(),
     };
 
-    state.orders.set(orderId, order);
+    return withMiddleware(() => {
+      state.lastCreateOrderBody = body;
+      const orderId = `${state.nextOrderId++}MOCK`;
+      const purchaseUnit = body.purchase_units[0];
 
-    return HttpResponse.json({
-      id: orderId,
-      status: order.status,
-      purchase_units: [
-        {
-          reference_id: orderId,
-          amount: order.amount,
-        },
-      ],
-      create_time: order.createTime,
-      links: [
-        {
-          href: `${PAYPAL_BASE_URL}/v2/checkout/orders/${orderId}`,
-          rel: 'self',
-          method: 'GET',
-        },
-        {
-          href: `${PAYPAL_BASE_URL}/v2/checkout/orders/${orderId}/capture`,
-          rel: 'capture',
-          method: 'POST',
-        },
-        {
-          href: `https://www.sandbox.paypal.com/checkoutnow?token=${orderId}`,
-          rel: 'payer-action',
-          method: 'GET',
-        },
-      ],
+      const order: MockOrder = {
+        id: orderId,
+        status: 'CREATED',
+        amount: purchaseUnit.amount,
+        paymentSource: body.payment_source?.venmo ? 'venmo' : 'paypal',
+        createTime: new Date().toISOString(),
+      };
+
+      state.orders.set(orderId, order);
+
+      return HttpResponse.json({
+        id: orderId,
+        status: order.status,
+        purchase_units: [
+          {
+            reference_id: orderId,
+            amount: order.amount,
+          },
+        ],
+        create_time: order.createTime,
+        links: [
+          {
+            href: `${PAYPAL_BASE_URL}/v2/checkout/orders/${orderId}`,
+            rel: 'self',
+            method: 'GET',
+          },
+          {
+            href: `${PAYPAL_BASE_URL}/v2/checkout/orders/${orderId}/capture`,
+            rel: 'capture',
+            method: 'POST',
+          },
+          {
+            href: `https://www.sandbox.paypal.com/checkoutnow?token=${orderId}`,
+            rel: 'payer-action',
+            method: 'GET',
+          },
+        ],
+      });
     });
-  });
-});
+  },
+);
 
-const getOrder = http.get(`${PAYPAL_BASE_URL}/v2/checkout/orders/:id`, async ({ params }) => {
-  const id = params.id as string;
+const getOrder = http.get(
+  `${PAYPAL_BASE_URL}/v2/checkout/orders/:id`,
+  async ({ params }) => {
+    const id = params.id as string;
 
-  return withMiddleware(() => {
-    const order = state.orders.get(id);
-    if (!order) {
-      return HttpResponse.json(
-        { name: 'RESOURCE_NOT_FOUND', message: `Order ${id} not found` },
-        { status: 404 }
-      );
-    }
+    return withMiddleware(() => {
+      const order = state.orders.get(id);
+      if (!order) {
+        return HttpResponse.json(
+          { name: 'RESOURCE_NOT_FOUND', message: `Order ${id} not found` },
+          { status: 404 },
+        );
+      }
 
-    return HttpResponse.json({
-      id: order.id,
-      status: order.status,
-      create_time: order.createTime,
-      purchase_units: [
-        {
-          amount: order.amount,
-          payments: order.captureId
-            ? {
-                captures: [
-                  {
-                    id: order.captureId,
-                    status: 'COMPLETED',
-                    amount: order.amount,
-                    final_capture: true,
-                    create_time: new Date().toISOString(),
-                  },
-                ],
-              }
-            : undefined,
-        },
-      ],
+      return HttpResponse.json({
+        id: order.id,
+        status: order.status,
+        create_time: order.createTime,
+        purchase_units: [
+          {
+            amount: order.amount,
+            payments: order.captureId
+              ? {
+                  captures: [
+                    {
+                      id: order.captureId,
+                      status: 'COMPLETED',
+                      amount: order.amount,
+                      final_capture: true,
+                      create_time: new Date().toISOString(),
+                    },
+                  ],
+                }
+              : undefined,
+          },
+        ],
+      });
     });
-  });
-});
+  },
+);
 
 const captureOrder = http.post(
   `${PAYPAL_BASE_URL}/v2/checkout/orders/:id/capture`,
@@ -252,7 +265,7 @@ const captureOrder = http.post(
             name: 'INTERNAL_SERVICE_ERROR',
             message: 'An internal error occurred while capturing payment.',
           },
-          { status: 500 }
+          { status: 500 },
         );
       }
 
@@ -260,7 +273,7 @@ const captureOrder = http.post(
       if (!order) {
         return HttpResponse.json(
           { name: 'RESOURCE_NOT_FOUND', message: `Order ${id} not found` },
-          { status: 404 }
+          { status: 404 },
         );
       }
 
@@ -277,7 +290,7 @@ const captureOrder = http.post(
               },
             ],
           },
-          { status: 422 }
+          { status: 422 },
         );
       }
 
@@ -315,7 +328,7 @@ const captureOrder = http.post(
         },
       });
     });
-  }
+  },
 );
 
 // =============================================================================
@@ -327,7 +340,10 @@ const createRefund = http.post(
   async ({ params, request }) => {
     const captureId = params.captureId as string;
     // Body may be empty for full refunds
-    let body: { amount?: { currency_code: string; value: string }; note_to_payer?: string } = {};
+    let body: {
+      amount?: { currency_code: string; value: string };
+      note_to_payer?: string;
+    } = {};
     try {
       const text = await request.text();
       if (text) {
@@ -346,14 +362,16 @@ const createRefund = http.post(
             name: 'INTERNAL_SERVICE_ERROR',
             message: 'An internal error occurred while processing the refund.',
           },
-          { status: 500 }
+          { status: 500 },
         );
       }
 
       // Find order with this capture (check both captures map and orders)
       let order = state.captures.get(captureId);
       if (!order) {
-        order = Array.from(state.orders.values()).find((o) => o.captureId === captureId);
+        order = Array.from(state.orders.values()).find(
+          (o) => o.captureId === captureId,
+        );
       }
 
       // For testing, create a synthetic order if not found (allows direct refund tests)
@@ -385,7 +403,7 @@ const createRefund = http.post(
         ],
       });
     });
-  }
+  },
 );
 
 // =============================================================================
@@ -416,7 +434,7 @@ const verifyWebhook = http.post(
       ) {
         return HttpResponse.json(
           { name: 'INVALID_REQUEST', message: 'Missing required fields' },
-          { status: 400 }
+          { status: 400 },
         );
       }
 
@@ -427,7 +445,7 @@ const verifyWebhook = http.post(
         verification_status: isValid ? 'SUCCESS' : 'FAILURE',
       });
     });
-  }
+  },
 );
 
 // =============================================================================
@@ -443,7 +461,7 @@ export const paypalUnavailableHandler = http.all(`${PAYPAL_BASE_URL}/*`, () => {
       name: 'SERVICE_UNAVAILABLE',
       message: 'Service temporarily unavailable. Please try again later.',
     },
-    { status: 503 }
+    { status: 503 },
   );
 });
 
@@ -456,7 +474,7 @@ export const paypalRateLimitHandler = http.all(`${PAYPAL_BASE_URL}/*`, () => {
       name: 'RATE_LIMIT_REACHED',
       message: 'Too many requests. Retry after 60 seconds.',
     },
-    { status: 429, headers: { 'Retry-After': '60' } }
+    { status: 429, headers: { 'Retry-After': '60' } },
   );
 });
 

--- a/src/tests/unit/payments/venmo.test.ts
+++ b/src/tests/unit/payments/venmo.test.ts
@@ -3,12 +3,17 @@
  * Validates PayPal API integration for Venmo payments
  */
 
+import fc from 'fast-check';
 import { describe, it, expect, beforeAll, afterEach, afterAll } from 'vitest';
 import { Effect } from 'effect';
 import { createVenmoAdapter } from '../../../payments/venmo.js';
 import type { PaymentAdapter } from '../../../payments/types.js';
 import { server } from '../../mocks/server.js';
-import { resetPayPalMockState, configurePayPalMock } from '../../mocks/handlers/index.js';
+import {
+  resetPayPalMockState,
+  configurePayPalMock,
+  getPayPalMockState,
+} from '../../mocks/handlers/index.js';
 import { expectSuccess, expectFailureTag } from '../../helpers/effect.js';
 
 // MSW server lifecycle
@@ -53,7 +58,7 @@ describe('Venmo Adapter', () => {
           currency: 'USD',
           description: 'TMD 60min massage',
           idempotencyKey: 'test-idempotency-key',
-        })
+        }),
       );
 
       expect(intent.id).toBeDefined();
@@ -71,7 +76,7 @@ describe('Venmo Adapter', () => {
           description: 'Massage session',
           metadata: { bookingId: '12345', serviceId: '67890' },
           idempotencyKey: 'test-meta-key',
-        })
+        }),
       );
 
       expect(intent.id).toBeDefined();
@@ -88,7 +93,7 @@ describe('Venmo Adapter', () => {
           description: 'Test payment',
           idempotencyKey: 'fail-key',
         }),
-        'PaymentError'
+        'PaymentError',
       );
 
       expect(error._tag).toBe('PaymentError');
@@ -97,6 +102,141 @@ describe('Venmo Adapter', () => {
         expect(error.processor).toBe('venmo');
         expect(error.recoverable).toBe(true);
       }
+    });
+
+    it('sends absolute return and cancel URLs to PayPal when configured', async () => {
+      const redirectAdapter = createVenmoAdapter({
+        type: 'venmo',
+        clientId: 'test-client-id',
+        clientSecret: 'test-client-secret',
+        environment: 'sandbox',
+        webhookId: 'test-webhook-id',
+        returnUrl:
+          'https://massageithaca-scheduling-bridge.taila4c78d.ts.net/booking',
+        cancelUrl:
+          'https://massageithaca-scheduling-bridge.taila4c78d.ts.net/booking',
+      });
+
+      await expectSuccess(
+        redirectAdapter.createIntent({
+          amount: 15500,
+          currency: 'USD',
+          description: 'TMD 1st Consultation & Session',
+          idempotencyKey: 'absolute-redirects',
+        }),
+      );
+
+      const body = getPayPalMockState().lastCreateOrderBody as {
+        payment_source?: {
+          venmo?: {
+            experience_context?: {
+              return_url?: string;
+              cancel_url?: string;
+            };
+          };
+        };
+      };
+      const context = body.payment_source?.venmo?.experience_context;
+
+      expect(context?.return_url).toBe(
+        'https://massageithaca-scheduling-bridge.taila4c78d.ts.net/booking',
+      );
+      expect(context?.cancel_url).toBe(
+        'https://massageithaca-scheduling-bridge.taila4c78d.ts.net/booking',
+      );
+    });
+
+    it('omits malformed or relative return and cancel URLs before PayPal sees them', async () => {
+      const redirectAdapter = createVenmoAdapter({
+        type: 'venmo',
+        clientId: 'test-client-id',
+        clientSecret: 'test-client-secret',
+        environment: 'sandbox',
+        webhookId: 'test-webhook-id',
+        returnUrl: '/booking',
+        cancelUrl: 'javascript:alert(1)',
+      });
+
+      await expectSuccess(
+        redirectAdapter.createIntent({
+          amount: 15500,
+          currency: 'USD',
+          description: 'TMD 1st Consultation & Session',
+          idempotencyKey: 'invalid-redirects',
+        }),
+      );
+
+      const body = getPayPalMockState().lastCreateOrderBody as {
+        payment_source?: {
+          venmo?: {
+            experience_context?: {
+              return_url?: string;
+              cancel_url?: string;
+            };
+          };
+        };
+      };
+      const context = body.payment_source?.venmo?.experience_context;
+
+      expect(context).not.toHaveProperty('return_url');
+      expect(context).not.toHaveProperty('cancel_url');
+    });
+
+    it('property: non-http(s) redirect URLs are never forwarded to PayPal', async () => {
+      await fc.assert(
+        fc.asyncProperty(
+          fc.string({ minLength: 1, maxLength: 80 }).filter((value) => {
+            const trimmed = value.trim();
+            if (trimmed.length === 0) return false;
+
+            try {
+              const parsed = new URL(trimmed);
+              return (
+                parsed.protocol !== 'http:' && parsed.protocol !== 'https:'
+              );
+            } catch {
+              return true;
+            }
+          }),
+          async (invalidUrl) => {
+            resetPayPalMockState();
+            const redirectAdapter = createVenmoAdapter({
+              type: 'venmo',
+              clientId: 'test-client-id',
+              clientSecret: 'test-client-secret',
+              environment: 'sandbox',
+              webhookId: 'test-webhook-id',
+              returnUrl: invalidUrl,
+              cancelUrl: invalidUrl,
+            });
+
+            await expectSuccess(
+              redirectAdapter.createIntent({
+                amount: 15500,
+                currency: 'USD',
+                description: 'TMD 1st Consultation & Session',
+                idempotencyKey: `invalid-redirect-${encodeURIComponent(invalidUrl).slice(0, 32)}`,
+              }),
+            );
+
+            const body = getPayPalMockState().lastCreateOrderBody as {
+              payment_source?: {
+                venmo?: {
+                  experience_context?: {
+                    return_url?: string;
+                    cancel_url?: string;
+                  };
+                };
+              };
+            };
+            const context = body.payment_source?.venmo?.experience_context;
+
+            expect(context).not.toHaveProperty('return_url');
+            expect(context).not.toHaveProperty('cancel_url');
+          },
+        ),
+        { numRuns: 25 },
+      );
     });
   });
 
@@ -109,7 +249,7 @@ describe('Venmo Adapter', () => {
           currency: 'USD',
           description: 'Test capture',
           idempotencyKey: 'capture-test-key',
-        })
+        }),
       );
 
       // Then capture it
@@ -128,7 +268,7 @@ describe('Venmo Adapter', () => {
 
       const error = await expectFailureTag(
         adapter.capturePayment('order_to_fail'),
-        'PaymentError'
+        'PaymentError',
       );
 
       expect(error._tag).toBe('PaymentError');
@@ -152,7 +292,7 @@ describe('Venmo Adapter', () => {
         adapter.refund({
           transactionId: 'capture_12345',
           reason: 'Customer requested cancellation',
-        })
+        }),
       );
 
       expect(refund.success).toBe(true);
@@ -168,7 +308,7 @@ describe('Venmo Adapter', () => {
           transactionId: 'capture_67890',
           amount: 10000, // $100 partial refund
           reason: 'Partial service',
-        })
+        }),
       );
 
       expect(refund.success).toBe(true);
@@ -183,7 +323,7 @@ describe('Venmo Adapter', () => {
           transactionId: 'capture_fail',
           reason: 'Test failure',
         }),
-        'PaymentError'
+        'PaymentError',
       );
 
       expect(error._tag).toBe('PaymentError');
@@ -280,7 +420,7 @@ describe('Venmo Adapter', () => {
     it('handles invalid JSON payload', async () => {
       const error = await expectFailureTag(
         adapter.parseWebhook('invalid json'),
-        'PaymentError'
+        'PaymentError',
       );
 
       expect(error._tag).toBe('PaymentError');
@@ -314,7 +454,7 @@ describe('Venmo Adapter Transformers', () => {
           currency: 'USD',
           description: 'Minimum amount',
           idempotencyKey: 'min-amount-key',
-        })
+        }),
       );
 
       // Mock returns what we sent, verify it's correct
@@ -348,7 +488,7 @@ describe('Venmo Adapter Transformers', () => {
           currency: 'USD',
           description: 'Status test',
           idempotencyKey: 'status-test-key',
-        })
+        }),
       );
 
       expect(intent.status).toBe('pending');

--- a/tests/e2e/date-time-picker.test.ts
+++ b/tests/e2e/date-time-picker.test.ts
@@ -1,0 +1,54 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/svelte';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import DateTimePicker from '../../src/components/DateTimePicker.svelte';
+
+describe('DateTimePicker component', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(2026, 4, 1, 12, 0, 0, 0));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('clears stale selected date and slot UI when the user advances months', async () => {
+    const onMonthChange = vi.fn();
+
+    render(DateTimePicker, {
+      props: {
+        availableDates: [{ date: '2026-05-30', slots: 1 }],
+        availableSlots: [
+          {
+            datetime: '2026-05-30T18:00:00.000Z',
+            available: true,
+          },
+        ],
+        selectedDate: '2026-05-30',
+        selectedTime: '2026-05-30T18:00:00.000Z',
+        timezone: 'America/New_York',
+        onMonthChange,
+      },
+    });
+
+    expect(screen.getByText('May 2026')).toBeInTheDocument();
+    expect(
+      screen.getByText('Available times for Saturday, May 30'),
+    ).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '2:00 PM' })).toBeInTheDocument();
+
+    await fireEvent.click(screen.getByRole('button', { name: 'Next month' }));
+
+    await waitFor(() => {
+      expect(screen.getByText('June 2026')).toBeInTheDocument();
+      expect(
+        screen.queryByText('Available times for Saturday, May 30'),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByRole('button', { name: '2:00 PM' }),
+      ).not.toBeInTheDocument();
+    });
+
+    expect(onMonthChange).toHaveBeenCalledWith('2026-06-01', '2026-06-30');
+  });
+});


### PR DESCRIPTION
## Summary
- sanitize Venmo/PayPal return and cancel URLs so only absolute http(s) URLs reach PayPal
- record PayPal create-order request bodies in the MSW mock for adapter contract assertions
- add Venmo unit/PBT coverage for absolute and invalid redirect URLs
- add a mounted DateTimePicker regression test that month navigation clears stale selected-date/slot UI

## Validation
- `pnpm install --frozen-lockfile`
- `pnpm exec svelte-kit sync`
- `pnpm exec vitest run src/tests/unit/payments/venmo.test.ts`
- `pnpm exec vitest run --config vitest.component.config.ts tests/e2e/date-time-picker.test.ts`
- `pnpm test:all`
- `pnpm run check`
- `pnpm lint`
- `git diff --check`