### PR TITLE
chore: land devshell, docs, and toolchain truth normalization (TIN-89)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 node_modules/
+.direnv/
 dist/
 .svelte-kit/
 .env

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,39 +38,39 @@ The package should be reusable across multiple businesses. Avoid app-specific as
 
 ## Current Tracking
 
-As of `2026-05-02`, the active structural work is no longer just downstream
-contract cleanup. It is release-authority, artifact-truth, and runner-contract
-convergence.
+As of `2026-06-10`, release-authority, artifact-truth, and runner-contract
+convergence have largely landed. The active structural work is docs/toolchain
+truth normalization and the adopter capability contract.
 
 Active threads:
 
 - `TIN-89` package, Bazel, CI, publish, and dependency truth across shared
-  scheduling packages
-- `TIN-165` bazel-registry generation from standalone package truth
-- release, tag, npm, and GitHub release authority cleanup tracked in GitHub
-  issue `#73`
-- downstream Bzlmod consumer builds of `//:pkg` from the active registry
-- runner reachability and shared-runner proof before treating package CI as a
-  stable public workflow contract
+  scheduling packages; its current GitHub face is kit issues `#73`/`#75` and
+  bridge issues `#76`/`#78`
+- the kit-side half of `TIN-88`, the explicit site and backend capability
+  contract for reusable adopters, tracked as kit `#79` and bridge `#82`
 
 Closed but still relevant context:
 
 - `TIN-101` completed the mini sprint for toolchain authority and hermetic package convergence
 - `TIN-103` closed the release-authority ambiguity for `Jesssullivan/scheduling-kit`
 - `TIN-104` was canceled as a duplicate during that convergence work
+- `TIN-165` is done: the tinyland bazel-registry is generated from standalone
+  package truth and currently carries scheduling-kit `0.8.0` and
+  scheduling-bridge `0.5.11`; the registry line is in `.bazelrc`
+- `TIN-677` is done: HomegrownAdapter takes injected schemas from
+  `@tummycrypt/tinyland-business-pg`, with `tinyland-auth-pg` kept only as an
+  optional legacy fallback
 
 Current operational truth:
 
 - local development should default to `jesssullivan/main`
 - that branch is the current functional release line
-- current published package truth is `@tummycrypt/scheduling-kit` `0.7.7`
-  on npm, GitHub Releases, GitHub Packages, and the active tinyland Bazel
-  registry
-- `0.7.7` fixes downstream Bzlmod `//:pkg` consumption by making the Svelte
-  package build independent of main-workspace-relative `src` paths
-- the next release candidate should not reintroduce a mandatory
-  `tinyland-auth-pg` dependency for HomegrownAdapter; use explicit schema
-  injection and keep any auth-pg fallback optional
+- current published package truth is `@tummycrypt/scheduling-kit` `0.8.0`
+  on GitHub Releases, GitHub Packages, and the active tinyland Bazel registry
+- HomegrownAdapter does not require `tinyland-auth-pg`; schemas are injected
+  explicitly (canonically from `@tummycrypt/tinyland-business-pg`) and any
+  auth-pg fallback stays optional
 - `#73` remains open only for explicit historical release-surface
   backfill/documentation around older `0.7.1` / `0.7.2` gaps; the current
   release/tag/npm/Bazel/registry authority path is healthy
@@ -176,7 +176,7 @@ package truth across both remotes by accident.
 
 Current runner truth:
 
-- current workflows use `runner_mode: shared` and read shared runner labels from
+- current workflows use `runner_mode: repo_owned` and read runner labels from
   `PRIMARY_LINUX_RUNNER_LABELS_JSON`
 - do not describe the runner lane as fully proven until repo Actions runner
   visibility and green workflow runs confirm it

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,6 +53,12 @@ Active threads:
 - runner reachability and shared-runner proof before treating package CI as a
   stable public workflow contract
 
+Closed but still relevant context:
+
+- `TIN-101` completed the mini sprint for toolchain authority and hermetic package convergence
+- `TIN-103` closed the release-authority ambiguity for `Jesssullivan/scheduling-kit`
+- `TIN-104` was canceled as a duplicate during that convergence work
+
 Current operational truth:
 
 - local development should default to `jesssullivan/main`
@@ -81,6 +87,10 @@ There are **two** build surfaces in this repo:
 2. Bazel defines and builds the publishable package artifact used by CI
 
 Do not confuse them.
+
+The repo flake and `.envrc` exist to make those surfaces reproducibly available
+from a fresh machine. They are bootstrap tools, not a second packaging
+authority.
 
 ### Canonical publish path
 

--- a/README.md
+++ b/README.md
@@ -79,7 +79,6 @@ nix build .#docs        # Build the static docs site as a derivation
 nix flake check         # Evaluate flake outputs and run lightweight checks
 ```
 
-
 ## Release Authority
 
 Current reality:
@@ -87,6 +86,8 @@ Current reality:
 - the functional release line is `Jesssullivan/scheduling-kit`
 - `tinyland-inc/scheduling-kit` is now a downstream mirror and validation
   surface, not a second publish authority
+- the active tinyland Bazel registry carries `scheduling-kit` `0.8.0` (and
+  `scheduling-bridge` `0.5.11`); the registry line is already in `.bazelrc`
 
 Treat `Jesssullivan/main` as the release authority for package publication and
 metadata changes. Do not assume both `main` branches are equivalent.

--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ nix build .#docs        # Build the static docs site as a derivation
 nix flake check         # Evaluate flake outputs and run lightweight checks
 ```
 
+
 ## Release Authority
 
 Current reality:
@@ -375,12 +376,13 @@ import { CassetteRecorder, CassettePlayer } from '@tummycrypt/scheduling-kit/tes
 ## Development
 
 ```bash
-pnpm install
-pnpm dev              # Start dev server
-pnpm build            # Build package
-pnpm check            # TypeScript check
-pnpm lint             # ESLint
-pnpm test:all         # Run all test suites
+pnpm dev                 # Start dev server
+pnpm build               # Build package
+pnpm check               # TypeScript check
+pnpm lint                # ESLint
+pnpm test:all            # Run all test suites
+pnpm docs:check          # Validate generated docs and MkDocs config
+bazel build //:pkg       # Build npm artifact through Bazel
 ```
 
 ## License

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,350 +1,77 @@
 # Testing Guide
 
-This document describes the testing strategy and practices for `@tummycrypt/scheduling-kit`.
+This repo uses Vitest for unit, integration, component-like, and live tests,
+and Playwright for browser E2E coverage. The package is Effect-based, so the
+test helpers and examples in this tree assert on `Effect` success and failure
+rather than fp-ts `Either` values.
 
-## Test Types
+## Test commands
 
-| Type | Directory | Command | Purpose |
-|------|-----------|---------|---------|
-| Unit | `src/tests/` | `pnpm test:unit` | Test individual functions and modules |
-| Integration | `tests/integration/` | `pnpm test:integration` | Test adapter interactions with mocked APIs |
-| Component | N/A | `pnpm test:component` | Test Svelte components |
-| Live | `tests/live/` | `pnpm test:live` | Test against real Acuity API |
-| E2E | `tests/e2e/` | `pnpm test:e2e` | Full browser tests with Playwright |
+| Lane | Command | Primary paths | Notes |
+| --- | --- | --- | --- |
+| Unit | `pnpm test:unit` | `src/tests/**`, `src/adapters/__tests__/**`, `src/onboarding/__tests__/**` | Fast default lane |
+| Integration | `pnpm test:integration` | `tests/integration/**` | Sequential file execution to avoid shared-state races |
+| Component | `pnpm test:component` | `tests/e2e/*.test.ts` | jsdom-driven UI tests that share the browser-facing fixture folder |
+| Playwright E2E | `pnpm test:e2e` | `tests/e2e/**` | Real browser run across Chromium, Firefox, WebKit, and mobile presets |
+| Live | `pnpm test:live` | `tests/live/**` | Explicit opt-in only |
 
-## Quick Start
+## Current layout
+
+```text
+src/tests/
+  helpers/        Effect assertions and factory utilities
+  fixtures/       Deterministic test data and raw provider payloads
+  mocks/          MSW server and handler set
+  unit/           Focused unit coverage
+  components/     Pure component state coverage
+tests/
+  integration/    Adapter-level integration flows
+  e2e/            Shared browser-facing tests used by Vitest and Playwright
+  live/           Real-provider smoke coverage
+cassettes/        Recorded provider interactions
+```
+
+## Effect-first helper patterns
+
+Use the helpers in `src/tests/helpers/effect.ts` when asserting on package
+behavior:
+
+```ts
+import { expectSuccess, expectFailureTag } from '../helpers/effect.js';
+
+it('returns a typed validation error', async () => {
+  const error = await expectFailureTag(
+    completeBookingWithAltPayment(ctx, invalidInput),
+    'ValidationError',
+  );
+
+  expect(error._tag).toBe('ValidationError');
+});
+```
+
+Those helpers execute the `Effect`, assert on the `Exit`, and preserve the
+typed `SchedulingError` contract exposed by the public API.
+
+## Fixtures, mocks, and recordings
+
+- Use `src/tests/fixtures/**` for deterministic data and raw provider payloads
+- Use `src/tests/mocks/**` for MSW-backed HTTP mocks
+- Use `src/testing/**` plus `cassettes/**` for record/replay workflows and API diffing
+
+## Live tests
+
+Live tests are intentionally gated and should never become the default CI path.
 
 ```bash
-# Run all unit tests
-pnpm test:unit
-
-# Run tests in watch mode
-pnpm test
-
-# Run with coverage
-pnpm test:coverage
-
-# Run integration tests (uses MSW mocks)
-pnpm test:integration
-
-# Run live API tests (requires credentials)
+cp .env.test.local.example .env.test.local
 RUN_LIVE_TESTS=true pnpm test:live
 ```
 
-## Directory Structure
+Keep those runs read-only unless a specific operator lane is being defined and
+reviewed.
 
-```
-src/tests/
-├── setup.ts                 # Global test setup
-├── helpers/
-│   ├── fp-ts.ts             # fp-ts assertion helpers
-│   ├── factories.ts         # Test data factories (fast-check)
-│   └── index.ts
-├── fixtures/
-│   ├── services.ts          # Service fixtures
-│   ├── bookings.ts          # Booking fixtures
-│   ├── providers.ts         # Provider fixtures
-│   ├── index.ts
-│   └── acuity/              # Raw Acuity API fixtures
-│       ├── appointment-types.json
-│       ├── calendars.json
-│       └── ...
-├── mocks/
-│   ├── server.ts            # MSW server setup
-│   └── handlers/
-│       ├── acuity.ts        # Acuity API handlers
-│       ├── paypal.ts        # PayPal API handlers
-│       └── index.ts
-├── unit/
-│   ├── core/
-│   │   └── pipelines.test.ts
-│   ├── adapters/
-│   │   └── acuity-transformers.test.ts
-│   └── payments/
-│       └── venmo.test.ts
-├── types.test.ts            # Core type tests
-├── utils.test.ts            # Utility function tests
-└── ...
+## Validation expectations
 
-tests/
-├── integration/
-│   ├── acuity.test.ts       # Acuity adapter integration
-│   └── booking-flow.test.ts # Full booking flow
-├── live/
-│   └── acuity.live.test.ts  # Live API tests
-└── e2e/
-    └── booking.spec.ts      # Playwright tests
-```
-
-## Writing Tests
-
-### Unit Tests
-
-Unit tests should be fast, isolated, and focused on a single unit of functionality.
-
-```typescript
-import { describe, it, expect } from 'vitest';
-import * as E from 'fp-ts/Either';
-import { expectRight, expectLeftTag } from '../helpers/fp-ts.js';
-
-describe('myFunction', () => {
-  it('returns Right on success', () => {
-    const result = myFunction('valid input');
-    expectRight(result, (value) => {
-      expect(value).toBe('expected');
-    });
-  });
-
-  it('returns Left with ValidationError on invalid input', () => {
-    const result = myFunction('invalid');
-    expectLeftTag(result, 'ValidationError');
-  });
-});
-```
-
-### fp-ts Test Helpers
-
-The `src/tests/helpers/fp-ts.ts` module provides assertion helpers for `Either` and `TaskEither`:
-
-```typescript
-import { expectRight, expectLeft, expectLeftTag, runTask } from '../helpers/fp-ts.js';
-
-// Assert Right and inspect value
-expectRight(result, (value) => {
-  expect(value.name).toBe('Test Service');
-});
-
-// Assert Left
-expectLeft(result, (error) => {
-  expect(error.message).toContain('failed');
-});
-
-// Assert Left with specific tag
-expectLeftTag(result, 'AcuityError');
-
-// Run TaskEither to Either
-const result = await runTask(someTaskEither);
-```
-
-### Test Fixtures
-
-Use the fixture modules for consistent test data:
-
-```typescript
-import { mockServices, mockProviders, mockBooking } from '../fixtures/index.js';
-
-it('transforms services correctly', () => {
-  const services = mockServices;
-  // ... test with fixtures
-});
-```
-
-### Factory Functions (fast-check)
-
-For property-based testing, use the factory arbitraries:
-
-```typescript
-import fc from 'fast-check';
-import { serviceArbitrary, clientArbitrary } from '../helpers/factories.js';
-
-it('booking price always matches service price', () => {
-  fc.assert(
-    fc.property(serviceArbitrary, clientArbitrary, (service, client) => {
-      const booking = createBooking(service, client);
-      return booking.price === service.price;
-    })
-  );
-});
-```
-
-### Integration Tests
-
-Integration tests use MSW to mock external APIs:
-
-```typescript
-import { describe, it, expect, beforeAll, afterAll, afterEach } from 'vitest';
-import { server } from '../../src/tests/mocks/server.js';
-import { createAcuityAdapter } from '../../src/adapters/acuity.js';
-
-describe('Acuity Adapter Integration', () => {
-  beforeAll(() => server.listen({ onUnhandledRequest: 'error' }));
-  afterEach(() => server.resetHandlers());
-  afterAll(() => server.close());
-
-  it('fetches services from Acuity', async () => {
-    const adapter = createAcuityAdapter({
-      type: 'acuity',
-      userId: 'test',
-      apiKey: 'test',
-    });
-
-    const result = await adapter.getServices()();
-    expectRight(result, (services) => {
-      expect(services.length).toBeGreaterThan(0);
-    });
-  });
-});
-```
-
-### Live Tests
-
-Live tests run against the real Acuity API. They are gated by environment variables:
-
-```typescript
-const RUN_LIVE_TESTS = process.env.RUN_LIVE_TESTS === 'true';
-
-describe.skipIf(!RUN_LIVE_TESTS)('Acuity Live API', () => {
-  // Tests only run when RUN_LIVE_TESTS=true
-});
-```
-
-**Setup for live tests:**
-
-1. Copy `.env.test.local.example` to `.env.test.local`
-2. Add your Acuity credentials
-3. Run `RUN_LIVE_TESTS=true pnpm test:live`
-
-**Important**: Live tests are read-only and should never create bookings or modify data.
-
-## MSW Mock Handlers
-
-### Adding New Handlers
-
-Create handlers in `src/tests/mocks/handlers/`:
-
-```typescript
-// src/tests/mocks/handlers/newservice.ts
-import { http, HttpResponse } from 'msw';
-
-export const newServiceHandlers = [
-  http.get('https://api.example.com/resource', () => {
-    return HttpResponse.json({ data: 'mocked' });
-  }),
-];
-```
-
-Register in `src/tests/mocks/handlers/index.ts`:
-
-```typescript
-import { acuityHandlers } from './acuity.js';
-import { paypalHandlers } from './paypal.js';
-import { newServiceHandlers } from './newservice.js';
-
-export const handlers = [
-  ...acuityHandlers,
-  ...paypalHandlers,
-  ...newServiceHandlers,
-];
-```
-
-### Handler Patterns
-
-```typescript
-// Success response
-http.get('/api/resource', () => {
-  return HttpResponse.json(mockData);
-});
-
-// Error response
-http.get('/api/resource/:id', ({ params }) => {
-  if (params.id === 'not-found') {
-    return HttpResponse.json({ error: 'Not found' }, { status: 404 });
-  }
-  return HttpResponse.json(mockData);
-});
-
-// Conditional based on query params
-http.get('/api/search', ({ request }) => {
-  const url = new URL(request.url);
-  const query = url.searchParams.get('q');
-  return HttpResponse.json({ results: filterByQuery(query) });
-});
-```
-
-## Coverage
-
-Coverage thresholds are configured in `vitest.config.ts`:
-
-```typescript
-coverage: {
-  thresholds: {
-    statements: 70,
-    branches: 65,
-    functions: 70,
-    lines: 70,
-  },
-}
-```
-
-Run coverage report:
-
-```bash
-pnpm test:coverage
-```
-
-CI will fail if coverage drops below thresholds.
-
-## Maintenance Scripts
-
-### Update Fixtures
-
-Regenerate static fixtures from type definitions:
-
-```bash
-pnpm fixtures:update
-pnpm fixtures:update --dry-run  # Preview changes
-```
-
-### Refresh Traces
-
-Re-record API cassettes from live endpoints:
-
-```bash
-pnpm traces:refresh                  # Record all
-pnpm traces:refresh --service acuity # Only Acuity
-pnpm traces:refresh --compare        # Compare to existing
-```
-
-## Best Practices
-
-1. **Use descriptive test names**: Start with the function/component name, then describe the scenario.
-
-2. **One assertion per test** (when practical): Makes failures easier to diagnose.
-
-3. **Don't test implementation details**: Test behavior, not internal state.
-
-4. **Use fixtures for consistent data**: Avoid magic values scattered in tests.
-
-5. **Clean up after tests**: Use `afterEach` to reset state.
-
-6. **Mock at the right level**: MSW mocks HTTP requests, not function calls.
-
-7. **Keep tests fast**: Unit tests should complete in milliseconds.
-
-8. **Write tests before fixing bugs**: Reproduces the issue and prevents regression.
-
-## Troubleshooting
-
-### Tests hang or timeout
-
-- Check for unresolved promises
-- Use `vi.useFakeTimers()` for timer-based code
-- Increase timeout: `it('test', { timeout: 30000 }, async () => {...})`
-
-### MSW requests not being intercepted
-
-- Verify handler URL matches exactly
-- Check server is started: `server.listen()`
-- Enable debugging: `server.listen({ onUnhandledRequest: 'warn' })`
-
-### Coverage not including files
-
-- Check `coverage.include` patterns in vitest config
-- Ensure files are imported in tests
-- Svelte files need special handling (excluded by default)
-
-### Live tests returning 403
-
-- Acuity API requires Powerhouse plan ($50/mo) for any API access
-- Tests are designed to handle 403 gracefully
-- Use MSW mocks for comprehensive testing without API access
+- `pnpm test:unit`, `pnpm test:integration`, and `pnpm test:component` are normal local validation lanes
+- `pnpm test:e2e` is appropriate when changing interactive browser behavior
+- `pnpm test:live` is for intentional provider-state checks only

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -23,6 +23,7 @@ const svelteConfig = eslintPluginSvelte.configs['flat/recommended'].map((config)
 export default [
   {
     ignores: [
+      '.claude/**',
       '.svelte-kit/**',
       'bazel-*/**',
       'coverage/**',
@@ -31,6 +32,7 @@ export default [
       'pkg/**',
       'pkg-github/**',
       'playwright-report/**',
+      'site/**',
       'test-results/**',
     ],
   },

--- a/src/adapters/homegrown.ts
+++ b/src/adapters/homegrown.ts
@@ -2,7 +2,7 @@
  * Homegrown Scheduling Adapter
  *
  * Direct PG-backed scheduling — replaces Acuity browser automation.
- * Implements the full SchedulingAdapter interface (16 methods) using
+ * Implements the full SchedulingAdapter interface (17 methods) using
  * Drizzle ORM queries against Neon PostgreSQL.
  *
  * Feature-flagged: only active when SCHEDULING_BACKEND=homegrown

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -33,13 +33,7 @@ export default defineConfig({
     },
     // Timeout for slower integration tests
     testTimeout: 10000,
-    // Pool configuration for parallel execution
     pool: 'threads',
-    poolOptions: {
-      threads: {
-        singleThread: false,
-      },
-    },
   },
   resolve: {
     conditions: ['browser'],

--- a/vitest.integration.config.ts
+++ b/vitest.integration.config.ts
@@ -10,13 +10,8 @@ export default defineConfig({
     setupFiles: ['src/tests/setup.ts'],
     // Integration tests may need longer timeouts
     testTimeout: 30000,
-    // Run integration tests sequentially to avoid race conditions
-    pool: 'threads',
-    poolOptions: {
-      threads: {
-        singleThread: true,
-      },
-    },
+    // Run integration test files sequentially to avoid shared-state races.
+    fileParallelism: false,
   },
   resolve: {
     conditions: ['browser'],


### PR DESCRIPTION
## What this is

Lands the local docs/toolchain truth normalization pass (Linear TIN-89), reconciled against the 0.8.0 line. The pass predated 0.8.0; upstream PRs #77/#78 already landed evolved versions of much of it (generated doc surfaces, provenance guard, mkdocs, `.envrc`, `flake.lock`), so this branch was rebased onto `main` and conflicts were resolved by preferring upstream structure and grafting the remaining local value:

- `docs/testing.md` rewritten to match the actual test layout and commands in this tree (-341 lines of stale content)
- `vitest.config.ts` / `vitest.integration.config.ts` simplified: drop redundant `poolOptions`, use `fileParallelism: false` for integration file ordering
- `eslint.config.js` ignores for `.claude/**` and `site/**`; `.gitignore` adds `.direnv/`
- AGENTS.md: flake/`.envrc` bootstrap framing, closed-tracker context block, fuller Important Files list
- README: Development command block includes `pnpm docs:check` and `bazel build //:pkg`

Refs #75 (this lands the committed-`flake.lock`/devshell portion that 0.8.0 already carried; the branch confirms lockfile + devshell parity against the flake). Refs #73 (release-truth guard surfaces regenerate cleanly against 0.8.0 metadata).

## Accuracy fixes (second commit)

- `AGENTS.md` Current Tracking refreshed to 2026-06-10: TIN-165 is Done (tinyland bazel-registry carries kit `0.8.0` + bridge `0.5.11`; registry line is in `.bazelrc`), TIN-677 is Done (HomegrownAdapter schemas injected from `@tummycrypt/tinyland-business-pg`, `tinyland-auth-pg` optional legacy fallback). Active threads are TIN-89 (GitHub face: kit #73/#75 + bridge #76/#78) and the kit-side half of TIN-88 (kit #79 + bridge #82).
- `AGENTS.md` runner truth corrected from `runner_mode: shared` to `repo_owned` (matches `ci.yml`/`publish.yml` after #95).
- `README.md` Release Authority notes current registry truth.
- `src/adapters/homegrown.ts` header comment: SchedulingAdapter contract is 17 methods, not 16 (comment-only; no functional `src/` changes).

## Validation

| Command | Result |
| --- | --- |
| `pnpm check` | pass (0 errors, 0 warnings, 1929 files) |
| `pnpm lint` | pass |
| `pnpm test:unit` | 609/621 pass; 12 pre-existing failures in `src/adapters/__tests__/availability-engine.test.ts` (identical failures reproduce on pristine `origin/main`; timezone/environment-sensitive, not introduced here) |
| `pnpm test:integration` | pass (27/27) |
| `pnpm build` | pass |
| `pnpm exec publint` | pass ("All good!") |
| `pnpm docs:generate` | idempotent — zero diff against committed generated surfaces |
| `bazelisk build //:pkg` | pass, 139.2s wall, 1776 actions (604 darwin-sandbox, 111 local) |
| `bazelisk test //:test` | 21.3s wall; same 12 pre-existing availability-engine failures as the pnpm lane |

Bazel posture: `.bazelrc` resolves modules through `https://raw.githubusercontent.com/tinyland-inc/bazel-registry/main` then BCR (`bazelisk mod graph` resolves root `tummycrypt_scheduling_kit@0.8.0` with no registry errors). Caching is repo-local disk cache only (`--disk_cache=~/.cache/bazel-scheduling-kit`); no `user.bazelrc`, no `BAZEL_REMOTE_CACHE`, no remote execution attached.