### PR TITLE
fix: make availability-engine tests clock-deterministic

### DIFF
--- a/src/adapters/__tests__/availability-engine.test.ts
+++ b/src/adapters/__tests__/availability-engine.test.ts
@@ -36,8 +36,22 @@ const BASE_CONFIG: SlotConfig = {
   timezone: 'America/New_York',
 };
 
-// A Monday in the future
+// A Monday. The engine filters slots earlier than `now + minAdvanceHours`
+// (even with minAdvanceHours: 0, `earliest` is `now`), so any real-clock run
+// after this date silently filters every candidate slot and the suite fails.
+// Freeze the system time before each test so the fixture date is always
+// "in the future" and results are identical on any machine, any day, any TZ.
 const TEST_DATE = '2026-06-01'; // Monday
+const FROZEN_NOW = new Date('2026-05-25T12:00:00Z'); // one week before TEST_DATE
+
+beforeEach(() => {
+  vi.useFakeTimers({ toFake: ['Date'] });
+  vi.setSystemTime(FROZEN_NOW);
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
 
 // ---------------------------------------------------------------------------
 // getEffectiveHours
@@ -440,8 +454,8 @@ describe('edge cases', () => {
 
   it('minAdvanceHours filters past slots', () => {
     // Set "now" to be at 13:00 ET on test date
-    const fakeNow = parseTimeInTz(TEST_DATE, '13:00', 'America/New_York').getTime();
-    vi.spyOn(Date, 'now').mockReturnValue(fakeNow);
+    const fakeNow = parseTimeInTz(TEST_DATE, '13:00', 'America/New_York');
+    vi.setSystemTime(fakeNow);
 
     const config = { ...BASE_CONFIG, minAdvanceHours: 2 };
     const slots = getAvailableSlots(TEST_DATE, MONDAY_HOURS, null, [], config);
@@ -451,8 +465,15 @@ describe('edge cases', () => {
     expect(new Date(slots[0].datetime).getTime()).toBeGreaterThanOrEqual(
       parseTimeInTz(TEST_DATE, '15:00', 'America/New_York').getTime(),
     );
+  });
 
-    vi.restoreAllMocks();
+  it('filters out every slot once the date is in the past (regression)', () => {
+    // This is the failure mode that broke the suite after 2026-06-01: with the
+    // clock past TEST_DATE, `earliest` (now + minAdvanceHours) exceeds every
+    // candidate slot and the engine correctly returns nothing.
+    vi.setSystemTime(new Date('2026-06-10T12:00:00Z')); // 9 days after TEST_DATE
+    const slots = getAvailableSlots(TEST_DATE, MONDAY_HOURS, null, [], BASE_CONFIG);
+    expect(slots.length).toBe(0);
   });
 
   it('multiple overlapping blocks handled correctly', () => {


### PR DESCRIPTION
## Root cause

The 12 failures in `src/adapters/__tests__/availability-engine.test.ts` are a **date-fixture time bomb**, not a Darwin/Linux, timezone, or Node/ICU issue.

- The suite anchors on `TEST_DATE = '2026-06-01'` ("a Monday in the future" — when written).
- `getAvailableSlots` filters any slot earlier than `now + minAdvanceHours`. Even with the test config's `minAdvanceHours: 0`, `earliest` is `Date.now()`.
- Once the real wall clock passed 2026-06-01, every candidate slot on the fixture date became "past" and was filtered, so slot-producing tests got 0 slots (e.g. line ~438 expected 1 got 0; line ~474 `TypeError: slots[0].datetime` because the array is empty).
- **Why CI is green:** the last CI run on `main` was **2026-05-28** (merge of #95) — before the fixture date passed. CI on Linux/Node 20/22 would fail identically if re-run today.

### Evidence

- The same 12 tests fail identically under `TZ=UTC`, `TZ=America/New_York`, and `TZ=Australia/Sydney` on pristine `origin/main` — timezone ruled out.
- A minimal repro calling `getAvailableSlots('2026-06-01', …)` returns **0 slots with the real clock** (2026-06-10) and **9 slots with the clock faked to 2026-05-28** (CI's last green date) — same machine, same Node (22.22.2), same ICU.
- The three `parseTimeInTz` Intl/DST tests pass on this machine in all tested TZs — no ICU skew in the tested surface.

## Fix

Test-file-local only (no engine change — the engine's past-slot filtering is correct and intentional; no vitest config change — PR #96 owns those files):

- `beforeEach`: `vi.useFakeTimers({ toFake: ['Date'] })` + `vi.setSystemTime('2026-05-25T12:00:00Z')` (one week before `TEST_DATE`), `afterEach`: `vi.useRealTimers()`.
- Converted the `minAdvanceHours` test from `vi.spyOn(Date, 'now')` to `vi.setSystemTime` (no mock-on-mock layering).
- Added a regression test pinning the failure mode: with the clock set after `TEST_DATE`, the engine correctly yields zero slots.

## Validation matrix

| Check | Result |
| --- | --- |
| `pnpm test:unit` (default TZ, America/New_York host) | 622/622 pass (621 prior + 1 new regression test) |
| `pnpm test:unit` under `TZ=UTC` | 622/622 pass |
| `pnpm test:unit` under `TZ=America/New_York` | 622/622 pass |
| `pnpm test:unit` under `TZ=Australia/Sydney` | 622/622 pass |
| `pnpm check` (svelte-check) | 0 errors, 0 warnings |
| `pnpm lint` (`eslint .`) | clean on tracked sources; the only errors are from the untracked local `.claude/worktrees/` dir (pre-existing on this machine, unrelated to this diff; `eslint . --ignore-pattern '.claude/**'` exits 0) |
| `bazelisk test //:test` | PASSED (Bazel 8.1.1, local disk cache only — no remote cache/RBE configured) |

## Independence from PR #96

No shared files. This PR touches only `src/adapters/__tests__/availability-engine.test.ts`; PR #96 touches `.gitignore`, `AGENTS.md`, `README.md`, `docs/testing.md`, `eslint.config.js`, `src/adapters/homegrown.ts`, `vitest.config.ts`, `vitest.integration.config.ts` (verified via `git diff --name-only` vs the PR #96 file list). Mergeable in either order.