### PR TITLE
Rename reservations to advisory soft holds

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -149,7 +149,7 @@ npm_package(
     ],
     package = "@tummycrypt/scheduling-kit",
     tags = ["manual"],
-    version = "0.7.8",
+    version = "0.8.0",
     visibility = ["//visibility:public"],
 )
 

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -22,7 +22,7 @@ Subpackage targets (finer-grained caching):
 
 module(
     name = "tummycrypt_scheduling_kit",
-    version = "0.7.8",
+    version = "0.8.0",
     compatibility_level = 1,
 )
 

--- a/docs/generated/package-surface.md
+++ b/docs/generated/package-surface.md
@@ -11,7 +11,7 @@ Generated from `package.json` and the current `src/` tree.
 | Field | Value |
 | --- | --- |
 | Package | `@tummycrypt/scheduling-kit` |
-| Version | `0.7.8` |
+| Version | `0.8.0` |
 | Description | Backend-agnostic scheduling components with alternative payment support |
 | Node range | `>=20 <25` |
 | Repository | https://github.com/Jesssullivan/scheduling-kit.git |

--- a/docs/generated/release-metadata.md
+++ b/docs/generated/release-metadata.md
@@ -11,9 +11,9 @@ Generated from `package.json`, `MODULE.bazel`, `BUILD.bazel`,
 
 | Surface | Value |
 | --- | --- |
-| package.json version | `0.7.8` |
-| MODULE.bazel version | `0.7.8` |
-| BUILD.bazel npm_package version | `0.7.8` |
+| package.json version | `0.8.0` |
+| MODULE.bazel version | `0.8.0` |
+| BUILD.bazel npm_package version | `0.8.0` |
 | BUILD.bazel package name | `@tummycrypt/scheduling-kit` |
 | .bazelversion | `8.1.1` |
 | pnpm packageManager | `pnpm@9.15.9` |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tummycrypt/scheduling-kit",
-  "version": "0.7.8",
+  "version": "0.8.0",
   "description": "Backend-agnostic scheduling components with alternative payment support",
   "type": "module",
   "packageManager": "pnpm@9.15.9",

--- a/src/adapters/__tests__/homegrown-adapter.test.ts
+++ b/src/adapters/__tests__/homegrown-adapter.test.ts
@@ -308,8 +308,8 @@ describe("HomegrownAdapter", () => {
         "getAvailableDates",
         "getAvailableSlots",
         "checkSlotAvailability",
-        "createReservation",
-        "releaseReservation",
+        "softHoldSlot",
+        "releaseSoftHold",
         "createBooking",
         "createBookingWithPaymentRef",
         "getBooking",
@@ -530,13 +530,13 @@ describe("HomegrownAdapter", () => {
   // Reservations
   // -------------------------------------------------------------------------
 
-  describe("createReservation", () => {
-    it("inserts a reservation and returns SlotReservation", async () => {
+  describe("softHoldSlot", () => {
+    it("inserts an advisory soft hold and returns SlotSoftHold", async () => {
       const mockDb = createMockDb({ insert: [RESERVATION_ROW] });
       const adapter = createAdapter({ getDb: async () => mockDb });
 
       const result = await Effect.runPromise(
-        adapter.createReservation({
+        adapter.softHoldSlot({
           serviceId: "svc-uuid-1",
           providerId: "prac-uuid-1",
           datetime: "2026-04-20T14:00:00.000Z",
@@ -561,7 +561,7 @@ describe("HomegrownAdapter", () => {
       // The adapter calculates expiresAt internally — we just verify the
       // insert goes through and returns the DB row
       const result = await Effect.runPromise(
-        adapter.createReservation({
+        adapter.softHoldSlot({
           serviceId: "svc-uuid-1",
           datetime: "2026-04-20T14:00:00.000Z",
           duration: 60,
@@ -572,14 +572,14 @@ describe("HomegrownAdapter", () => {
     });
   });
 
-  describe("releaseReservation", () => {
-    it("sets releasedAt on the reservation", async () => {
+  describe("releaseSoftHold", () => {
+    it("sets releasedAt on the soft hold", async () => {
       const mockDb = createMockDb();
       const adapter = createAdapter({ getDb: async () => mockDb });
 
-      // releaseReservation returns void — just ensure no throw
+      // releaseSoftHold returns void — just ensure no throw
       await expect(
-        Effect.runPromise(adapter.releaseReservation("res-uuid-1")),
+        Effect.runPromise(adapter.releaseSoftHold("res-uuid-1")),
       ).resolves.toBeUndefined();
 
       expect(mockDb.update).toHaveBeenCalled();

--- a/src/adapters/acuity.ts
+++ b/src/adapters/acuity.ts
@@ -12,7 +12,7 @@ import type {
   AvailableDate,
   Booking,
   BookingRequest,
-  SlotReservation,
+  SlotSoftHold,
   ClientInfo,
 } from '../core/types.js';
 import { Errors } from '../core/types.js';
@@ -297,10 +297,10 @@ export const createAcuityAdapter = (config: AcuityAdapterConfig): SchedulingAdap
       );
     },
 
-    // Reservations (via Acuity blocks)
-    createReservation: ({ providerId, datetime, duration, notes }) => {
+    // Advisory soft holds (via Acuity blocks)
+    softHoldSlot: ({ providerId, datetime, duration, notes }) => {
       if (!providerId) {
-        return Effect.fail(Errors.reservation('BLOCK_FAILED', 'Provider ID required for reservation'));
+        return Effect.fail(Errors.reservation('BLOCK_FAILED', 'Provider ID required for soft hold'));
       }
 
       const startTime = new Date(datetime);
@@ -312,7 +312,7 @@ export const createAcuityAdapter = (config: AcuityAdapterConfig): SchedulingAdap
             calendarID: parseInt(providerId, 10),
             start: startTime.toISOString(),
             end: endTime.toISOString(),
-            notes: notes ?? 'Payment pending - slot reserved',
+            notes: notes ?? 'Payment pending - advisory soft hold',
           }),
           (block) => ({
             id: String(block.id),
@@ -320,17 +320,17 @@ export const createAcuityAdapter = (config: AcuityAdapterConfig): SchedulingAdap
             duration,
             expiresAt: new Date(Date.now() + 15 * 60 * 1000).toISOString(),
             providerId,
-          } satisfies SlotReservation)
+          } satisfies SlotSoftHold)
         ),
         Effect.mapError((e) =>
-          Errors.reservation('BLOCK_FAILED', e._tag === 'AcuityError' ? e.message : 'Failed to create reservation')
+          Errors.reservation('BLOCK_FAILED', e._tag === 'AcuityError' ? e.message : 'Failed to create soft hold')
         )
       );
     },
 
-    releaseReservation: (reservationId) =>
+    releaseSoftHold: (softHoldId) =>
       pipe(
-        Effect.map(del<void>(`/blocks/${reservationId}`), () => undefined),
+        Effect.map(del<void>(`/blocks/${softHoldId}`), () => undefined),
         Effect.catchAll(() => Effect.succeed(undefined)) // Ignore errors when releasing
       ),
 

--- a/src/adapters/calcom.ts
+++ b/src/adapters/calcom.ts
@@ -14,7 +14,7 @@ import type {
 	TimeSlot,
 	Booking,
 	BookingRequest,
-	SlotReservation,
+	SlotSoftHold,
 	ClientInfo,
 } from '../core/types.js';
 import type { SchedulingResult } from '../core/types.js';
@@ -82,16 +82,16 @@ export const createCalComAdapter = (_config: CalComConfig): SchedulingAdapter =>
 			datetime: string;
 		}) => notImplemented<boolean>(),
 
-		createReservation: (_params: {
+		softHoldSlot: (_params: {
 			serviceId: string;
 			providerId?: string;
 			datetime: string;
 			duration: number;
 			expirationMinutes?: number;
 			notes?: string;
-		}) => notImplemented<SlotReservation>(),
+		}) => notImplemented<SlotSoftHold>(),
 
-		releaseReservation: (_reservationId: string) => notImplemented<void>(),
+		releaseSoftHold: (_softHoldId: string) => notImplemented<void>(),
 
 		createBooking: (_request: BookingRequest) => notImplemented<Booking>(),
 

--- a/src/adapters/homegrown.ts
+++ b/src/adapters/homegrown.ts
@@ -18,7 +18,7 @@ import type {
   AvailableDate,
   Booking,
   BookingRequest,
-  SlotReservation,
+  SlotSoftHold,
   ClientInfo,
   SchedulingResult,
   BookingStatus,
@@ -295,8 +295,8 @@ export const createHomegrownAdapter = (
           ),
         );
 
-      // Active reservations (not expired, not released)
-      const reservationRows = await d
+      // Active soft holds (not expired, not released)
+      const softHoldRows = await d
         .select({
           datetime: slotReservations.datetime,
           duration: slotReservations.duration,
@@ -325,7 +325,7 @@ export const createHomegrownAdapter = (
           end: new Date(r.endTime),
         });
       }
-      for (const r of reservationRows) {
+      for (const r of softHoldRows) {
         const start = new Date(r.datetime);
         occupied.push({
           start,
@@ -606,9 +606,9 @@ export const createHomegrownAdapter = (
         });
       }),
 
-    // --- Reservations ---
+    // --- Advisory soft holds ---
 
-    createReservation: (params) =>
+    softHoldSlot: (params) =>
       fromAsync(async () => {
         const { slotReservations } = (await loadSchemas()).booking;
         const expirationMinutes = params.expirationMinutes ?? 10;
@@ -633,10 +633,10 @@ export const createHomegrownAdapter = (
           duration: row.duration,
           expiresAt: row.expiresAt,
           providerId: params.providerId,
-        } satisfies SlotReservation;
+        } satisfies SlotSoftHold;
       }),
 
-    releaseReservation: (reservationId: string) =>
+    releaseSoftHold: (softHoldId: string) =>
       fromAsync(async () => {
         const { slotReservations } = (await loadSchemas()).booking;
         const { eq } = await import("drizzle-orm");
@@ -644,7 +644,7 @@ export const createHomegrownAdapter = (
           d
             .update(slotReservations)
             .set({ releasedAt: new Date().toISOString() })
-            .where(eq(slotReservations.id, reservationId)),
+            .where(eq(slotReservations.id, softHoldId)),
         );
       }),
 

--- a/src/adapters/types.ts
+++ b/src/adapters/types.ts
@@ -11,7 +11,7 @@ import type {
   AvailableDate,
   Booking,
   BookingRequest,
-  SlotReservation,
+  SlotSoftHold,
   ClientInfo,
 } from '../core/types.js';
 
@@ -92,26 +92,30 @@ export interface SchedulingAdapter {
   }): SchedulingResult<boolean>;
 
   // ---------------------------------------------------------------------------
-  // Slot Reservation (Hold)
+  // Slot Soft Hold (Advisory)
   // ---------------------------------------------------------------------------
 
   /**
-   * Create a temporary hold on a time slot while payment is processing.
-   * This prevents double-booking during the checkout flow.
+   * Create an advisory temporary hold on a time slot while payment is
+   * processing. This is not a cross-backend reservation guarantee.
+   *
+   * Correctness still belongs to the backing scheduler's final booking
+   * conflict/rejection semantics, and backends should pair this with their own
+   * slot-scoped locking when they can.
    */
-  createReservation(params: {
+  softHoldSlot(params: {
     serviceId: string;
     providerId?: string;
     datetime: string;
     duration: number;
     expirationMinutes?: number;
     notes?: string;
-  }): SchedulingResult<SlotReservation>;
+  }): SchedulingResult<SlotSoftHold>;
 
   /**
-   * Release a slot reservation (after successful booking or timeout)
+   * Release a soft hold after successful booking, timeout, or abandonment.
    */
-  releaseReservation(reservationId: string): SchedulingResult<void>;
+  releaseSoftHold(softHoldId: string): SchedulingResult<void>;
 
   // ---------------------------------------------------------------------------
   // Bookings

--- a/src/core/pipelines.ts
+++ b/src/core/pipelines.ts
@@ -8,7 +8,7 @@ import type {
   SchedulingResult,
   BookingRequest,
   Booking,
-  SlotReservation,
+  SlotSoftHold,
   PaymentResult,
   Service,
   TimeSlot,
@@ -60,7 +60,7 @@ export interface BookingPipelineInput {
 export interface BookingPipelineResult {
   readonly booking: Booking;
   readonly payment: PaymentResult;
-  readonly reservation?: SlotReservation;
+  readonly softHold?: SlotSoftHold;
 }
 
 // =============================================================================
@@ -73,14 +73,18 @@ export interface BookingPipelineResult {
  * Flow:
  * 1. Validate request
  * 2. Check slot availability
- * 3. Create slot reservation (block)
+ * 3. Create advisory soft hold when supported
  * 4. Process payment
  * 5. Create booking with payment reference
- * 6. Release reservation
+ * 6. Release soft hold
  * 7. Return result
  *
- * On payment failure: Release reservation, return error
- * On booking failure: Refund payment, release reservation, return error
+ * On payment failure: release soft hold, return error.
+ * On booking failure: refund payment, release soft hold, return error.
+ *
+ * The soft hold is an advisory checkout guard, not a correctness boundary.
+ * Backends must still rely on their final booking write/rejection semantics,
+ * and database-backed adapters should pair this with slot-scoped locks.
  */
 export const completeBookingWithAltPayment = (
   ctx: PipelineContext,
@@ -109,20 +113,20 @@ export const completeBookingWithAltPayment = (
       );
     }
 
-    // Phase B: Reserve slot (optional — graceful fallback if adapter doesn't support)
-    const reservation = yield* pipe(
-      scheduler.createReservation({
+    // Phase B: Advisory hold (optional; graceful fallback when unsupported)
+    const softHold = yield* pipe(
+      scheduler.softHoldSlot({
         serviceId: request.serviceId,
         providerId: request.providerId,
         datetime: request.datetime,
         duration: service.duration,
         notes: `Payment pending: ${request.idempotencyKey}`,
       }),
-      Effect.map((r) => r as SlotReservation | undefined),
-      Effect.catchAll(() => Effect.succeed(undefined as SlotReservation | undefined)),
+      Effect.map((r) => r as SlotSoftHold | undefined),
+      Effect.catchAll(() => Effect.succeed(undefined as SlotSoftHold | undefined)),
     );
 
-    // Phase C: Process payment (release reservation on failure)
+    // Phase C: Process payment (release soft hold on failure)
     const payment = yield* pipe(
       Effect.flatMap(
         paymentAdapter.createIntent({
@@ -135,9 +139,9 @@ export const completeBookingWithAltPayment = (
         (intent) => paymentAdapter.capturePayment(intent.id),
       ),
       Effect.catchAll((error) => {
-        if (reservation) {
+        if (softHold) {
           return Effect.flatMap(
-            scheduler.releaseReservation(reservation.id),
+            scheduler.releaseSoftHold(softHold.id),
             () => Effect.fail(error),
           );
         }
@@ -145,7 +149,7 @@ export const completeBookingWithAltPayment = (
       }),
     );
 
-    // Phase D: Create booking (refund + release on failure)
+    // Phase D: Create booking (refund + release soft hold on failure)
     const booking = yield* pipe(
       scheduler.createBookingWithPaymentRef(request, payment.transactionId, paymentAdapter.name),
       Effect.catchAll((error) =>
@@ -154,9 +158,9 @@ export const completeBookingWithAltPayment = (
             paymentAdapter.refund({ transactionId: payment.transactionId, reason: 'Booking creation failed' }),
             () => Effect.succeed(undefined),
           );
-          if (reservation) {
+          if (softHold) {
             yield* Effect.catchAll(
-              scheduler.releaseReservation(reservation.id),
+              scheduler.releaseSoftHold(softHold.id),
               () => Effect.succeed(undefined),
             );
           }
@@ -165,15 +169,15 @@ export const completeBookingWithAltPayment = (
       ),
     );
 
-    // Phase E: Cleanup — release reservation
-    if (reservation) {
+    // Phase E: Cleanup - release soft hold
+    if (softHold) {
       yield* Effect.catchAll(
-        scheduler.releaseReservation(reservation.id),
+        scheduler.releaseSoftHold(softHold.id),
         () => Effect.succeed(undefined),
       );
     }
 
-    return { booking, payment, reservation } satisfies BookingPipelineResult;
+    return { booking, payment, softHold } satisfies BookingPipelineResult;
   });
 
   return pipe(pipeline, withCorrelationId('completeBookingWithAltPayment', correlationId));

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -238,13 +238,20 @@ export interface Booking {
 export type BookingStatus = 'confirmed' | 'pending' | 'cancelled' | 'completed' | 'no-show';
 export type PaymentStatus = 'pending' | 'paid' | 'refunded' | 'failed';
 
-export interface SlotReservation {
+export interface SlotSoftHold {
   readonly id: string;
   readonly datetime: string;
   readonly duration: number;
   readonly expiresAt: string;
   readonly providerId?: string;
 }
+
+/**
+ * @deprecated Use `SlotSoftHold`. Soft holds are advisory checkout guards, not
+ * cross-backend reservation guarantees. Final booking creation remains the
+ * authoritative conflict point.
+ */
+export type SlotReservation = SlotSoftHold;
 
 // =============================================================================
 // PAYMENT TYPES

--- a/src/tests/fixtures/bookings.ts
+++ b/src/tests/fixtures/bookings.ts
@@ -7,7 +7,7 @@ import type {
   Booking,
   BookingRequest,
   ClientInfo,
-  SlotReservation,
+  SlotSoftHold,
   TimeSlot,
   AvailableDate,
 } from '../../core/types.js';
@@ -231,9 +231,9 @@ export const allBookings: Booking[] = [
 // =============================================================================
 
 /**
- * Active reservation (not expired)
+ * Active soft hold (not expired)
  */
-export const activeReservation: SlotReservation = {
+export const activeSoftHold: SlotSoftHold = {
   id: '999001',
   datetime: '2026-02-15T14:00:00-05:00',
   duration: 60,
@@ -242,9 +242,9 @@ export const activeReservation: SlotReservation = {
 };
 
 /**
- * Reservation about to expire (< 1 min)
+ * Soft hold about to expire (< 1 min)
  */
-export const expiringReservation: SlotReservation = {
+export const expiringSoftHold: SlotSoftHold = {
   id: '999002',
   datetime: '2026-02-15T15:00:00-05:00',
   duration: 30,
@@ -253,9 +253,9 @@ export const expiringReservation: SlotReservation = {
 };
 
 /**
- * Expired reservation
+ * Expired soft hold
  */
-export const expiredReservation: SlotReservation = {
+export const expiredSoftHold: SlotSoftHold = {
   id: '999003',
   datetime: '2026-02-15T16:00:00-05:00',
   duration: 60,
@@ -377,13 +377,13 @@ export const acuityAppointmentRaw = {
 };
 
 /**
- * Raw Acuity block (reservation) response
+ * Raw Acuity block (soft hold) response
  */
 export const acuityBlockRaw = {
   id: 999001,
   start: '2026-02-15T14:00:00-05:00',
   end: '2026-02-15T15:00:00-05:00',
-  notes: 'Payment pending - slot reserved',
+  notes: 'Payment pending - advisory soft hold',
   calendarID: 67890,
 };
 

--- a/src/tests/helpers.test.ts
+++ b/src/tests/helpers.test.ts
@@ -30,7 +30,7 @@ import {
   createClient,
   createBooking,
   createBookingRequest,
-  createReservation,
+  softHoldSlot,
   createTimeSlot,
   createDaySlots,
   createMonthDates,
@@ -198,13 +198,13 @@ describe('factory functions', () => {
     });
   });
 
-  describe('createReservation', () => {
-    it('creates valid reservation', () => {
-      const reservation = createReservation();
-      expect(reservation.id).toBeDefined();
-      expect(reservation.datetime).toBeDefined();
-      expect(reservation.duration).toBeGreaterThan(0);
-      expect(new Date(reservation.expiresAt).getTime()).toBeGreaterThan(Date.now());
+  describe('softHoldSlot', () => {
+    it('creates valid soft hold', () => {
+      const softHold = softHoldSlot();
+      expect(softHold.id).toBeDefined();
+      expect(softHold.datetime).toBeDefined();
+      expect(softHold.duration).toBeGreaterThan(0);
+      expect(new Date(softHold.expiresAt).getTime()).toBeGreaterThan(Date.now());
     });
   });
 

--- a/src/tests/helpers/factories.ts
+++ b/src/tests/helpers/factories.ts
@@ -14,7 +14,7 @@ import type {
   Booking,
   BookingStatus,
   PaymentStatus,
-  SlotReservation,
+  SlotSoftHold,
   PaymentIntent,
   PaymentResult,
   RefundResult,
@@ -232,9 +232,9 @@ export const bookingArb: fc.Arbitrary<Booking> = fc
   }));
 
 /**
- * SlotReservation arbitrary
+ * SlotSoftHold arbitrary
  */
-export const slotReservationArb: fc.Arbitrary<SlotReservation> = fc.record({
+export const slotSoftHoldArb: fc.Arbitrary<SlotSoftHold> = fc.record({
   id: idArb,
   datetime: datetimeArb,
   duration: durationArb,
@@ -377,9 +377,9 @@ export const createBooking = (overrides?: Partial<Booking>): Booking => ({
 });
 
 /**
- * Create a valid SlotReservation with optional overrides
+ * Create a valid SlotSoftHold with optional overrides
  */
-export const createReservation = (overrides?: Partial<SlotReservation>): SlotReservation => ({
+export const softHoldSlot = (overrides?: Partial<SlotSoftHold>): SlotSoftHold => ({
   id: '99999',
   datetime: '2026-02-15T19:00:00.000Z',
   duration: 60,

--- a/src/tests/mocks.test.ts
+++ b/src/tests/mocks.test.ts
@@ -120,7 +120,7 @@ describe('Acuity mock handlers', () => {
   });
 
   describe('POST /blocks', () => {
-    it('creates a block (reservation)', async () => {
+    it('creates a block (soft hold)', async () => {
       const response = await fetch(`${BASE_URL}/blocks`, {
         method: 'POST',
         headers: { ...authHeader, 'Content-Type': 'application/json' },

--- a/src/tests/mocks/handlers/acuity.ts
+++ b/src/tests/mocks/handlers/acuity.ts
@@ -217,7 +217,7 @@ const createBlock = http.post(`${BASE_URL}/blocks`, async ({ request }) => {
       calendarID: body.calendarID,
       start: body.start,
       end: body.end,
-      notes: body.notes || 'Payment pending - slot reserved',
+      notes: body.notes || 'Payment pending - advisory soft hold',
     };
 
     state.blocks.set(blockId, block);

--- a/src/tests/unit/adapters/acuity-transformers.test.ts
+++ b/src/tests/unit/adapters/acuity-transformers.test.ts
@@ -230,10 +230,10 @@ describe('Acuity Adapter Transformers', () => {
     });
   });
 
-  describe('reservation transformer (blocks)', () => {
-    it('transforms block to SlotReservation', async () => {
-      const reservation = await expectSuccess(
-        adapter.createReservation({
+  describe('softHold transformer (blocks)', () => {
+    it('transforms block to SlotSoftHold', async () => {
+      const softHold = await expectSuccess(
+        adapter.softHoldSlot({
           serviceId: '12345',
           providerId: '67890',
           datetime: '2026-02-15T19:00:00.000Z',
@@ -241,18 +241,18 @@ describe('Acuity Adapter Transformers', () => {
         })
       );
 
-      expect(reservation.id).toBeDefined();
-      expect(typeof reservation.id).toBe('string');
-      expect(reservation.datetime).toBe('2026-02-15T19:00:00.000Z');
-      expect(reservation.duration).toBe(60);
-      expect(reservation.expiresAt).toBeDefined();
+      expect(softHold.id).toBeDefined();
+      expect(typeof softHold.id).toBe('string');
+      expect(softHold.datetime).toBe('2026-02-15T19:00:00.000Z');
+      expect(softHold.duration).toBe(60);
+      expect(softHold.expiresAt).toBeDefined();
       // Expires in the future
-      expect(new Date(reservation.expiresAt).getTime()).toBeGreaterThan(Date.now());
+      expect(new Date(softHold.expiresAt).getTime()).toBeGreaterThan(Date.now());
     });
 
-    it('requires provider ID for reservation', async () => {
+    it('requires provider ID for soft hold', async () => {
       const error = await expectFailureTag(
-        adapter.createReservation({
+        adapter.softHoldSlot({
           serviceId: '12345',
           datetime: '2026-02-15T19:00:00.000Z',
           duration: 60,

--- a/src/tests/unit/core/pipelines.test.ts
+++ b/src/tests/unit/core/pipelines.test.ts
@@ -22,7 +22,7 @@ import {
   createProvider,
   createBooking,
   createBookingRequest,
-  createReservation,
+  softHoldSlot,
   createPaymentIntent,
   createPaymentResult,
   createTimeSlot,
@@ -61,8 +61,8 @@ const createMockScheduler = (): SchedulingAdapter => ({
   checkSlotAvailability: vi.fn(() => Effect.succeed(true)),
 
   // Reservations
-  createReservation: vi.fn(() => Effect.succeed(createReservation())),
-  releaseReservation: vi.fn(() => Effect.succeed(undefined)),
+  softHoldSlot: vi.fn(() => Effect.succeed(softHoldSlot())),
+  releaseSoftHold: vi.fn(() => Effect.succeed(undefined)),
 
   // Bookings
   createBooking: vi.fn(() => Effect.succeed(createBooking())),
@@ -150,11 +150,11 @@ describe('completeBookingWithAltPayment', () => {
     // Verify all steps were called
     expect(scheduler.getService).toHaveBeenCalledWith(input.request.serviceId);
     expect(scheduler.checkSlotAvailability).toHaveBeenCalled();
-    expect(scheduler.createReservation).toHaveBeenCalled();
+    expect(scheduler.softHoldSlot).toHaveBeenCalled();
     expect(paymentAdapter.createIntent).toHaveBeenCalled();
     expect(paymentAdapter.capturePayment).toHaveBeenCalled();
     expect(scheduler.createBookingWithPaymentRef).toHaveBeenCalled();
-    expect(scheduler.releaseReservation).toHaveBeenCalled();
+    expect(scheduler.releaseSoftHold).toHaveBeenCalled();
   });
 
   it('returns error for unknown payment method', async () => {
@@ -185,7 +185,7 @@ describe('completeBookingWithAltPayment', () => {
     expect(error._tag).toBe('ValidationError');
   });
 
-  it('returns reservation error when slot is taken', async () => {
+  it('returns soft hold error when slot is taken', async () => {
     vi.mocked(scheduler.checkSlotAvailability).mockReturnValue(Effect.succeed(false));
 
     const error = await expectFailureTag(
@@ -199,25 +199,25 @@ describe('completeBookingWithAltPayment', () => {
     }
   });
 
-  it('releases reservation on payment intent failure', async () => {
+  it('releases soft hold on payment intent failure', async () => {
     vi.mocked(paymentAdapter.createIntent).mockReturnValue(
       Effect.fail(Errors.payment('INTENT_FAILED', 'Failed to create intent', 'cash'))
     );
 
     await expectFailure(completeBookingWithAltPayment(ctx, input));
 
-    // Reservation should have been released
-    expect(scheduler.releaseReservation).toHaveBeenCalled();
+    // Soft hold should have been released
+    expect(scheduler.releaseSoftHold).toHaveBeenCalled();
   });
 
-  it('releases reservation on payment capture failure', async () => {
+  it('releases soft hold on payment capture failure', async () => {
     vi.mocked(paymentAdapter.capturePayment).mockReturnValue(
       Effect.fail(Errors.payment('CAPTURE_FAILED', 'Failed to capture payment', 'cash'))
     );
 
     await expectFailure(completeBookingWithAltPayment(ctx, input));
 
-    expect(scheduler.releaseReservation).toHaveBeenCalled();
+    expect(scheduler.releaseSoftHold).toHaveBeenCalled();
   });
 
   it('refunds payment on booking creation failure', async () => {
@@ -229,18 +229,18 @@ describe('completeBookingWithAltPayment', () => {
 
     // Payment should have been refunded
     expect(paymentAdapter.refund).toHaveBeenCalled();
-    expect(scheduler.releaseReservation).toHaveBeenCalled();
+    expect(scheduler.releaseSoftHold).toHaveBeenCalled();
   });
 
-  it('continues without reservation if reservation fails', async () => {
-    vi.mocked(scheduler.createReservation).mockReturnValue(
+  it('continues without softHold if softHold fails', async () => {
+    vi.mocked(scheduler.softHoldSlot).mockReturnValue(
       Effect.fail(Errors.reservation('BLOCK_FAILED', 'Could not create block'))
     );
 
     const result = await expectSuccess(completeBookingWithAltPayment(ctx, input));
 
     expect(result.booking).toBeDefined();
-    expect(result.reservation).toBeUndefined();
+    expect(result.softHold).toBeUndefined();
   });
 });
 

--- a/src/tests/unit/core/wizard-pipeline.test.ts
+++ b/src/tests/unit/core/wizard-pipeline.test.ts
@@ -84,10 +84,10 @@ const createMockWizardAdapter = (overrides?: Partial<SchedulingAdapter>): Schedu
   checkSlotAvailability: vi.fn(() => Effect.succeed(true)),
 
   // Reservation: BLOCK_FAILED (wizard adapter doesn't support reservations)
-  createReservation: vi.fn(() =>
-    Effect.fail(Errors.reservation('BLOCK_FAILED', 'Reservations not supported by wizard adapter'))
+  softHoldSlot: vi.fn(() =>
+    Effect.fail(Errors.reservation('BLOCK_FAILED', 'Soft holds not supported by wizard adapter'))
   ),
-  releaseReservation: vi.fn(() => Effect.succeed(undefined)),
+  releaseSoftHold: vi.fn(() => Effect.succeed(undefined)),
 
   // Write ops (Effect middleware delegation)
   createBooking: vi.fn((request) =>
@@ -307,14 +307,14 @@ describe('Wizard Adapter + Pipeline Integration', () => {
       expect(venmoAdapter.capturePayment).toHaveBeenCalled();
     });
 
-    it('skips reservation gracefully (wizard adapter returns BLOCK_FAILED)', async () => {
+    it('skips softHold gracefully (wizard adapter returns BLOCK_FAILED)', async () => {
       const request = createBookingRequest();
 
       const result = await expectSuccess(kit.completeBooking(request, 'cash'));
 
-      // Pipeline should have tried reservation and continued without one
-      expect(wizardAdapter.createReservation).toHaveBeenCalled();
-      expect(result.reservation).toBeUndefined();
+      // Pipeline should have tried softHold and continued without one
+      expect(wizardAdapter.softHoldSlot).toHaveBeenCalled();
+      expect(result.softHold).toBeUndefined();
       expect(result.booking).toBeDefined();
     });
 

--- a/tests/integration/acuity.test.ts
+++ b/tests/integration/acuity.test.ts
@@ -105,13 +105,13 @@ describe('Acuity Integration: Full Booking Lifecycle', () => {
     await expectSuccess(adapter.cancelBooking(booking.id, 'Integration test cleanup'));
   });
 
-  it('creates reservation (block) for slot protection', async () => {
+  it('creates soft hold (block) for slot protection', async () => {
     const services = await expectSuccess(adapter.getServices());
     const providers = await expectSuccess(adapter.getProviders());
 
-    // Create a reservation
-    const reservation = await expectSuccess(
-      adapter.createReservation({
+    // Create a soft hold
+    const softHold = await expectSuccess(
+      adapter.softHoldSlot({
         serviceId: services[0].id,
         providerId: providers[0].id,
         datetime: '2026-02-20T19:00:00.000Z',
@@ -119,16 +119,16 @@ describe('Acuity Integration: Full Booking Lifecycle', () => {
       })
     );
 
-    expect(reservation.id).toBeDefined();
-    expect(reservation.duration).toBe(60);
-    expect(reservation.expiresAt).toBeDefined();
+    expect(softHold.id).toBeDefined();
+    expect(softHold.duration).toBe(60);
+    expect(softHold.expiresAt).toBeDefined();
 
-    // Verify reservation is in mock state
+    // Verify soft hold is in mock state
     const mockState = getAcuityMockState();
     expect(mockState.blocks.size).toBe(1);
 
-    // Release the reservation
-    await expectSuccess(adapter.releaseReservation(reservation.id));
+    // Release the soft hold
+    await expectSuccess(adapter.releaseSoftHold(softHold.id));
 
     // Verify it's removed
     const stateAfter = getAcuityMockState();

--- a/tests/integration/booking-flow.test.ts
+++ b/tests/integration/booking-flow.test.ts
@@ -201,7 +201,7 @@ describe('Complete Booking Flow: Error Recovery', () => {
     // First call (checkSlotAvailability) succeeds, but booking creation fails
     configureAcuityMock({ failOnBookingCreate: true });
 
-    // This should fail but cleanup (release reservation) should still happen
+    // This should fail but cleanup (release soft hold) should still happen
     const exit = await Effect.runPromiseExit(
       kit.completeBooking(
         createBookingRequest({ idempotencyKey: 'api-failure-key' }),


### PR DESCRIPTION
## Summary
- Bumps scheduling-kit to 0.8.0 for the breaking soft-hold contract rename.
- Replaces SchedulingAdapter.createReservation/releaseReservation with softHoldSlot/releaseSoftHold.
- Adds SlotSoftHold as the forward type and keeps SlotReservation as a deprecated alias.
- Updates Acuity, Homegrown, Cal.com adapters plus pipeline/test helpers to describe holds as advisory rather than authoritative reservations.

## Validation
- pnpm docs:generate
- pnpm docs:generate --check
- pnpm check:release-metadata
- pnpm check
- pnpm lint
- pnpm test:unit
- pnpm test:integration
- pnpm build
- pnpm check:package
- git diff --check

## Note
- pnpm docs:check could not complete in this shell because mkdocs is not on PATH; trying through nix develop was blocked by the local Nix SQLite DB lock. The generated-docs portion passed.