### PR TITLE
[codex] Bump scheduling-kit to 0.7.7

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -149,7 +149,7 @@ npm_package(
     ],
     package = "@tummycrypt/scheduling-kit",
     tags = ["manual"],
-    version = "0.7.6",
+    version = "0.7.7",
     visibility = ["//visibility:public"],
 )
 

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -22,7 +22,7 @@ Subpackage targets (finer-grained caching):
 
 module(
     name = "tummycrypt_scheduling_kit",
-    version = "0.7.6",
+    version = "0.7.7",
     compatibility_level = 1,
 )
 

--- a/docs/generated/package-surface.md
+++ b/docs/generated/package-surface.md
@@ -11,7 +11,7 @@ Generated from `package.json` and the current `src/` tree.
 | Field | Value |
 | --- | --- |
 | Package | `@tummycrypt/scheduling-kit` |
-| Version | `0.7.6` |
+| Version | `0.7.7` |
 | Description | Backend-agnostic scheduling components with alternative payment support |
 | Node range | `>=20 <25` |
 | Repository | https://github.com/Jesssullivan/scheduling-kit.git |

--- a/docs/generated/release-metadata.md
+++ b/docs/generated/release-metadata.md
@@ -11,9 +11,9 @@ Generated from `package.json`, `MODULE.bazel`, `BUILD.bazel`,
 
 | Surface | Value |
 | --- | --- |
-| package.json version | `0.7.6` |
-| MODULE.bazel version | `0.7.6` |
-| BUILD.bazel npm_package version | `0.7.6` |
+| package.json version | `0.7.7` |
+| MODULE.bazel version | `0.7.7` |
+| BUILD.bazel npm_package version | `0.7.7` |
 | BUILD.bazel package name | `@tummycrypt/scheduling-kit` |
 | .bazelversion | `8.1.1` |
 | pnpm packageManager | `pnpm@9.15.9` |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tummycrypt/scheduling-kit",
-  "version": "0.7.6",
+  "version": "0.7.7",
   "description": "Backend-agnostic scheduling components with alternative payment support",
   "type": "module",
   "packageManager": "pnpm@9.15.9",


### PR DESCRIPTION
## Summary

- bumps `@tummycrypt/scheduling-kit` release metadata from `0.7.6` to `0.7.7`
- aligns `package.json`, `MODULE.bazel`, `BUILD.bazel`, and generated release docs
- prepares a patch release for the merged Venmo redirect and DateTimePicker lifecycle fixes

## Validation

- `pnpm check:release-metadata`
- `pnpm package && pnpm check:package`

## Release Boundary

This PR does not publish npm artifacts. Publishing still requires the explicit release workflow / GitHub Release path after merge.