### PR TITLE
ci: run package lane on repo-owned runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,9 @@ on:
   workflow_dispatch:
 
 permissions:
+  actions: read
   contents: read
+  packages: read
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -16,13 +18,13 @@ concurrency:
 
 jobs:
   package:
-    uses: tinyland-inc/ci-templates/.github/workflows/js-bazel-package.yml@21e0093a7586931ee69d716387e00556c6da7738
+    uses: tinyland-inc/ci-templates/.github/workflows/js-bazel-package.yml@61cd1338ca9dae8a25985c0a36ff7beb111449be
     with:
-      runner_mode: shared
-      shared_runner_labels_json: ${{ vars.PRIMARY_LINUX_RUNNER_LABELS_JSON }}
+      runner_mode: repo_owned
       runner_labels_json: ${{ vars.PRIMARY_LINUX_RUNNER_LABELS_JSON }}
       workspace_mode: isolated
-      publish_mode: same_runner
+      publish_mode: hosted_exception
+      npm_publish_mode: disabled
       node_versions: '["20", "22"]'
       publish_node_version: "22"
       pnpm_version: "9.15.9"
@@ -37,6 +39,5 @@ jobs:
       bazel_targets: "//:typecheck //:pkg //:test"
       package_dir: ./bazel-bin/pkg
       npm_access: public
-      npm_publish_provenance: true
       github_package_name: "@jesssullivan/scheduling-kit"
       dry_run: true

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,13 +23,13 @@ concurrency:
 
 jobs:
   package:
-    uses: tinyland-inc/ci-templates/.github/workflows/js-bazel-package.yml@21e0093a7586931ee69d716387e00556c6da7738
+    uses: tinyland-inc/ci-templates/.github/workflows/js-bazel-package.yml@61cd1338ca9dae8a25985c0a36ff7beb111449be
     with:
-      runner_mode: shared
-      shared_runner_labels_json: ${{ vars.PRIMARY_LINUX_RUNNER_LABELS_JSON }}
+      runner_mode: repo_owned
       runner_labels_json: ${{ vars.PRIMARY_LINUX_RUNNER_LABELS_JSON }}
       workspace_mode: isolated
-      publish_mode: same_runner
+      publish_mode: hosted_exception
+      npm_publish_mode: disabled
       node_versions: '["20", "22"]'
       publish_node_version: "22"
       pnpm_version: "9.15.9"
@@ -44,8 +44,5 @@ jobs:
       bazel_targets: "//:typecheck //:pkg //:test"
       package_dir: ./bazel-bin/pkg
       npm_access: public
-      npm_publish_provenance: true
       github_package_name: "@jesssullivan/scheduling-kit"
       dry_run: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run || false }}
-    secrets:
-      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -94,17 +94,18 @@ Longer term, the intended publish shape is:
 
 1. release metadata declared once
 2. Bazel defines and builds the publishable artifact
-3. GitHub Actions publishes that artifact to npm
-4. downstream apps consume the published package only
+3. GitHub Actions validates that artifact on the repo-owned package runner
+4. GitHub Packages is the package publish authority while npmjs publishing is disabled
+5. downstream apps consume the published package only
 
 ## Runner Authority
 
-Package CI and publish currently use the shared `js-bazel-package` workflow with
-`runner_mode: shared` and labels from `PRIMARY_LINUX_RUNNER_LABELS_JSON`.
+Package CI and publish use the shared `js-bazel-package` workflow with
+`runner_mode: repo_owned` and labels from `PRIMARY_LINUX_RUNNER_LABELS_JSON`.
+The workflow publishes through the hosted publish exception for GitHub Packages
+and explicitly disables npmjs publication.
 
-Treat that runner contract as pending proof until the repo Actions runner API
-and green workflow runs confirm the lane. Keep private runner topology and
-apply details out of this public repo.
+Keep private runner topology and apply details out of this public repo.
 
 ## Quick Start
 

--- a/docs/build-and-release.md
+++ b/docs/build-and-release.md
@@ -34,6 +34,10 @@ That split is intentional. Nix bootstraps the tools, Bazel models the artifact
 graph, and the shared `js-bazel-package` workflow publishes from
 `./bazel-bin/pkg`.
 
+The active workflow contract uses repo-owned runner registration with Tinyland
+capability labels. npmjs publication is disabled; the publish path validates and
+publishes the Bazel artifact through GitHub Packages.
+
 ## Bazel Cache Contract
 
 Local Bazel use defaults to the repo-local disk cache in `.bazelrc`:
@@ -78,6 +82,7 @@ Version drift across those files is a bug.
 Before cutting a package release, verify these surfaces together:
 
 - npm package: `@tummycrypt/scheduling-kit`
+- npmjs publish mode: `disabled`
 - GitHub Packages package: `@jesssullivan/scheduling-kit`
 - tag and GitHub release for the package version
 - Bazel package artifact from `./bazel-bin/pkg`

--- a/docs/generated/release-metadata.md
+++ b/docs/generated/release-metadata.md
@@ -25,7 +25,10 @@ Generated from `package.json`, `MODULE.bazel`, `BUILD.bazel`,
 | --- | --- |
 | npm package | `@tummycrypt/scheduling-kit` |
 | npm access | `public` |
+| npmjs publish mode | `disabled` |
 | GitHub Packages name | `@jesssullivan/scheduling-kit` |
+| CI runner mode | `repo_owned` |
+| Publish mode | `hosted_exception` |
 | CI node versions | `["20", "22"]` |
 | Publish node version | `22` |
 | Bazel targets | `//:typecheck //:pkg //:test` |

--- a/scripts/check-release-metadata.mjs
+++ b/scripts/check-release-metadata.mjs
@@ -91,12 +91,26 @@ const checks = [
 	{
 		label: 'CI runner mode',
 		actual: scalar(extract(ciWorkflow, /runner_mode:\s*([^\n]+)/, 'CI runner_mode')),
-		expected: 'shared',
+		expected: 'repo_owned',
+	},
+	{
+		label: 'CI runner labels',
+		actual: scalar(
+			extract(ciWorkflow, /runner_labels_json:\s*([^\n]+)/, 'CI runner_labels_json'),
+		),
+		expected: '${{ vars.PRIMARY_LINUX_RUNNER_LABELS_JSON }}',
 	},
 	{
 		label: 'CI publish mode',
 		actual: scalar(extract(ciWorkflow, /publish_mode:\s*([^\n]+)/, 'CI publish_mode')),
-		expected: 'same_runner',
+		expected: 'hosted_exception',
+	},
+	{
+		label: 'CI npm publish mode',
+		actual: scalar(
+			extract(ciWorkflow, /npm_publish_mode:\s*([^\n]+)/, 'CI npm_publish_mode'),
+		),
+		expected: 'disabled',
 	},
 	{
 		label: 'CI package artifact path',
@@ -104,10 +118,8 @@ const checks = [
 		expected: './bazel-bin/pkg',
 	},
 	{
-		label: 'CI npm provenance intent',
-		actual: scalar(
-			extract(ciWorkflow, /npm_publish_provenance:\s*([^\n]+)/, 'CI npm provenance'),
-		),
+		label: 'CI omits npm provenance',
+		actual: String(!/npm_publish_provenance:/.test(ciWorkflow)),
 		expected: 'true',
 	},
 	{
@@ -147,19 +159,54 @@ const checks = [
 		expected: 'write',
 	},
 	{
+		label: 'publish runner mode',
+		actual: scalar(
+			extract(publishWorkflow, /runner_mode:\s*([^\n]+)/, 'publish runner_mode'),
+		),
+		expected: 'repo_owned',
+	},
+	{
+		label: 'publish runner labels',
+		actual: scalar(
+			extract(
+				publishWorkflow,
+				/runner_labels_json:\s*([^\n]+)/,
+				'publish runner_labels_json',
+			),
+		),
+		expected: '${{ vars.PRIMARY_LINUX_RUNNER_LABELS_JSON }}',
+	},
+	{
+		label: 'publish mode',
+		actual: scalar(
+			extract(publishWorkflow, /publish_mode:\s*([^\n]+)/, 'publish publish_mode'),
+		),
+		expected: 'hosted_exception',
+	},
+	{
+		label: 'publish npm publish mode',
+		actual: scalar(
+			extract(
+				publishWorkflow,
+				/npm_publish_mode:\s*([^\n]+)/,
+				'publish npm_publish_mode',
+			),
+		),
+		expected: 'disabled',
+	},
+	{
 		label: 'publish package artifact path',
 		actual: scalar(extract(publishWorkflow, /package_dir:\s*([^\n]+)/, 'publish package_dir')),
 		expected: './bazel-bin/pkg',
 	},
 	{
-		label: 'publish npm provenance',
-		actual: scalar(
-			extract(
-				publishWorkflow,
-				/npm_publish_provenance:\s*([^\n]+)/,
-				'publish npm provenance',
-			),
-		),
+		label: 'publish omits npm provenance',
+		actual: String(!/npm_publish_provenance:/.test(publishWorkflow)),
+		expected: 'true',
+	},
+	{
+		label: 'publish omits npm token',
+		actual: String(!/NPM_TOKEN/.test(publishWorkflow)),
 		expected: 'true',
 	},
 	{

--- a/scripts/generate-doc-artifacts.mjs
+++ b/scripts/generate-doc-artifacts.mjs
@@ -28,6 +28,9 @@ const modulePnpmVersion = extract(moduleBazel, /pnpm_version = "([^"]+)"/, 'MODU
 const ciNodeVersions = extract(ciWorkflow, /node_versions:\s*'([^']+)'/, 'CI node versions');
 const ciBazelTargets = extract(ciWorkflow, /bazel_targets:\s*"([^"]+)"/, 'CI bazel targets');
 const ciPackageDir = extract(ciWorkflow, /package_dir:\s*([^\n]+)/, 'CI package dir');
+const ciRunnerMode = extract(ciWorkflow, /runner_mode:\s*([^\n]+)/, 'CI runner mode');
+const publishMode = extract(publishWorkflow, /publish_mode:\s*([^\n]+)/, 'publish mode');
+const npmPublishMode = extract(publishWorkflow, /npm_publish_mode:\s*([^\n]+)/, 'npm publish mode');
 const publishNodeVersion = extract(publishWorkflow, /publish_node_version:\s*"([^"]+)"/, 'publish node version');
 const githubPackageName = extract(publishWorkflow, /github_package_name:\s*"([^"]+)"/, 'GitHub Packages name');
 const npmAccess = extract(publishWorkflow, /npm_access:\s*([^\n]+)/, 'npm access');
@@ -172,7 +175,10 @@ ${markdownTable(
   [
     ['npm package', `\`${packageJson.name}\``],
     ['npm access', `\`${npmAccess}\``],
+    ['npmjs publish mode', `\`${npmPublishMode}\``],
     ['GitHub Packages name', `\`${githubPackageName}\``],
+    ['CI runner mode', `\`${ciRunnerMode}\``],
+    ['Publish mode', `\`${publishMode}\``],
     ['CI node versions', `\`${ciNodeVersions}\``],
     ['Publish node version', `\`${publishNodeVersion}\``],
     ['Bazel targets', `\`${ciBazelTargets}\``],


### PR DESCRIPTION
## Summary
- pin the js-bazel package reusable workflow to the repo-owned runner guard
- move canonical scheduling-kit CI/publish to runner_mode=repo_owned with repo variable-backed labels
- disable npmjs publication and make GitHub Packages the package publish authority
- update release metadata/docs guards so they assert the new runner and publish contract

## Validation
- node scripts/generate-doc-artifacts.mjs
- node scripts/check-release-metadata.mjs
- pnpm check:release-metadata
- pnpm docs:generate --check
- git diff --check
- actionlint .github/workflows/ci.yml .github/workflows/publish.yml

Linear: TIN-1676