### PR TITLE
Decouple HomegrownAdapter schema authority

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,11 +57,14 @@ Current operational truth:
 
 - local development should default to `jesssullivan/main`
 - that branch is the current functional release line
-- current published package truth is `@tummycrypt/scheduling-kit` `0.7.6`
+- current published package truth is `@tummycrypt/scheduling-kit` `0.7.7`
   on npm, GitHub Releases, GitHub Packages, and the active tinyland Bazel
   registry
-- `0.7.6` fixes downstream Bzlmod `//:pkg` consumption by making the Svelte
+- `0.7.7` fixes downstream Bzlmod `//:pkg` consumption by making the Svelte
   package build independent of main-workspace-relative `src` paths
+- the next release candidate should not reintroduce a mandatory
+  `tinyland-auth-pg` dependency for HomegrownAdapter; use explicit schema
+  injection and keep any auth-pg fallback optional
 - `#73` remains open only for explicit historical release-surface
   backfill/documentation around older `0.7.1` / `0.7.2` gaps; the current
   release/tag/npm/Bazel/registry authority path is healthy

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -149,7 +149,7 @@ npm_package(
     ],
     package = "@tummycrypt/scheduling-kit",
     tags = ["manual"],
-    version = "0.7.7",
+    version = "0.7.8",
     visibility = ["//visibility:public"],
 )
 
@@ -189,7 +189,6 @@ ts_project(
         ":node_modules",
         ":node_modules/effect",
         ":node_modules/drizzle-orm",
-        ":node_modules/@tummycrypt/tinyland-auth-pg",
     ],
     visibility = ["//visibility:public"],
 )

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -22,7 +22,7 @@ Subpackage targets (finer-grained caching):
 
 module(
     name = "tummycrypt_scheduling_kit",
-    version = "0.7.7",
+    version = "0.7.8",
     compatibility_level = 1,
 )
 
@@ -42,14 +42,6 @@ bazel_dep(name = "rules_nodejs", version = "6.7.3")
 bazel_dep(name = "aspect_rules_js", version = "2.9.1")
 bazel_dep(name = "aspect_rules_ts", version = "3.8.4")
 bazel_dep(name = "aspect_rules_swc", version = "2.6.1")
-
-# =============================================================================
-# Inter-module dependencies (tinyland building blocks)
-# =============================================================================
-
-# HomegrownAdapter uses @tummycrypt/tinyland-auth-pg's drizzle schema and
-# storage primitives. The bazel_dep edge mirrors the npm dependency.
-bazel_dep(name = "tummycrypt_tinyland_auth_pg", version = "0.2.2")
 
 # =============================================================================
 # Node.js toolchain

--- a/README.md
+++ b/README.md
@@ -119,7 +119,11 @@ import {
 
 // Create a scheduling adapter
 const scheduler = createHomegrownAdapter({
-  db: drizzleInstance,
+  withDb: async (fn) => fn(drizzleInstance),
+  schemas: {
+    content: contentSchema,
+    booking: bookingSchema,
+  },
   timezone: 'America/New_York',
 });
 
@@ -170,16 +174,32 @@ Direct PostgreSQL adapter using Drizzle ORM. Replaces third-party scheduling
 APIs entirely.
 
 ```typescript
-import { createHomegrownAdapter } from '@tummycrypt/scheduling-kit/adapters';
+import {
+  createHomegrownAdapter,
+  type HomegrownAdapterSchemas,
+} from '@tummycrypt/scheduling-kit/adapters';
+import * as contentSchema from '@your-org/business-pg/content-schema';
+import * as bookingSchema from '@your-org/business-pg/booking-schema';
+
+const schemas: HomegrownAdapterSchemas = {
+  content: contentSchema,
+  booking: bookingSchema,
+};
 
 const adapter = createHomegrownAdapter({
-  db: drizzleInstance,
+  withDb: async (fn) => fn(drizzleInstance),
+  schemas,
   timezone: 'America/New_York',
 });
 
 // 16 methods: getServices, getAvailability, getSlots, book, cancel,
 // reschedule, ...
 ```
+
+`schemas` is the preferred boundary for reusable adopters. It lets the
+homegrown backend use whichever Drizzle schema package owns business and
+booking tables. Existing adopters may still omit it if they intentionally use
+the legacy optional `@tummycrypt/tinyland-auth-pg` schema exports.
 
 ### AcuityAdapter
 

--- a/README.md
+++ b/README.md
@@ -178,8 +178,8 @@ import {
   createHomegrownAdapter,
   type HomegrownAdapterSchemas,
 } from '@tummycrypt/scheduling-kit/adapters';
-import * as contentSchema from '@your-org/business-pg/content-schema';
-import * as bookingSchema from '@your-org/business-pg/booking-schema';
+import * as contentSchema from '@tummycrypt/tinyland-business-pg/content-schema';
+import * as bookingSchema from '@tummycrypt/tinyland-business-pg/booking-schema';
 
 const schemas: HomegrownAdapterSchemas = {
   content: contentSchema,

--- a/docs/generated/package-surface.md
+++ b/docs/generated/package-surface.md
@@ -11,7 +11,7 @@ Generated from `package.json` and the current `src/` tree.
 | Field | Value |
 | --- | --- |
 | Package | `@tummycrypt/scheduling-kit` |
-| Version | `0.7.7` |
+| Version | `0.7.8` |
 | Description | Backend-agnostic scheduling components with alternative payment support |
 | Node range | `>=20 <25` |
 | Repository | https://github.com/Jesssullivan/scheduling-kit.git |

--- a/docs/generated/release-metadata.md
+++ b/docs/generated/release-metadata.md
@@ -11,9 +11,9 @@ Generated from `package.json`, `MODULE.bazel`, `BUILD.bazel`,
 
 | Surface | Value |
 | --- | --- |
-| package.json version | `0.7.7` |
-| MODULE.bazel version | `0.7.7` |
-| BUILD.bazel npm_package version | `0.7.7` |
+| package.json version | `0.7.8` |
+| MODULE.bazel version | `0.7.8` |
+| BUILD.bazel npm_package version | `0.7.8` |
 | BUILD.bazel package name | `@tummycrypt/scheduling-kit` |
 | .bazelversion | `8.1.1` |
 | pnpm packageManager | `pnpm@9.15.9` |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tummycrypt/scheduling-kit",
-  "version": "0.7.7",
+  "version": "0.7.8",
   "description": "Backend-agnostic scheduling components with alternative payment support",
   "type": "module",
   "packageManager": "pnpm@9.15.9",
@@ -87,11 +87,15 @@
     "traces:refresh": "npx tsx scripts/refresh-traces.ts"
   },
   "peerDependencies": {
+    "@tummycrypt/tinyland-auth-pg": "^0.2.1",
     "@skeletonlabs/skeleton": "^4.0.0",
     "@skeletonlabs/skeleton-svelte": "^4.0.0",
     "svelte": "^5.0.0"
   },
   "peerDependenciesMeta": {
+    "@tummycrypt/tinyland-auth-pg": {
+      "optional": true
+    },
     "@skeletonlabs/skeleton": {
       "optional": true
     },
@@ -100,7 +104,6 @@
     }
   },
   "dependencies": {
-    "@tummycrypt/tinyland-auth-pg": "^0.2.1",
     "drizzle-orm": "0.39.3",
     "effect": "^3.19.14",
     "zod": "^4.3.5"
@@ -112,6 +115,7 @@
     "@sveltejs/vite-plugin-svelte": "^6.0.0",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/svelte": "^5.3.1",
+    "@tummycrypt/tinyland-auth-pg": "^0.2.4",
     "@types/node": "^20.0.0",
     "@typescript-eslint/parser": "^8.58.2",
     "@vitest/coverage-v8": "^4.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,9 +14,6 @@ importers:
       '@skeletonlabs/skeleton-svelte':
         specifier: ^4.0.0
         version: 4.13.0(svelte@5.54.1)
-      '@tummycrypt/tinyland-auth-pg':
-        specifier: ^0.2.1
-        version: 0.2.1(@tummycrypt/tinyland-auth@0.2.0(@sveltejs/kit@2.55.0(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.54.1)(vite@6.4.1(@types/node@20.19.37)))(svelte@5.54.1)(typescript@5.9.3)(vite@6.4.1(@types/node@20.19.37)))(svelte@5.54.1))(@types/pg@8.11.6)
       drizzle-orm:
         specifier: 0.39.3
         version: 0.39.3(@neondatabase/serverless@0.10.4)(@types/pg@8.11.6)(pg@8.20.0)
@@ -45,6 +42,9 @@ importers:
       '@testing-library/svelte':
         specifier: ^5.3.1
         version: 5.3.1(svelte@5.54.1)(vite@6.4.1(@types/node@20.19.37))(vitest@4.1.0(@types/node@20.19.37)(jsdom@28.1.0)(msw@2.7.0(@types/node@20.19.37)(typescript@5.9.3))(vite@6.4.1(@types/node@20.19.37)))
+      '@tummycrypt/tinyland-auth-pg':
+        specifier: ^0.2.4
+        version: 0.2.4(@tummycrypt/tinyland-auth@0.2.0(@sveltejs/kit@2.55.0(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.54.1)(vite@6.4.1(@types/node@20.19.37)))(svelte@5.54.1)(typescript@5.9.3)(vite@6.4.1(@types/node@20.19.37)))(svelte@5.54.1))(@types/pg@8.11.6)
       '@types/node':
         specifier: ^20.0.0
         version: 20.19.37
@@ -738,10 +738,10 @@ packages:
       vitest:
         optional: true
 
-  '@tummycrypt/tinyland-auth-pg@0.2.1':
-    resolution: {integrity: sha512-4xzcLu64OmaHKsaVOgXoSJ6oaIrp1+tgDoNvKcqIXuELCaaT14ifXaU00RWQjDJDQOx4iIiPgvAoL8P2pi2j8w==}
+  '@tummycrypt/tinyland-auth-pg@0.2.4':
+    resolution: {integrity: sha512-Z4n8R4iD7+CWqmwEDDu919jIWwiW66Oq/48YSrdKQ+rqO61+ZiPfnEA7G++aMaVU3G96DkK46+KNtbOY4ZffKw==}
     peerDependencies:
-      '@tummycrypt/tinyland-auth': ^0.2.0
+      '@tummycrypt/tinyland-auth': ^0.2.0 || ^0.3.0
 
   '@tummycrypt/tinyland-auth@0.2.0':
     resolution: {integrity: sha512-XL3UfRyBNeuILZw56r5iw+WtUAZ0l7f5zjbDsHGOeR5O0D0rpRZjUMSTqNoHWYjU4NkKl07YKmDphXsTwC6dLA==}
@@ -2865,7 +2865,7 @@ snapshots:
       vite: 6.4.1(@types/node@20.19.37)
       vitest: 4.1.0(@types/node@20.19.37)(jsdom@28.1.0)(msw@2.7.0(@types/node@20.19.37)(typescript@5.9.3))(vite@6.4.1(@types/node@20.19.37))
 
-  '@tummycrypt/tinyland-auth-pg@0.2.1(@tummycrypt/tinyland-auth@0.2.0(@sveltejs/kit@2.55.0(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.54.1)(vite@6.4.1(@types/node@20.19.37)))(svelte@5.54.1)(typescript@5.9.3)(vite@6.4.1(@types/node@20.19.37)))(svelte@5.54.1))(@types/pg@8.11.6)':
+  '@tummycrypt/tinyland-auth-pg@0.2.4(@tummycrypt/tinyland-auth@0.2.0(@sveltejs/kit@2.55.0(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.54.1)(vite@6.4.1(@types/node@20.19.37)))(svelte@5.54.1)(typescript@5.9.3)(vite@6.4.1(@types/node@20.19.37)))(svelte@5.54.1))(@types/pg@8.11.6)':
     dependencies:
       '@neondatabase/serverless': 0.10.4
       '@tummycrypt/tinyland-auth': 0.2.0(@sveltejs/kit@2.55.0(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.54.1)(vite@6.4.1(@types/node@20.19.37)))(svelte@5.54.1)(typescript@5.9.3)(vite@6.4.1(@types/node@20.19.37)))(svelte@5.54.1)

--- a/src/adapters/__tests__/homegrown-adapter.test.ts
+++ b/src/adapters/__tests__/homegrown-adapter.test.ts
@@ -16,7 +16,10 @@
 
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { Effect } from "effect";
-import { createHomegrownAdapter } from "../homegrown.js";
+import {
+  createHomegrownAdapter,
+  type HomegrownAdapterConfig,
+} from "../homegrown.js";
 
 // ---------------------------------------------------------------------------
 // Mock schemas — minimal shape matching what Drizzle ORM tables expose
@@ -51,20 +54,23 @@ const mockSlotReservationsTable = {
 };
 const mockClientsTable = { id: "id", email: "email" };
 
-// Mock dynamic imports for schema modules
-vi.mock("@tummycrypt/tinyland-auth-pg/content-schema", () => ({
-  services: mockServicesTable,
-  practitioners: mockPractitionersTable,
-  businessHours: mockBusinessHoursTable,
-}));
+const testSchemas = {
+  content: {
+    services: mockServicesTable,
+    practitioners: mockPractitionersTable,
+    businessHours: mockBusinessHoursTable,
+  },
+  booking: {
+    bookings: mockBookingsTable,
+    timeBlocks: mockTimeBlocksTable,
+    slotReservations: mockSlotReservationsTable,
+    clients: mockClientsTable,
+    businessHoursOverrides: mockBusinessHoursOverridesTable,
+  },
+};
 
-vi.mock("@tummycrypt/tinyland-auth-pg/booking-schema", () => ({
-  bookings: mockBookingsTable,
-  timeBlocks: mockTimeBlocksTable,
-  slotReservations: mockSlotReservationsTable,
-  clients: mockClientsTable,
-  businessHoursOverrides: mockBusinessHoursOverridesTable,
-}));
+const createAdapter = (config: HomegrownAdapterConfig) =>
+  createHomegrownAdapter({ schemas: testSchemas, ...config });
 
 // Mock drizzle-orm operators — return identity functions for where-clause building
 vi.mock("drizzle-orm", () => ({
@@ -260,19 +266,19 @@ const TEST_CLIENT: {
 describe("HomegrownAdapter", () => {
   describe("creation and configuration", () => {
     it('creates an adapter with name "homegrown"', () => {
-      const adapter = createHomegrownAdapter({ getDb: async () => ({}) });
+      const adapter = createAdapter({ getDb: async () => ({}) });
       expect(adapter.name).toBe("homegrown");
     });
 
     it("creates an adapter with a scoped database executor only", () => {
-      const adapter = createHomegrownAdapter({
+      const adapter = createAdapter({
         withDb: async (fn) => fn({}),
       });
       expect(adapter.name).toBe("homegrown");
     });
 
     it("throws immediately when no database accessor is configured", () => {
-      expect(() => createHomegrownAdapter({})).toThrow(
+      expect(() => createAdapter({})).toThrow(
         "HomegrownAdapter requires either getDb or withDb",
       );
     });
@@ -283,7 +289,7 @@ describe("HomegrownAdapter", () => {
       const getDb = vi.fn(async () => mockDb);
       const withDb = vi.fn(async (fn) => fn(mockDb));
 
-      const adapter = createHomegrownAdapter({ getDb, withDb });
+      const adapter = createAdapter({ getDb, withDb });
       const result = await Effect.runPromise(adapter.getServices());
 
       expect(result).toHaveLength(1);
@@ -292,7 +298,7 @@ describe("HomegrownAdapter", () => {
     });
 
     it("exposes all 16+1 SchedulingAdapter methods", () => {
-      const adapter = createHomegrownAdapter({ getDb: async () => ({}) });
+      const adapter = createAdapter({ getDb: async () => ({}) });
       const methods = [
         "getServices",
         "getService",
@@ -318,7 +324,7 @@ describe("HomegrownAdapter", () => {
     });
 
     it("accepts custom configuration", () => {
-      const adapter = createHomegrownAdapter({
+      const adapter = createAdapter({
         getDb: async () => ({}),
         timezone: "America/Chicago",
         slotInterval: 15,
@@ -340,7 +346,7 @@ describe("HomegrownAdapter", () => {
       // orderBy terminal returns the service rows
       mockDb._terminals.orderBy.mockResolvedValue([SERVICE_ROW]);
 
-      const adapter = createHomegrownAdapter({ getDb: async () => mockDb });
+      const adapter = createAdapter({ getDb: async () => mockDb });
       const result = await Effect.runPromise(adapter.getServices());
 
       expect(result).toEqual([
@@ -361,7 +367,7 @@ describe("HomegrownAdapter", () => {
       const mockDb = createMockDb();
       mockDb._terminals.orderBy.mockResolvedValue([]);
 
-      const adapter = createHomegrownAdapter({ getDb: async () => mockDb });
+      const adapter = createAdapter({ getDb: async () => mockDb });
       const result = await Effect.runPromise(adapter.getServices());
 
       expect(result).toEqual([]);
@@ -373,7 +379,7 @@ describe("HomegrownAdapter", () => {
         { ...SERVICE_ROW, description: null, category: null },
       ]);
 
-      const adapter = createHomegrownAdapter({ getDb: async () => mockDb });
+      const adapter = createAdapter({ getDb: async () => mockDb });
       const result = await Effect.runPromise(adapter.getServices());
 
       expect(result[0].description).toBeUndefined();
@@ -392,7 +398,7 @@ describe("HomegrownAdapter", () => {
         }),
       });
 
-      const adapter = createHomegrownAdapter({ getDb: async () => mockDb });
+      const adapter = createAdapter({ getDb: async () => mockDb });
       const result = await Effect.runPromiseExit(adapter.getServices());
 
       expect(result._tag).toBe("Failure");
@@ -402,7 +408,7 @@ describe("HomegrownAdapter", () => {
   describe("getService", () => {
     it("resolves service by UUID", async () => {
       const mockDb = createMockDb({ select: [SERVICE_ROW] });
-      const adapter = createHomegrownAdapter({ getDb: async () => mockDb });
+      const adapter = createAdapter({ getDb: async () => mockDb });
 
       const result = await Effect.runPromise(
         adapter.getService("a1b2c3d4-e5f6-7890-abcd-ef1234567890"),
@@ -416,7 +422,7 @@ describe("HomegrownAdapter", () => {
 
     it("resolves service by acuityId (non-UUID string)", async () => {
       const mockDb = createMockDb({ select: [SERVICE_ROW] });
-      const adapter = createHomegrownAdapter({ getDb: async () => mockDb });
+      const adapter = createAdapter({ getDb: async () => mockDb });
 
       const result = await Effect.runPromise(adapter.getService("12345"));
 
@@ -427,7 +433,7 @@ describe("HomegrownAdapter", () => {
       const mockDb = createMockDb({ select: [] });
       mockDb._terminals.limit.mockResolvedValue([]);
 
-      const adapter = createHomegrownAdapter({ getDb: async () => mockDb });
+      const adapter = createAdapter({ getDb: async () => mockDb });
       const result = await Effect.runPromiseExit(
         adapter.getService("nonexistent"),
       );
@@ -443,7 +449,7 @@ describe("HomegrownAdapter", () => {
   describe("getProviders", () => {
     it("returns the default practitioner as a Provider", async () => {
       const mockDb = createMockDb({ select: [PRACTITIONER_ROW] });
-      const adapter = createHomegrownAdapter({ getDb: async () => mockDb });
+      const adapter = createAdapter({ getDb: async () => mockDb });
 
       const result = await Effect.runPromise(adapter.getProviders());
 
@@ -462,7 +468,7 @@ describe("HomegrownAdapter", () => {
       const mockDb = createMockDb({ select: [] });
       mockDb._terminals.limit.mockResolvedValue([]);
 
-      const adapter = createHomegrownAdapter({ getDb: async () => mockDb });
+      const adapter = createAdapter({ getDb: async () => mockDb });
       const result = await Effect.runPromise(adapter.getProviders());
 
       expect(result).toEqual([]);
@@ -470,7 +476,7 @@ describe("HomegrownAdapter", () => {
 
     it("uses custom timezone from config", async () => {
       const mockDb = createMockDb({ select: [PRACTITIONER_ROW] });
-      const adapter = createHomegrownAdapter({
+      const adapter = createAdapter({
         getDb: async () => mockDb,
         timezone: "America/Chicago",
       });
@@ -483,7 +489,7 @@ describe("HomegrownAdapter", () => {
   describe("getProvider", () => {
     it("returns a specific provider by ID", async () => {
       const mockDb = createMockDb({ select: [PRACTITIONER_ROW] });
-      const adapter = createHomegrownAdapter({ getDb: async () => mockDb });
+      const adapter = createAdapter({ getDb: async () => mockDb });
 
       const result = await Effect.runPromise(
         adapter.getProvider("prac-uuid-1"),
@@ -497,7 +503,7 @@ describe("HomegrownAdapter", () => {
       const mockDb = createMockDb({ select: [] });
       mockDb._terminals.limit.mockResolvedValue([]);
 
-      const adapter = createHomegrownAdapter({ getDb: async () => mockDb });
+      const adapter = createAdapter({ getDb: async () => mockDb });
       const result = await Effect.runPromiseExit(
         adapter.getProvider("nonexistent"),
       );
@@ -509,7 +515,7 @@ describe("HomegrownAdapter", () => {
   describe("getProvidersForService", () => {
     it("delegates to getProviders (solo practice)", async () => {
       const mockDb = createMockDb({ select: [PRACTITIONER_ROW] });
-      const adapter = createHomegrownAdapter({ getDb: async () => mockDb });
+      const adapter = createAdapter({ getDb: async () => mockDb });
 
       const result = await Effect.runPromise(
         adapter.getProvidersForService("any-service"),
@@ -527,7 +533,7 @@ describe("HomegrownAdapter", () => {
   describe("createReservation", () => {
     it("inserts a reservation and returns SlotReservation", async () => {
       const mockDb = createMockDb({ insert: [RESERVATION_ROW] });
-      const adapter = createHomegrownAdapter({ getDb: async () => mockDb });
+      const adapter = createAdapter({ getDb: async () => mockDb });
 
       const result = await Effect.runPromise(
         adapter.createReservation({
@@ -550,7 +556,7 @@ describe("HomegrownAdapter", () => {
 
     it("defaults expiration to 10 minutes when not specified", async () => {
       const mockDb = createMockDb({ insert: [RESERVATION_ROW] });
-      const adapter = createHomegrownAdapter({ getDb: async () => mockDb });
+      const adapter = createAdapter({ getDb: async () => mockDb });
 
       // The adapter calculates expiresAt internally — we just verify the
       // insert goes through and returns the DB row
@@ -569,7 +575,7 @@ describe("HomegrownAdapter", () => {
   describe("releaseReservation", () => {
     it("sets releasedAt on the reservation", async () => {
       const mockDb = createMockDb();
-      const adapter = createHomegrownAdapter({ getDb: async () => mockDb });
+      const adapter = createAdapter({ getDb: async () => mockDb });
 
       // releaseReservation returns void — just ensure no throw
       await expect(
@@ -587,7 +593,7 @@ describe("HomegrownAdapter", () => {
   describe("findOrCreateClient", () => {
     it("returns existing client with isNew=false and updates info", async () => {
       const mockDb = createMockDb({ select: [CLIENT_ROW] });
-      const adapter = createHomegrownAdapter({ getDb: async () => mockDb });
+      const adapter = createAdapter({ getDb: async () => mockDb });
 
       const result = await Effect.runPromise(
         adapter.findOrCreateClient(TEST_CLIENT),
@@ -607,7 +613,7 @@ describe("HomegrownAdapter", () => {
         { id: "client-uuid-new" },
       ]);
 
-      const adapter = createHomegrownAdapter({ getDb: async () => mockDb });
+      const adapter = createAdapter({ getDb: async () => mockDb });
 
       const result = await Effect.runPromise(
         adapter.findOrCreateClient(TEST_CLIENT),
@@ -621,7 +627,7 @@ describe("HomegrownAdapter", () => {
   describe("getClientByEmail", () => {
     it("returns ClientInfo when client exists", async () => {
       const mockDb = createMockDb({ select: [CLIENT_ROW] });
-      const adapter = createHomegrownAdapter({ getDb: async () => mockDb });
+      const adapter = createAdapter({ getDb: async () => mockDb });
 
       const result = await Effect.runPromise(
         adapter.getClientByEmail("alice@example.com"),
@@ -640,7 +646,7 @@ describe("HomegrownAdapter", () => {
       const mockDb = createMockDb({ select: [] });
       mockDb._terminals.limit.mockResolvedValue([]);
 
-      const adapter = createHomegrownAdapter({ getDb: async () => mockDb });
+      const adapter = createAdapter({ getDb: async () => mockDb });
 
       const result = await Effect.runPromise(
         adapter.getClientByEmail("nobody@example.com"),
@@ -653,7 +659,7 @@ describe("HomegrownAdapter", () => {
       const mockDb = createMockDb({
         select: [{ ...CLIENT_ROW, phone: null, notes: null }],
       });
-      const adapter = createHomegrownAdapter({ getDb: async () => mockDb });
+      const adapter = createAdapter({ getDb: async () => mockDb });
 
       const result = await Effect.runPromise(
         adapter.getClientByEmail("alice@example.com"),
@@ -671,7 +677,7 @@ describe("HomegrownAdapter", () => {
   describe("cancelBooking", () => {
     it("sets status to cancelled", async () => {
       const mockDb = createMockDb();
-      const adapter = createHomegrownAdapter({ getDb: async () => mockDb });
+      const adapter = createAdapter({ getDb: async () => mockDb });
 
       await expect(
         Effect.runPromise(
@@ -684,7 +690,7 @@ describe("HomegrownAdapter", () => {
 
     it("works without a reason", async () => {
       const mockDb = createMockDb();
-      const adapter = createHomegrownAdapter({ getDb: async () => mockDb });
+      const adapter = createAdapter({ getDb: async () => mockDb });
 
       await expect(
         Effect.runPromise(adapter.cancelBooking("booking-uuid-1")),
@@ -714,7 +720,7 @@ describe("HomegrownAdapter", () => {
         ],
       );
 
-      const adapter = createHomegrownAdapter({ getDb: async () => mockDb });
+      const adapter = createAdapter({ getDb: async () => mockDb });
       const result = await Effect.runPromise(
         adapter.createBooking({
           serviceId: "svc-uuid-1",
@@ -738,7 +744,7 @@ describe("HomegrownAdapter", () => {
         [], // resolveService returns empty
       ]);
 
-      const adapter = createHomegrownAdapter({ getDb: async () => mockDb });
+      const adapter = createAdapter({ getDb: async () => mockDb });
       const exit = await Effect.runPromiseExit(
         adapter.createBooking({
           serviceId: "nonexistent",
@@ -764,7 +770,7 @@ describe("HomegrownAdapter", () => {
         ],
       );
 
-      const adapter = createHomegrownAdapter({ getDb: async () => mockDb });
+      const adapter = createAdapter({ getDb: async () => mockDb });
       const result = await Effect.runPromise(
         adapter.createBooking({
           serviceId: "svc-uuid-1",
@@ -792,7 +798,7 @@ describe("HomegrownAdapter", () => {
         [PRACTITIONER_ROW], // practitioner
       ]);
 
-      const adapter = createHomegrownAdapter({ getDb: async () => mockDb });
+      const adapter = createAdapter({ getDb: async () => mockDb });
       const result = await Effect.runPromise(
         adapter.getBooking("booking-uuid-1"),
       );
@@ -812,7 +818,7 @@ describe("HomegrownAdapter", () => {
         [], // booking not found
       ]);
 
-      const adapter = createHomegrownAdapter({ getDb: async () => mockDb });
+      const adapter = createAdapter({ getDb: async () => mockDb });
       const exit = await Effect.runPromiseExit(
         adapter.getBooking("nonexistent"),
       );
@@ -827,7 +833,7 @@ describe("HomegrownAdapter", () => {
         [CLIENT_ROW], // client
       ]);
 
-      const adapter = createHomegrownAdapter({ getDb: async () => mockDb });
+      const adapter = createAdapter({ getDb: async () => mockDb });
       const result = await Effect.runPromise(
         adapter.getBooking("booking-uuid-1"),
       );
@@ -859,7 +865,7 @@ describe("HomegrownAdapter", () => {
         [PRACTITIONER_ROW],
       ]);
 
-      const adapter = createHomegrownAdapter({ getDb: async () => mockDb });
+      const adapter = createAdapter({ getDb: async () => mockDb });
       const result = await Effect.runPromise(
         adapter.rescheduleBooking("booking-uuid-1", "2026-04-21T10:00:00.000Z"),
       );
@@ -873,7 +879,7 @@ describe("HomegrownAdapter", () => {
         [], // existing booking not found
       ]);
 
-      const adapter = createHomegrownAdapter({ getDb: async () => mockDb });
+      const adapter = createAdapter({ getDb: async () => mockDb });
       const exit = await Effect.runPromiseExit(
         adapter.rescheduleBooking("nonexistent", "2026-04-21T10:00:00.000Z"),
       );
@@ -897,7 +903,7 @@ describe("HomegrownAdapter", () => {
       ]);
       const withDb = vi.fn(async (fn) => fn(mockDb));
 
-      const adapter = createHomegrownAdapter({ withDb });
+      const adapter = createAdapter({ withDb });
       const result = await Effect.runPromise(
         adapter.rescheduleBooking("booking-uuid-1", "2026-04-21T10:00:00.000Z"),
       );
@@ -913,7 +919,7 @@ describe("HomegrownAdapter", () => {
 
   describe("Effect error wrapping", () => {
     it("wraps DB connection errors as InfrastructureError", async () => {
-      const adapter = createHomegrownAdapter({
+      const adapter = createAdapter({
         getDb: async () => {
           throw new Error("ECONNREFUSED");
         },
@@ -924,7 +930,7 @@ describe("HomegrownAdapter", () => {
     });
 
     it("wraps non-Error throws as InfrastructureError with UNKNOWN code", async () => {
-      const adapter = createHomegrownAdapter({
+      const adapter = createAdapter({
         getDb: async () => {
           throw "string error";
         },

--- a/src/adapters/homegrown.ts
+++ b/src/adapters/homegrown.ts
@@ -40,6 +40,29 @@ import {
 // Config
 // ---------------------------------------------------------------------------
 
+export interface HomegrownContentSchemaTables {
+  services: any;
+  practitioners: any;
+  businessHours: any;
+}
+
+export interface HomegrownBookingSchemaTables {
+  bookings: any;
+  timeBlocks: any;
+  slotReservations: any;
+  clients: any;
+  businessHoursOverrides: any;
+}
+
+export interface HomegrownAdapterSchemas {
+  content: HomegrownContentSchemaTables;
+  booking: HomegrownBookingSchemaTables;
+}
+
+export type HomegrownAdapterSchemaProvider =
+  | HomegrownAdapterSchemas
+  | (() => Promise<HomegrownAdapterSchemas>);
+
 export interface HomegrownAdapterConfig {
   /** Drizzle database instance (lazy, to avoid import-time DB connection). */
   getDb?: () => Promise<any>;
@@ -52,6 +75,14 @@ export interface HomegrownAdapterConfig {
    * awaits the callback result before leaving the scope.
    */
   withDb?: <T>(fn: (db: any) => Promise<T>) => Promise<T>;
+  /**
+   * Drizzle table modules used by the homegrown scheduling backend.
+   *
+   * Pass this to keep scheduling-kit independent from any specific schema
+   * package. If omitted, the adapter falls back to the legacy
+   * @tummycrypt/tinyland-auth-pg schema exports for existing adopters.
+   */
+  schemas?: HomegrownAdapterSchemaProvider;
   /** Timezone for availability calculations */
   timezone?: string;
   /** Slot interval in minutes */
@@ -80,10 +111,56 @@ export const createHomegrownAdapter = (
   const buffer = config.bufferMinutes ?? 0;
   const minAdvance = config.minAdvanceHours ?? 2;
   const practitionerHandle = config.defaultPractitionerHandle ?? "jen";
+  let legacySchemasPromise: Promise<HomegrownAdapterSchemas> | undefined;
 
   const withDb = async <T>(fn: (db: any) => Promise<T>): Promise<T> => {
     if (config.withDb) return config.withDb(fn);
     return fn(await config.getDb!());
+  };
+
+  const loadLegacyAuthPgSchemas =
+    async (): Promise<HomegrownAdapterSchemas> => {
+      const importOptional = (specifier: string): Promise<any> =>
+        import(specifier);
+
+      try {
+        const [content, booking] = await Promise.all([
+          importOptional("@tummycrypt/tinyland-auth-pg/content-schema"),
+          importOptional("@tummycrypt/tinyland-auth-pg/booking-schema"),
+        ]);
+
+        return {
+          content: {
+            services: content.services,
+            practitioners: content.practitioners,
+            businessHours: content.businessHours,
+          },
+          booking: {
+            bookings: booking.bookings,
+            timeBlocks: booking.timeBlocks,
+            slotReservations: booking.slotReservations,
+            clients: booking.clients,
+            businessHoursOverrides: booking.businessHoursOverrides,
+          },
+        };
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        throw new Error(
+          `HomegrownAdapter could not load legacy @tummycrypt/tinyland-auth-pg schemas. Pass config.schemas to use a dedicated schema package. Cause: ${message}`,
+        );
+      }
+    };
+
+  const loadSchemas = async (): Promise<HomegrownAdapterSchemas> => {
+    if (typeof config.schemas === "function") {
+      return config.schemas();
+    }
+    if (config.schemas) {
+      return config.schemas;
+    }
+
+    legacySchemasPromise ??= loadLegacyAuthPgSchemas();
+    return legacySchemasPromise;
   };
 
   // ---------------------------------------------------------------------------
@@ -104,8 +181,7 @@ export const createHomegrownAdapter = (
 
   /** Resolve a service by UUID or acuityId */
   const resolveService = async (serviceId: string): Promise<any> => {
-    const { services: servicesTable } =
-      await import("@tummycrypt/tinyland-auth-pg/content-schema");
+    const { services: servicesTable } = (await loadSchemas()).content;
     const { eq, or } = await import("drizzle-orm");
 
     // UUID regex — only compare against UUID column if input looks like one
@@ -134,8 +210,7 @@ export const createHomegrownAdapter = (
 
   /** Load business hours as a Map<dayOfWeek, HoursWindow> */
   const loadHoursMap = async (): Promise<Map<number, HoursWindow>> => {
-    const { businessHours } =
-      await import("@tummycrypt/tinyland-auth-pg/content-schema");
+    const { businessHours } = (await loadSchemas()).content;
     const { asc } = await import("drizzle-orm");
     return withDb(async (d) => {
       const rows = await d
@@ -155,8 +230,7 @@ export const createHomegrownAdapter = (
     startDate: string,
     endDate: string,
   ): Promise<HoursOverride[]> => {
-    const { businessHoursOverrides } =
-      await import("@tummycrypt/tinyland-auth-pg/booking-schema");
+    const { businessHoursOverrides } = (await loadSchemas()).booking;
     const { gte, lte, and } = await import("drizzle-orm");
     return withDb(async (d) => {
       const rows = await d
@@ -185,7 +259,7 @@ export const createHomegrownAdapter = (
       bookings: bookingsTable,
       timeBlocks,
       slotReservations,
-    } = await import("@tummycrypt/tinyland-auth-pg/booking-schema");
+    } = (await loadSchemas()).booking;
     const { gte, lte, and, ne, isNull, or, gt } = await import("drizzle-orm");
 
     const startIso = `${startDate}T00:00:00Z`;
@@ -265,8 +339,7 @@ export const createHomegrownAdapter = (
 
   /** Get the default practitioner */
   const getDefaultPractitioner = async (): Promise<any> => {
-    const { practitioners } =
-      await import("@tummycrypt/tinyland-auth-pg/content-schema");
+    const { practitioners } = (await loadSchemas()).content;
     const { eq } = await import("drizzle-orm");
     return withDb(async (d) => {
       const [row] = await d
@@ -282,10 +355,9 @@ export const createHomegrownAdapter = (
     d: any,
     bookingId: string,
   ): Promise<Booking> => {
-    const { bookings: bookingsTable, clients: clientsTable } =
-      await import("@tummycrypt/tinyland-auth-pg/booking-schema");
-    const { services: servicesTable, practitioners } =
-      await import("@tummycrypt/tinyland-auth-pg/content-schema");
+    const { content, booking } = await loadSchemas();
+    const { bookings: bookingsTable, clients: clientsTable } = booking;
+    const { services: servicesTable, practitioners } = content;
     const { eq } = await import("drizzle-orm");
 
     const [row] = await d
@@ -354,8 +426,7 @@ export const createHomegrownAdapter = (
 
     getServices: () =>
       fromAsync(async () => {
-        const { services: servicesTable } =
-          await import("@tummycrypt/tinyland-auth-pg/content-schema");
+        const { services: servicesTable } = (await loadSchemas()).content;
         const { asc, eq } = await import("drizzle-orm");
         const rows = await withDb<any[]>((d) =>
           d
@@ -416,8 +487,7 @@ export const createHomegrownAdapter = (
 
     getProvider: (providerId: string) =>
       fromAsync(async () => {
-        const { practitioners } =
-          await import("@tummycrypt/tinyland-auth-pg/content-schema");
+        const { practitioners } = (await loadSchemas()).content;
         const { eq } = await import("drizzle-orm");
         const [row] = await withDb<any[]>((d) =>
           d
@@ -540,8 +610,7 @@ export const createHomegrownAdapter = (
 
     createReservation: (params) =>
       fromAsync(async () => {
-        const { slotReservations } =
-          await import("@tummycrypt/tinyland-auth-pg/booking-schema");
+        const { slotReservations } = (await loadSchemas()).booking;
         const expirationMinutes = params.expirationMinutes ?? 10;
         const expiresAt = new Date(
           Date.now() + expirationMinutes * 60_000,
@@ -569,8 +638,7 @@ export const createHomegrownAdapter = (
 
     releaseReservation: (reservationId: string) =>
       fromAsync(async () => {
-        const { slotReservations } =
-          await import("@tummycrypt/tinyland-auth-pg/booking-schema");
+        const { slotReservations } = (await loadSchemas()).booking;
         const { eq } = await import("drizzle-orm");
         await withDb((d) =>
           d
@@ -584,8 +652,7 @@ export const createHomegrownAdapter = (
 
     createBooking: (request: BookingRequest) =>
       fromAsync(async () => {
-        const { bookings: bookingsTable } =
-          await import("@tummycrypt/tinyland-auth-pg/booking-schema");
+        const { bookings: bookingsTable } = (await loadSchemas()).booking;
 
         // Resolve service (by UUID or acuityId)
         const svc = await resolveService(request.serviceId);
@@ -652,8 +719,7 @@ export const createHomegrownAdapter = (
     ) =>
       Effect.flatMap(adapter.createBooking(request), (booking) =>
         fromAsync(async () => {
-          const { bookings: bookingsTable } =
-            await import("@tummycrypt/tinyland-auth-pg/booking-schema");
+          const { bookings: bookingsTable } = (await loadSchemas()).booking;
           const { eq } = await import("drizzle-orm");
 
           await withDb((d) =>
@@ -682,8 +748,7 @@ export const createHomegrownAdapter = (
 
     cancelBooking: (bookingId: string, reason?: string) =>
       fromAsync(async () => {
-        const { bookings: bookingsTable } =
-          await import("@tummycrypt/tinyland-auth-pg/booking-schema");
+        const { bookings: bookingsTable } = (await loadSchemas()).booking;
         const { eq } = await import("drizzle-orm");
 
         await withDb((d) =>
@@ -701,8 +766,7 @@ export const createHomegrownAdapter = (
 
     rescheduleBooking: (bookingId: string, newDatetime: string) =>
       fromAsync(async () => {
-        const { bookings: bookingsTable } =
-          await import("@tummycrypt/tinyland-auth-pg/booking-schema");
+        const { bookings: bookingsTable } = (await loadSchemas()).booking;
         const { eq } = await import("drizzle-orm");
 
         return withDb(async (d) => {
@@ -734,8 +798,7 @@ export const createHomegrownAdapter = (
 
     findOrCreateClient: (client: ClientInfo) =>
       fromAsync(async () => {
-        const { clients: clientsTable } =
-          await import("@tummycrypt/tinyland-auth-pg/booking-schema");
+        const { clients: clientsTable } = (await loadSchemas()).booking;
         const { eq } = await import("drizzle-orm");
         return withDb(async (d) => {
           // Try to find existing
@@ -779,8 +842,7 @@ export const createHomegrownAdapter = (
 
     getClientByEmail: (email: string) =>
       fromAsync(async () => {
-        const { clients: clientsTable } =
-          await import("@tummycrypt/tinyland-auth-pg/booking-schema");
+        const { clients: clientsTable } = (await loadSchemas()).booking;
         const { eq } = await import("drizzle-orm");
         const [row] = await withDb<any[]>((d) =>
           d

--- a/src/adapters/index.ts
+++ b/src/adapters/index.ts
@@ -16,6 +16,10 @@ export { createCalComAdapter } from './calcom.js';
 export {
   createHomegrownAdapter,
   type HomegrownAdapterConfig,
+  type HomegrownAdapterSchemas,
+  type HomegrownAdapterSchemaProvider,
+  type HomegrownBookingSchemaTables,
+  type HomegrownContentSchemaTables,
 } from './homegrown.js';
 
 // Availability Engine (pure functions)


### PR DESCRIPTION
## Summary

- add explicit HomegrownAdapter schema injection for business/content and booking Drizzle tables
- keep legacy auth-pg schema loading as an optional compatibility fallback
- remove the mandatory `tummycrypt_tinyland_auth_pg` Bzlmod edge and move `@tummycrypt/tinyland-auth-pg` out of published dependencies
- bump release metadata to `0.7.8` and refresh generated docs
- document `@tummycrypt/tinyland-business-pg` as the intended dedicated schema package consumer

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm check:release-metadata`
- `pnpm docs:check` via `nix develop`
- `pnpm check`
- `pnpm lint`
- `pnpm test:unit`
- `pnpm test:integration`
- `pnpm build`
- `pnpm check:package`
- `nix develop --command bazel mod graph` shows no `tummycrypt_tinyland_auth_pg` edge
- `nix develop --command bazel build //:pkg`
- `git diff --check`

## Boundary

This is the scheduling-kit-side schema authority boundary. It does not add a hard dependency on the new business schema package, and it is not an RBE proof. The companion `tinyland-inc/tinyland-business-pg` authority surface now exists separately for content/booking Drizzle tables.