### PR TITLE
feat: generic scheduling capability contract + canonical extractCapabilities (TIN-88)

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -9,6 +9,7 @@ Subpackage structure:
   //src/core         - SchedulingAdapter interface, types, Effect wrappers
   //src/adapters     - HomegrownAdapter (PostgreSQL/Drizzle)
   //src/payments     - Stripe, Venmo/PayPal, manual payment adapters
+  //src/onboarding   - Payment provider onboarding (credentials, OAuth, webhooks)
   //src/capabilities - Scheduling runtime capability contract + resolver
   //src/components   - 12 Svelte checkout UI components
   //src/stores       - Svelte stores (checkout state)

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -9,6 +9,7 @@ Subpackage structure:
   //src/core         - SchedulingAdapter interface, types, Effect wrappers
   //src/adapters     - HomegrownAdapter (PostgreSQL/Drizzle)
   //src/payments     - Stripe, Venmo/PayPal, manual payment adapters
+  //src/capabilities - Scheduling runtime capability contract + resolver
   //src/components   - 12 Svelte checkout UI components
   //src/stores       - Svelte stores (checkout state)
   //src/lib          - Utilities (URL builder, Acuity listener)
@@ -204,6 +205,19 @@ ts_project(
         ":core",
         ":node_modules",
         ":node_modules/effect",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+ts_project(
+    name = "capabilities",
+    srcs = glob(["src/capabilities/**/*.ts"], exclude = ["src/capabilities/**/*.test.ts"]),
+    declaration = True,
+    tsconfig = ":tsconfig.json",
+    transpiler = "tsc",
+    validate = False,
+    deps = [
+        ":node_modules",
     ],
     visibility = ["//visibility:public"],
 )

--- a/package.json
+++ b/package.json
@@ -27,6 +27,10 @@
       "types": "./dist/payments/types.d.ts",
       "default": "./dist/payments/types.js"
     },
+    "./capabilities": {
+      "types": "./dist/capabilities/index.d.ts",
+      "default": "./dist/capabilities/index.js"
+    },
     "./core": {
       "types": "./dist/core/index.d.ts",
       "default": "./dist/core/index.js"

--- a/src/capabilities/index.ts
+++ b/src/capabilities/index.ts
@@ -1,0 +1,80 @@
+/**
+ * @tummycrypt/scheduling-kit/capabilities
+ *
+ * Generic scheduling runtime capability contract.
+ *
+ * A capability row answers, for one deployed scheduling surface: which backend
+ * owns booking truth, how the public booking flow is served, which runtime
+ * dependencies (remote bridge, postgres, schedule cache) are required /
+ * optional / skipped, and whether local booking-provider automation is
+ * allowed. Health endpoints and lane guards key off the resolved row instead
+ * of raw env vars, so production surfaces cannot drift backends because a
+ * shared env var changed.
+ *
+ * Ownership split:
+ *
+ * - the kit owns the contract shape and the resolution precedence
+ *   (explicit site row > explicit lane row > dynamic synthesis)
+ * - the adopting application owns the row tables — its site names, lane
+ *   names, and dynamic-host policy
+ *
+ * @example
+ * ```typescript
+ * import {
+ *   resolveSchedulingCapabilities,
+ *   type SchedulingCapabilityRowTable,
+ * } from '@tummycrypt/scheduling-kit/capabilities';
+ *
+ * type Backend = 'homegrown' | 'acuity';
+ *
+ * const SITE_ROWS: SchedulingCapabilityRowTable<Backend> = {
+ *   production: {
+ *     environment: 'production',
+ *     backend: 'acuity',
+ *     publicBookingMode: 'acuity',
+ *     remoteBridge: 'skipped',
+ *     postgres: 'optional',
+ *     cache: 'optional',
+ *     localAutomation: 'forbidden',
+ *     owner: 'acuity',
+ *   },
+ * };
+ *
+ * const capabilities = resolveSchedulingCapabilities(
+ *   { site: 'production', lane: null, backend: 'acuity' },
+ *   {
+ *     siteRows: SITE_ROWS,
+ *     synthesizeDynamic: ({ backend, environment }) => ({
+ *       environment,
+ *       backend,
+ *       publicBookingMode: backend === 'homegrown' ? 'self-service' : 'acuity',
+ *       remoteBridge: backend === 'homegrown' ? 'skipped' : 'optional',
+ *       postgres: backend === 'homegrown' ? 'required' : 'optional',
+ *       cache: 'optional',
+ *       localAutomation: backend === 'homegrown' ? 'forbidden' : 'allowed',
+ *       owner: backend === 'homegrown' ? 'homegrown' : 'scheduling-bridge',
+ *     }),
+ *   },
+ * );
+ * // capabilities.source === 'site'
+ * ```
+ */
+
+// Types
+export type {
+  SchedulingCapabilitySource,
+  RuntimeRequirement,
+  LocalAutomationPolicy,
+  SchedulingRuntimeCapabilities,
+  SchedulingCapabilityRow,
+  SchedulingCapabilityRowTable,
+} from './types.js';
+
+// Resolver
+export type {
+  DynamicCapabilityInput,
+  SchedulingCapabilityTables,
+  SchedulingCapabilityQuery,
+} from './resolve.js';
+
+export { resolveSchedulingCapabilities } from './resolve.js';

--- a/src/capabilities/index.ts
+++ b/src/capabilities/index.ts
@@ -18,6 +18,9 @@
  * - the adopting application owns the row tables — its site names, lane
  *   names, and dynamic-host policy
  *
+ * For payment-method capabilities (`PaymentCapabilities` /
+ * `extractCapabilities`), see `@tummycrypt/scheduling-kit/payments` instead.
+ *
  * @example
  * ```typescript
  * import {

--- a/src/capabilities/resolve.ts
+++ b/src/capabilities/resolve.ts
@@ -1,0 +1,198 @@
+/**
+ * Scheduling capability resolution.
+ *
+ * Precedence (proven in production booking surfaces):
+ *
+ *   1. explicit site row    (`siteRows[site]`)
+ *   2. explicit lane row    (`laneRows[lane]`)
+ *   3. dynamic synthesis    (`synthesizeDynamic({ backend, environment })`)
+ *
+ * The resolver fails closed: unknown or missing site/lane identifiers never
+ * match a row (lookups are own-property only, so inherited keys such as
+ * `toString` cannot leak a row), and empty tables always fall through to the
+ * adopter's explicit dynamic synthesis instead of guessing.
+ */
+import type {
+  SchedulingCapabilityRow,
+  SchedulingCapabilityRowTable,
+  SchedulingRuntimeCapabilities,
+  SchedulingCapabilitySource,
+} from './types.js';
+
+/** Input to the adopter-supplied dynamic synthesizer. */
+export interface DynamicCapabilityInput<TBackend extends string = string> {
+  /** Backend selected for the dynamic host (e.g. from an env var). */
+  readonly backend: TBackend;
+  /** Environment label to stamp on the synthesized row. */
+  readonly environment: string;
+}
+
+/**
+ * Adopter-supplied capability tables and dynamic synthesis policy.
+ */
+export interface SchedulingCapabilityTables<
+  TBackend extends string = string,
+  TBookingMode extends string = string,
+  TOwner extends string = string,
+> {
+  /**
+   * Explicit rows for stable public sites, keyed by the adopter's resolved
+   * site identifier. Highest precedence.
+   */
+  readonly siteRows?: SchedulingCapabilityRowTable<TBackend, TBookingMode, TOwner>;
+  /**
+   * Explicit rows for fixed deployment lanes (e.g. k8s environments), keyed
+   * by lane identifier. Checked after site rows.
+   */
+  readonly laneRows?: SchedulingCapabilityRowTable<TBackend, TBookingMode, TOwner>;
+  /**
+   * Synthesizes a row for dynamic hosts (previews, localhost) when no
+   * explicit row matches. Required so that fallback policy is always a
+   * deliberate adopter decision.
+   */
+  readonly synthesizeDynamic: (
+    input: DynamicCapabilityInput<TBackend>,
+  ) => SchedulingCapabilityRow<TBackend, TBookingMode, TOwner>;
+}
+
+/** Query describing the surface whose capabilities should be resolved. */
+export interface SchedulingCapabilityQuery<TBackend extends string = string> {
+  /** Resolved stable-site identifier, if any. */
+  readonly site?: string | null;
+  /** Resolved deployment-lane identifier, if any. */
+  readonly lane?: string | null;
+  /** Backend value used for dynamic synthesis when no explicit row matches. */
+  readonly backend: TBackend;
+  /** Environment label for dynamically synthesized rows. Defaults to `'unknown'`. */
+  readonly dynamicEnvironment?: string;
+}
+
+const lookupRow = <
+  TBackend extends string,
+  TBookingMode extends string,
+  TOwner extends string,
+>(
+  table: SchedulingCapabilityRowTable<TBackend, TBookingMode, TOwner> | undefined,
+  key: string | null | undefined,
+): SchedulingCapabilityRow<TBackend, TBookingMode, TOwner> | null => {
+  if (!table || !key) return null;
+  // Own-property lookup only: inherited keys (`toString`, `constructor`, …)
+  // and absent keys fail closed to null.
+  return Object.prototype.hasOwnProperty.call(table, key) ? table[key] : null;
+};
+
+const stampSource = <
+  TBackend extends string,
+  TBookingMode extends string,
+  TOwner extends string,
+>(
+  row: SchedulingCapabilityRow<TBackend, TBookingMode, TOwner>,
+  source: SchedulingCapabilitySource,
+): SchedulingRuntimeCapabilities<TBackend, TBookingMode, TOwner> => ({
+  ...row,
+  source,
+});
+
+/**
+ * Resolve runtime scheduling capabilities for a surface.
+ *
+ * Precedence: explicit site row > explicit lane row > dynamic synthesis from
+ * the query's backend value. The resolver stamps `source` on the returned
+ * row according to which step matched.
+ *
+ * @example
+ * ```typescript
+ * import {
+ *   resolveSchedulingCapabilities,
+ *   type SchedulingCapabilityRowTable,
+ *   type SchedulingCapabilityRow,
+ * } from '@tummycrypt/scheduling-kit/capabilities';
+ *
+ * type Backend = 'homegrown' | 'acuity';
+ * type BookingMode = 'acuity' | 'self-service';
+ * type Owner = 'homegrown' | 'scheduling-bridge' | 'acuity';
+ *
+ * // Adopter-owned: stable public sites.
+ * const SITE_ROWS: SchedulingCapabilityRowTable<Backend, BookingMode, Owner> = {
+ *   production: {
+ *     environment: 'production',
+ *     backend: 'acuity',
+ *     publicBookingMode: 'acuity',
+ *     remoteBridge: 'skipped',
+ *     postgres: 'optional',
+ *     cache: 'optional',
+ *     localAutomation: 'forbidden',
+ *     owner: 'acuity',
+ *   },
+ * };
+ *
+ * // Adopter-owned: fixed deployment lanes.
+ * const LANE_ROWS: SchedulingCapabilityRowTable<Backend, BookingMode, Owner> = {
+ *   'bridge-lane': {
+ *     environment: 'bridge-lane',
+ *     backend: 'acuity',
+ *     publicBookingMode: 'self-service',
+ *     remoteBridge: 'required',
+ *     postgres: 'optional',
+ *     cache: 'required',
+ *     localAutomation: 'forbidden',
+ *     owner: 'scheduling-bridge',
+ *   },
+ *   'native-lane': {
+ *     environment: 'native-lane',
+ *     backend: 'homegrown',
+ *     publicBookingMode: 'self-service',
+ *     remoteBridge: 'skipped',
+ *     postgres: 'required',
+ *     cache: 'required',
+ *     localAutomation: 'forbidden',
+ *     owner: 'homegrown',
+ *   },
+ * };
+ *
+ * // Adopter-owned: dynamic policy for previews/localhost.
+ * const synthesizeDynamic = ({
+ *   backend,
+ *   environment,
+ * }: {
+ *   backend: Backend;
+ *   environment: string;
+ * }): SchedulingCapabilityRow<Backend, BookingMode, Owner> => ({
+ *   environment,
+ *   backend,
+ *   publicBookingMode: backend === 'homegrown' ? 'self-service' : 'acuity',
+ *   remoteBridge: backend === 'homegrown' ? 'skipped' : 'optional',
+ *   postgres: backend === 'homegrown' ? 'required' : 'optional',
+ *   cache: 'optional',
+ *   localAutomation: backend === 'homegrown' ? 'forbidden' : 'allowed',
+ *   owner: backend === 'homegrown' ? 'homegrown' : 'scheduling-bridge',
+ * });
+ *
+ * const capabilities = resolveSchedulingCapabilities(
+ *   { site: resolvedSite, lane: resolvedLane, backend: 'acuity' },
+ *   { siteRows: SITE_ROWS, laneRows: LANE_ROWS, synthesizeDynamic },
+ * );
+ * ```
+ */
+export const resolveSchedulingCapabilities = <
+  TBackend extends string = string,
+  TBookingMode extends string = string,
+  TOwner extends string = string,
+>(
+  query: SchedulingCapabilityQuery<TBackend>,
+  tables: SchedulingCapabilityTables<TBackend, TBookingMode, TOwner>,
+): SchedulingRuntimeCapabilities<TBackend, TBookingMode, TOwner> => {
+  const siteRow = lookupRow(tables.siteRows, query.site);
+  if (siteRow) return stampSource(siteRow, 'site');
+
+  const laneRow = lookupRow(tables.laneRows, query.lane);
+  if (laneRow) return stampSource(laneRow, 'lane');
+
+  return stampSource(
+    tables.synthesizeDynamic({
+      backend: query.backend,
+      environment: query.dynamicEnvironment ?? 'unknown',
+    }),
+    'dynamic',
+  );
+};

--- a/src/capabilities/types.ts
+++ b/src/capabilities/types.ts
@@ -1,0 +1,87 @@
+/**
+ * Scheduling runtime capability contract.
+ *
+ * Generic types describing what a deployed scheduling surface is allowed and
+ * required to do at runtime: which backend owns booking truth, how the public
+ * booking flow is served, and which infrastructure dependencies are required,
+ * optional, or skipped.
+ *
+ * The kit owns the *shape* of the contract and the resolution precedence.
+ * Adopting applications own the row tables (their site names, lane names, and
+ * environment policy) — no application constants live here.
+ */
+
+/**
+ * How a capability row was resolved.
+ *
+ * - `site`: matched an explicit row for a stable public site
+ * - `lane`: matched an explicit row for a fixed deployment lane (e.g. a k8s
+ *   environment)
+ * - `dynamic`: synthesized from a backend value for dynamic hosts (previews,
+ *   localhost)
+ */
+export type SchedulingCapabilitySource = 'site' | 'lane' | 'dynamic';
+
+/** Whether a runtime dependency must be present for the surface to be healthy. */
+export type RuntimeRequirement = 'required' | 'optional' | 'skipped';
+
+/** Whether the surface may run local booking-provider automation itself. */
+export type LocalAutomationPolicy = 'allowed' | 'forbidden';
+
+/**
+ * Resolved runtime capabilities for a scheduling surface.
+ *
+ * Type parameters let adopters narrow the open string fields to their own
+ * unions (e.g. `SchedulingRuntimeCapabilities<'homegrown' | 'acuity'>`)
+ * without the kit hardcoding application vocabulary.
+ *
+ * @typeParam TBackend - scheduling backend identifiers used by the adopter
+ * @typeParam TBookingMode - public booking mode identifiers (e.g. a hosted
+ *   provider flow vs. `self-service`)
+ * @typeParam TOwner - which component owns booking automation for the row
+ */
+export interface SchedulingRuntimeCapabilities<
+  TBackend extends string = string,
+  TBookingMode extends string = string,
+  TOwner extends string = string,
+> {
+  /** How this row was resolved (stamped by the resolver, not by row tables). */
+  readonly source: SchedulingCapabilitySource;
+  /** Environment identifier the row describes (site name, lane name, or dynamic label). */
+  readonly environment: string;
+  /** Scheduling backend that owns booking truth for this surface. */
+  readonly backend: TBackend;
+  /** How the public booking flow is served. */
+  readonly publicBookingMode: TBookingMode;
+  /** Whether a remote scheduling bridge service is required at runtime. */
+  readonly remoteBridge: RuntimeRequirement;
+  /** Whether a direct PostgreSQL connection is required at runtime. */
+  readonly postgres: RuntimeRequirement;
+  /** Whether an app-side schedule cache (e.g. Redis) is required at runtime. */
+  readonly cache: RuntimeRequirement;
+  /** Whether this surface may run local booking-provider automation. */
+  readonly localAutomation: LocalAutomationPolicy;
+  /** Component that owns booking automation for this surface. */
+  readonly owner: TOwner;
+}
+
+/**
+ * A capability row as supplied by an adopter. Identical to
+ * {@link SchedulingRuntimeCapabilities} minus `source`, which the resolver
+ * stamps based on which table (or synthesis) produced the row. This prevents
+ * a site row from claiming it was lane- or dynamically-resolved.
+ */
+export type SchedulingCapabilityRow<
+  TBackend extends string = string,
+  TBookingMode extends string = string,
+  TOwner extends string = string,
+> = Omit<SchedulingRuntimeCapabilities<TBackend, TBookingMode, TOwner>, 'source'>;
+
+/**
+ * Adopter-owned table of capability rows keyed by site or lane identifier.
+ */
+export type SchedulingCapabilityRowTable<
+  TBackend extends string = string,
+  TBookingMode extends string = string,
+  TOwner extends string = string,
+> = Readonly<Record<string, SchedulingCapabilityRow<TBackend, TBookingMode, TOwner>>>;

--- a/src/payments/capabilities.ts
+++ b/src/payments/capabilities.ts
@@ -3,7 +3,8 @@
  *
  * This is the canonical extraction logic used by downstream booking surfaces
  * to produce consistent payment method availability. `scheduling-bridge`
- * delegates to this implementation; do not fork the semantics downstream.
+ * will delegate to this implementation once it adopts the next kit release
+ * (Refs: scheduling-bridge#82); do not fork the semantics downstream.
  *
  * Inputs are intentionally generic: a flat string map of practitioner-level
  * settings (typically loaded from a database) and a flat string map of
@@ -21,6 +22,9 @@ import type {
  * Practitioner-scoped settings, e.g. rows from a settings table keyed by
  * setting name. Recognized keys: `stripe_publishable_key`,
  * `stripe_connect_account_id`, `paypal_payee_email`.
+ *
+ * Empty-string values are treated as absent: a setting explicitly cleared to
+ * `''` falls through to the platform env var (and then to disabled).
  */
 export type PractitionerPaymentSettings = Record<string, string>;
 
@@ -28,6 +32,8 @@ export type PractitionerPaymentSettings = Record<string, string>;
  * Platform-scoped environment variables. Recognized keys:
  * `PUBLIC_STRIPE_PUBLISHABLE_KEY`, `STRIPE_CONNECT_ACCOUNT_ID`,
  * `PUBLIC_PAYPAL_CLIENT_ID`, `PAYPAL_PAYEE_EMAIL`, `PAYPAL_ENVIRONMENT`.
+ *
+ * Empty-string values are treated as absent, the same as unset variables.
  */
 export type PlatformPaymentEnv = Record<string, string>;
 

--- a/src/payments/capabilities.ts
+++ b/src/payments/capabilities.ts
@@ -1,0 +1,92 @@
+/**
+ * Payment capability extraction from practitioner settings and platform env vars.
+ *
+ * This is the canonical extraction logic used by downstream booking surfaces
+ * to produce consistent payment method availability. `scheduling-bridge`
+ * delegates to this implementation; do not fork the semantics downstream.
+ *
+ * Inputs are intentionally generic: a flat string map of practitioner-level
+ * settings (typically loaded from a database) and a flat string map of
+ * platform-level environment variables. No host application or bridge types
+ * are required.
+ */
+import type {
+  PaymentCapabilities,
+  PaymentMethodOption,
+  StripeCapability,
+  VenmoCapability,
+} from './types.js';
+
+/**
+ * Practitioner-scoped settings, e.g. rows from a settings table keyed by
+ * setting name. Recognized keys: `stripe_publishable_key`,
+ * `stripe_connect_account_id`, `paypal_payee_email`.
+ */
+export type PractitionerPaymentSettings = Record<string, string>;
+
+/**
+ * Platform-scoped environment variables. Recognized keys:
+ * `PUBLIC_STRIPE_PUBLISHABLE_KEY`, `STRIPE_CONNECT_ACCOUNT_ID`,
+ * `PUBLIC_PAYPAL_CLIENT_ID`, `PAYPAL_PAYEE_EMAIL`, `PAYPAL_ENVIRONMENT`.
+ */
+export type PlatformPaymentEnv = Record<string, string>;
+
+/**
+ * Extract payment capabilities from practitioner settings and platform env vars.
+ *
+ * Priority hierarchy: practitioner settings (DB) > platform env vars > disabled.
+ * Cash at Visit is structurally excluded (cash: false).
+ *
+ * @param settings - Practitioner-specific settings from database
+ * @param env - Platform environment variables
+ * @returns PaymentCapabilities contract for booking surfaces
+ */
+export const extractCapabilities = (
+  settings: PractitionerPaymentSettings,
+  env: PlatformPaymentEnv,
+): PaymentCapabilities => {
+  const methods: PaymentMethodOption[] = [];
+
+  // --- Stripe ---
+  const stripeKey = settings.stripe_publishable_key || env.PUBLIC_STRIPE_PUBLISHABLE_KEY || '';
+  const stripeConnectId = settings.stripe_connect_account_id || env.STRIPE_CONNECT_ACCOUNT_ID || '';
+  let stripe: StripeCapability | null = null;
+
+  if (stripeKey) {
+    stripe = {
+      available: true,
+      publishableKey: stripeKey,
+      ...(stripeConnectId ? { connectedAccountId: stripeConnectId } : {}),
+    };
+    methods.push({
+      id: 'card',
+      name: 'card',
+      displayName: 'Credit/Debit Card',
+      icon: 'card',
+      available: true,
+    });
+  }
+
+  // --- Venmo/PayPal ---
+  const paypalClientId = env.PUBLIC_PAYPAL_CLIENT_ID || '';
+  const payeeEmail = settings.paypal_payee_email || env.PAYPAL_PAYEE_EMAIL || '';
+  const paypalEnv: 'sandbox' | 'production' = env.PAYPAL_ENVIRONMENT === 'production' ? 'production' : 'sandbox';
+  let venmo: VenmoCapability | null = null;
+
+  if (paypalClientId && payeeEmail) {
+    venmo = {
+      available: true,
+      clientId: paypalClientId,
+      environment: paypalEnv,
+    };
+    methods.push({
+      id: 'venmo',
+      name: 'venmo',
+      displayName: 'Venmo',
+      icon: 'venmo',
+      available: true,
+    });
+  }
+
+  return { methods, stripe, venmo, cash: false };
+};

--- a/src/payments/index.ts
+++ b/src/payments/index.ts
@@ -5,6 +5,13 @@
 // Types
 export * from './types.js';
 
+// Payment capability extraction (canonical; scheduling-bridge delegates here)
+export {
+  extractCapabilities,
+  type PractitionerPaymentSettings,
+  type PlatformPaymentEnv,
+} from './capabilities.js';
+
 // Venmo Adapter
 export { createVenmoAdapter } from './venmo.js';
 

--- a/src/tests/unit/capabilities/resolve-scheduling-capabilities.test.ts
+++ b/src/tests/unit/capabilities/resolve-scheduling-capabilities.test.ts
@@ -1,0 +1,215 @@
+/**
+ * Tests for the generic scheduling capability resolver.
+ *
+ * Precedence under test: explicit site row > explicit lane row > dynamic
+ * synthesis. Row tables are adopter-supplied; the kit only owns the contract
+ * shape and the resolution order. Tables here are deliberately generic —
+ * no application site or lane names.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  resolveSchedulingCapabilities,
+  type DynamicCapabilityInput,
+  type SchedulingCapabilityRow,
+  type SchedulingCapabilityRowTable,
+} from '../../../capabilities/index.js';
+
+type Backend = 'homegrown' | 'acuity';
+type BookingMode = 'hosted' | 'self-service';
+type Owner = 'app' | 'bridge' | 'provider';
+
+type Row = SchedulingCapabilityRow<Backend, BookingMode, Owner>;
+type Table = SchedulingCapabilityRowTable<Backend, BookingMode, Owner>;
+
+const SITE_ROWS: Table = {
+  'public-prod': {
+    environment: 'public-prod',
+    backend: 'acuity',
+    publicBookingMode: 'hosted',
+    remoteBridge: 'skipped',
+    postgres: 'optional',
+    cache: 'optional',
+    localAutomation: 'forbidden',
+    owner: 'provider',
+  },
+  'public-staging': {
+    environment: 'public-staging',
+    backend: 'homegrown',
+    publicBookingMode: 'self-service',
+    remoteBridge: 'skipped',
+    postgres: 'required',
+    cache: 'optional',
+    localAutomation: 'forbidden',
+    owner: 'app',
+  },
+};
+
+const LANE_ROWS: Table = {
+  'bridge-lane': {
+    environment: 'bridge-lane',
+    backend: 'acuity',
+    publicBookingMode: 'self-service',
+    remoteBridge: 'required',
+    postgres: 'optional',
+    cache: 'required',
+    localAutomation: 'forbidden',
+    owner: 'bridge',
+  },
+  'native-lane': {
+    environment: 'native-lane',
+    backend: 'homegrown',
+    publicBookingMode: 'self-service',
+    remoteBridge: 'skipped',
+    postgres: 'required',
+    cache: 'required',
+    localAutomation: 'forbidden',
+    owner: 'app',
+  },
+};
+
+const synthesizeDynamic = ({ backend, environment }: DynamicCapabilityInput<Backend>): Row => ({
+  environment,
+  backend,
+  publicBookingMode: backend === 'homegrown' ? 'self-service' : 'hosted',
+  remoteBridge: backend === 'homegrown' ? 'skipped' : 'optional',
+  postgres: backend === 'homegrown' ? 'required' : 'optional',
+  cache: 'optional',
+  localAutomation: backend === 'homegrown' ? 'forbidden' : 'allowed',
+  owner: backend === 'homegrown' ? 'app' : 'bridge',
+});
+
+const TABLES = { siteRows: SITE_ROWS, laneRows: LANE_ROWS, synthesizeDynamic };
+
+describe('resolveSchedulingCapabilities', () => {
+  describe('precedence', () => {
+    it('resolves an explicit site row first and stamps source=site', () => {
+      const caps = resolveSchedulingCapabilities(
+        { site: 'public-prod', lane: 'bridge-lane', backend: 'homegrown' },
+        TABLES,
+      );
+      expect(caps.source).toBe('site');
+      expect(caps.environment).toBe('public-prod');
+      expect(caps.backend).toBe('acuity');
+      expect(caps.owner).toBe('provider');
+    });
+
+    it('site row wins even when the query backend disagrees (no env-var drift)', () => {
+      const caps = resolveSchedulingCapabilities(
+        { site: 'public-prod', lane: null, backend: 'homegrown' },
+        TABLES,
+      );
+      // The shared backend value must not flip a stable site's policy.
+      expect(caps.backend).toBe('acuity');
+      expect(caps.publicBookingMode).toBe('hosted');
+    });
+
+    it('falls back to the lane row when no site matches and stamps source=lane', () => {
+      const caps = resolveSchedulingCapabilities(
+        { site: null, lane: 'bridge-lane', backend: 'homegrown' },
+        TABLES,
+      );
+      expect(caps.source).toBe('lane');
+      expect(caps.environment).toBe('bridge-lane');
+      expect(caps.remoteBridge).toBe('required');
+      expect(caps.owner).toBe('bridge');
+    });
+
+    it('synthesizes dynamically when neither site nor lane matches', () => {
+      const caps = resolveSchedulingCapabilities(
+        { site: null, lane: null, backend: 'homegrown' },
+        TABLES,
+      );
+      expect(caps.source).toBe('dynamic');
+      expect(caps.backend).toBe('homegrown');
+      expect(caps.publicBookingMode).toBe('self-service');
+      expect(caps.postgres).toBe('required');
+      expect(caps.localAutomation).toBe('forbidden');
+    });
+
+    it('synthesizes provider-backed capabilities for non-homegrown dynamic hosts', () => {
+      const caps = resolveSchedulingCapabilities(
+        { site: null, lane: null, backend: 'acuity' },
+        TABLES,
+      );
+      expect(caps.source).toBe('dynamic');
+      expect(caps.remoteBridge).toBe('optional');
+      expect(caps.localAutomation).toBe('allowed');
+      expect(caps.owner).toBe('bridge');
+    });
+  });
+
+  describe('dynamic environment label', () => {
+    it('defaults the dynamic environment to "unknown"', () => {
+      const caps = resolveSchedulingCapabilities(
+        { site: null, lane: null, backend: 'acuity' },
+        TABLES,
+      );
+      expect(caps.environment).toBe('unknown');
+    });
+
+    it('passes dynamicEnvironment through to the synthesizer', () => {
+      const caps = resolveSchedulingCapabilities(
+        { site: null, lane: null, backend: 'acuity', dynamicEnvironment: 'preview-42' },
+        TABLES,
+      );
+      expect(caps.environment).toBe('preview-42');
+    });
+  });
+
+  describe('fail-closed behavior', () => {
+    it('unknown site and lane identifiers never match a row', () => {
+      const caps = resolveSchedulingCapabilities(
+        { site: 'no-such-site', lane: 'no-such-lane', backend: 'acuity' },
+        TABLES,
+      );
+      expect(caps.source).toBe('dynamic');
+    });
+
+    it('empty row tables fall through to dynamic synthesis', () => {
+      const caps = resolveSchedulingCapabilities(
+        { site: 'public-prod', lane: 'bridge-lane', backend: 'homegrown' },
+        { siteRows: {}, laneRows: {}, synthesizeDynamic },
+      );
+      expect(caps.source).toBe('dynamic');
+      expect(caps.backend).toBe('homegrown');
+    });
+
+    it('omitted row tables fall through to dynamic synthesis', () => {
+      const caps = resolveSchedulingCapabilities(
+        { site: 'public-prod', lane: 'bridge-lane', backend: 'acuity' },
+        { synthesizeDynamic },
+      );
+      expect(caps.source).toBe('dynamic');
+    });
+
+    it('inherited object keys do not leak rows (own-property lookup only)', () => {
+      const caps = resolveSchedulingCapabilities(
+        { site: 'toString', lane: 'constructor', backend: 'acuity' },
+        TABLES,
+      );
+      expect(caps.source).toBe('dynamic');
+    });
+
+    it('empty-string identifiers do not match rows', () => {
+      const caps = resolveSchedulingCapabilities(
+        { site: '', lane: '', backend: 'acuity' },
+        TABLES,
+      );
+      expect(caps.source).toBe('dynamic');
+    });
+  });
+
+  describe('source stamping', () => {
+    it('stamps source from the resolver, returning a new object', () => {
+      const caps = resolveSchedulingCapabilities(
+        { site: 'public-staging', lane: null, backend: 'acuity' },
+        TABLES,
+      );
+      expect(caps.source).toBe('site');
+      // Resolution must not mutate the adopter's row table.
+      expect(SITE_ROWS['public-staging']).not.toHaveProperty('source');
+      expect(caps).not.toBe(SITE_ROWS['public-staging']);
+    });
+  });
+});

--- a/src/tests/unit/capabilities/resolve-scheduling-capabilities.test.ts
+++ b/src/tests/unit/capabilities/resolve-scheduling-capabilities.test.ts
@@ -7,7 +7,7 @@
  * no application site or lane names.
  */
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import {
   resolveSchedulingCapabilities,
   type DynamicCapabilityInput,
@@ -115,6 +115,28 @@ describe('resolveSchedulingCapabilities', () => {
       expect(caps.owner).toBe('bridge');
     });
 
+    it('falls through an unknown site to a known lane row (no site short-circuit)', () => {
+      // A present-but-unmatched site must not short-circuit to dynamic
+      // synthesis; the lane tier is still consulted.
+      const caps = resolveSchedulingCapabilities(
+        { site: 'no-such-site', lane: 'bridge-lane', backend: 'acuity' },
+        TABLES,
+      );
+      expect(caps.source).toBe('lane');
+      expect(caps.environment).toBe('bridge-lane');
+    });
+
+    it('lane row wins even when the query backend disagrees (no env-var drift)', () => {
+      const caps = resolveSchedulingCapabilities(
+        { site: null, lane: 'native-lane', backend: 'acuity' },
+        TABLES,
+      );
+      // The shared backend value must not flip a fixed lane's policy either.
+      expect(caps.source).toBe('lane');
+      expect(caps.backend).toBe('homegrown');
+      expect(caps.publicBookingMode).toBe('self-service');
+    });
+
     it('synthesizes dynamically when neither site nor lane matches', () => {
       const caps = resolveSchedulingCapabilities(
         { site: null, lane: null, backend: 'homegrown' },
@@ -197,6 +219,38 @@ describe('resolveSchedulingCapabilities', () => {
         TABLES,
       );
       expect(caps.source).toBe('dynamic');
+    });
+  });
+
+  describe('dynamic synthesis laziness', () => {
+    it('does not invoke synthesizeDynamic when a site row matches', () => {
+      const synthesizeSpy = vi.fn(synthesizeDynamic);
+      const caps = resolveSchedulingCapabilities(
+        { site: 'public-prod', lane: null, backend: 'homegrown' },
+        { siteRows: SITE_ROWS, laneRows: LANE_ROWS, synthesizeDynamic: synthesizeSpy },
+      );
+      expect(caps.source).toBe('site');
+      expect(synthesizeSpy).not.toHaveBeenCalled();
+    });
+
+    it('does not invoke synthesizeDynamic when a lane row matches', () => {
+      const synthesizeSpy = vi.fn(synthesizeDynamic);
+      const caps = resolveSchedulingCapabilities(
+        { site: null, lane: 'bridge-lane', backend: 'homegrown' },
+        { siteRows: SITE_ROWS, laneRows: LANE_ROWS, synthesizeDynamic: synthesizeSpy },
+      );
+      expect(caps.source).toBe('lane');
+      expect(synthesizeSpy).not.toHaveBeenCalled();
+    });
+
+    it('invokes synthesizeDynamic exactly once when both lookups miss', () => {
+      const synthesizeSpy = vi.fn(synthesizeDynamic);
+      const caps = resolveSchedulingCapabilities(
+        { site: null, lane: null, backend: 'acuity' },
+        { siteRows: SITE_ROWS, laneRows: LANE_ROWS, synthesizeDynamic: synthesizeSpy },
+      );
+      expect(caps.source).toBe('dynamic');
+      expect(synthesizeSpy).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/src/tests/unit/payments/capabilities.test.ts
+++ b/src/tests/unit/payments/capabilities.test.ts
@@ -66,7 +66,7 @@ describe('extractCapabilities', () => {
     expect(caps.methods).not.toContainEqual(expect.objectContaining({ id: 'venmo' }));
   });
 
-  it('should prefer practitioner payee email over env var', () => {
+  it('should enable Venmo when both practitioner and platform payee emails are present', () => {
     const settings = { paypal_payee_email: 'practitioner@example.com' };
     const env = {
       PUBLIC_PAYPAL_CLIENT_ID: 'paypal_123',
@@ -74,8 +74,9 @@ describe('extractCapabilities', () => {
     };
     const caps = extractCapabilities(settings, env);
     expect(caps.venmo).not.toBeNull();
-    // Payee routing uses the practitioner value; env is fallback only.
-    // (Payee email is server-side routing input, not exposed on the capability.)
+    // Payee email only gates enablement here; which value routes the payment
+    // is decided outside this function, so settings-over-env precedence for
+    // the payee is not observable (and not asserted) at this API boundary.
     expect(caps.venmo!.clientId).toBe('paypal_123');
   });
 

--- a/src/tests/unit/payments/capabilities.test.ts
+++ b/src/tests/unit/payments/capabilities.test.ts
@@ -1,0 +1,124 @@
+/**
+ * Tests for payment capability extraction.
+ *
+ * Parity-ported from scheduling-bridge's capabilities tests: the bridge
+ * delegates to this kit implementation, so these cases pin the canonical
+ * semantics (settings > env > disabled, cash structurally false).
+ */
+
+import { describe, it, expect } from 'vitest';
+import { extractCapabilities } from '../../../payments/capabilities.js';
+import type { PaymentCapabilities } from '../../../payments/types.js';
+
+describe('extractCapabilities', () => {
+  it('should return empty capabilities when nothing is configured', () => {
+    const caps: PaymentCapabilities = extractCapabilities({}, {});
+    expect(caps.methods).toEqual([]);
+    expect(caps.stripe).toBeNull();
+    expect(caps.venmo).toBeNull();
+    expect(caps.cash).toBe(false);
+  });
+
+  it('should detect Stripe from practitioner settings', () => {
+    const settings = { stripe_publishable_key: 'pk_test_123' };
+    const caps = extractCapabilities(settings, {});
+    expect(caps.stripe).not.toBeNull();
+    expect(caps.stripe!.available).toBe(true);
+    expect(caps.stripe!.publishableKey).toBe('pk_test_123');
+    expect(caps.methods).toContainEqual(expect.objectContaining({ id: 'card', available: true }));
+  });
+
+  it('should detect Stripe from env var fallback', () => {
+    const env = { PUBLIC_STRIPE_PUBLISHABLE_KEY: 'pk_test_env' };
+    const caps = extractCapabilities({}, env);
+    expect(caps.stripe!.publishableKey).toBe('pk_test_env');
+  });
+
+  it('should prefer practitioner settings over env vars for Stripe', () => {
+    const settings = { stripe_publishable_key: 'pk_practitioner' };
+    const env = { PUBLIC_STRIPE_PUBLISHABLE_KEY: 'pk_platform' };
+    const caps = extractCapabilities(settings, env);
+    expect(caps.stripe!.publishableKey).toBe('pk_practitioner');
+  });
+
+  it('should detect Venmo when client ID and payee email both exist', () => {
+    const settings = { paypal_payee_email: 'practitioner@example.com' };
+    const env = { PUBLIC_PAYPAL_CLIENT_ID: 'paypal_123', PAYPAL_ENVIRONMENT: 'sandbox' };
+    const caps = extractCapabilities(settings, env);
+    expect(caps.venmo).not.toBeNull();
+    expect(caps.venmo!.available).toBe(true);
+    expect(caps.venmo!.clientId).toBe('paypal_123');
+    expect(caps.venmo!.environment).toBe('sandbox');
+    expect(caps.methods).toContainEqual(expect.objectContaining({ id: 'venmo', available: true }));
+  });
+
+  it('should NOT enable Venmo when payee email is missing', () => {
+    const env = { PUBLIC_PAYPAL_CLIENT_ID: 'paypal_123' };
+    const caps = extractCapabilities({}, env);
+    expect(caps.venmo).toBeNull();
+    expect(caps.methods).not.toContainEqual(expect.objectContaining({ id: 'venmo' }));
+  });
+
+  it('should NOT enable Venmo when client ID is missing', () => {
+    const settings = { paypal_payee_email: 'practitioner@example.com' };
+    const caps = extractCapabilities(settings, {});
+    expect(caps.venmo).toBeNull();
+    expect(caps.methods).not.toContainEqual(expect.objectContaining({ id: 'venmo' }));
+  });
+
+  it('should prefer practitioner payee email over env var', () => {
+    const settings = { paypal_payee_email: 'practitioner@example.com' };
+    const env = {
+      PUBLIC_PAYPAL_CLIENT_ID: 'paypal_123',
+      PAYPAL_PAYEE_EMAIL: 'platform@example.com',
+    };
+    const caps = extractCapabilities(settings, env);
+    expect(caps.venmo).not.toBeNull();
+    // Payee routing uses the practitioner value; env is fallback only.
+    // (Payee email is server-side routing input, not exposed on the capability.)
+    expect(caps.venmo!.clientId).toBe('paypal_123');
+  });
+
+  it('should default PayPal environment to sandbox for unknown values', () => {
+    const settings = { paypal_payee_email: 'practitioner@example.com' };
+    const env = { PUBLIC_PAYPAL_CLIENT_ID: 'paypal_123', PAYPAL_ENVIRONMENT: 'staging' };
+    const caps = extractCapabilities(settings, env);
+    expect(caps.venmo!.environment).toBe('sandbox');
+  });
+
+  it('should return both Stripe and Venmo when both configured', () => {
+    const settings = {
+      stripe_publishable_key: 'pk_test_123',
+      paypal_payee_email: 'practitioner@example.com',
+    };
+    const env = { PUBLIC_PAYPAL_CLIENT_ID: 'paypal_123', PAYPAL_ENVIRONMENT: 'production' };
+    const caps = extractCapabilities(settings, env);
+    expect(caps.stripe!.available).toBe(true);
+    expect(caps.venmo!.available).toBe(true);
+    expect(caps.venmo!.environment).toBe('production');
+    expect(caps.methods).toHaveLength(2);
+  });
+
+  it('should never enable cash', () => {
+    const settings = { allow_cash: 'true', cash_enabled: 'true' };
+    const caps = extractCapabilities(settings, {});
+    expect(caps.cash).toBe(false);
+    expect(caps.methods).not.toContainEqual(expect.objectContaining({ id: 'cash' }));
+  });
+
+  it('should include connected account ID when available', () => {
+    const settings = {
+      stripe_publishable_key: 'pk_test_123',
+      stripe_connect_account_id: 'acct_123',
+    };
+    const caps = extractCapabilities(settings, {});
+    expect(caps.stripe!.connectedAccountId).toBe('acct_123');
+  });
+
+  it('should omit connected account ID when not configured', () => {
+    const settings = { stripe_publishable_key: 'pk_test_123' };
+    const caps = extractCapabilities(settings, {});
+    expect(caps.stripe).not.toBeNull();
+    expect('connectedAccountId' in caps.stripe!).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Kit half of TIN-88 / kit side of Jesssullivan/scheduling-bridge#82: move booking-surface capability policy into the reusable kit so the bridge stays focused on remote Acuity automation and apps adopt a shared contract.

- `src/payments/capabilities.ts` — canonical `extractCapabilities` (practitioner settings > platform env > disabled; `'card'`/`'venmo'` methods; `cash: false` structurally). Exported from `./payments` (and the root barrel via the payments re-export).
- `src/capabilities/` — new `./capabilities` subpath export: generic `SchedulingRuntimeCapabilities` (source, environment, backend, publicBookingMode, `required|optional|skipped` requirements for remoteBridge/postgres/cache, `allowed|forbidden` localAutomation, owner) plus `resolveSchedulingCapabilities` with site row > lane row > dynamic synthesis precedence. Adopters supply the row tables and dynamic policy; the kit owns only the contract shape and resolution order. Consumer wiring example in the module docstring.
- `BUILD.bazel` — `//:capabilities` `ts_project` wired consistently with the sibling per-directory targets.

## Requirement → implementation

| Requirement | Implementation |
| --- | --- |
| Port `extractCapabilities` with exactly the bridge's semantics | `src/payments/capabilities.ts`. Function body is byte-identical to `scheduling-bridge` `src/capabilities.ts` (verified by diff); only the doc header, the type-import path (kit-local `./types.js` instead of the published `@tummycrypt/scheduling-kit/payments` — same declarations), and two named parameter aliases structurally equal to `Record<string, string>` differ. Bridge delegation/re-export lands after the next kit release (tracked on bridge#82); the doc header states this as pending, not landed. Empty-string settings/env values are documented as treated-as-absent (`\|\|` fallback), matching bridge behavior. |
| Generalize inputs, no bridge/app types | `PractitionerPaymentSettings` / `PlatformPaymentEnv` are flat string maps with documented recognized keys; no host imports. |
| Generic capability-contract module | `src/capabilities/{types,resolve,index}.ts`. Open string fields are type parameters (`TBackend`/`TBookingMode`/`TOwner`) so adopters narrow to their unions; no app lane names, hostnames, or practitioner constants in the kit. Source values generalized to `site | lane | dynamic` (app's `stable-site`/`k8s` map onto these at the adopter boundary). |
| Proven precedence, adopter-supplied rows | `resolveSchedulingCapabilities(query, tables)`: explicit site row > lane row > required `synthesizeDynamic({ backend, environment })`. Row tables omit `source`; the resolver stamps it, so a row cannot claim a different resolution path. |
| Fail-closed resolution | Own-property lookups only (inherited keys like `toString` never match), empty/omitted tables and unknown or empty identifiers always fall through to the adopter's explicit dynamic synthesis. |
| Subpath wiring mirrors `./onboarding` / `./reconciliation` | `package.json` `exports["./capabilities"]` → `dist/capabilities`; svelte-package already compiles all of `src/` (`kit.files.lib = 'src'`), verified `dist/capabilities/` in both pnpm and Bazel pkg outputs. |
| Tests | `src/tests/unit/payments/capabilities.test.ts` (13 cases; parity-ported from the bridge's `tests/capabilities.test.ts` + added client-ID-missing, both-payee-sources-present, sandbox-default, connectedAccountId-omitted cases) and `src/tests/unit/capabilities/resolve-scheduling-capabilities.test.ts` (18 cases: precedence incl. unknown-site→known-lane fall-through, site- and lane-row backend no-drift, lazy `synthesizeDynamic` (not invoked when a row matches; exactly once on double miss), source stamping, dynamic env labels, fail-closed empty/omitted/unknown/inherited-key/empty-string rows). Placed under `src/tests/unit/` to match the existing vitest `include` globs without touching `vitest.config.ts` (kept disjoint from #96). |
| Bazel | `//:capabilities` `ts_project` added consistently with siblings. `bazel build //:pkg` green. |

## Validation (at `aa23fc4`)

| Check | Result |
| --- | --- |
| `pnpm check` (svelte-check) | 0 errors, 0 warnings (1935 files) |
| `pnpm lint` (eslint) | clean |
| `pnpm test:unit` | 640 passed / 12 failed — all 12 failures are the pre-existing clock-dependent `src/adapters/__tests__/availability-engine.test.ts` cases on untouched `origin/main` (`aa07055`); #97 fixes exactly that file. All 31 new tests pass. |
| `pnpm build` (svelte-package) | green; emits `dist/capabilities/` |
| `pnpm exec publint` | All good |
| `bazelisk build //:pkg` | green in 23s (9 processes: 3533 action-cache hits, 2 darwin-sandbox, 6 local; local sandboxed execution, disk cache only — no RBE configured in `.bazelrc`) |
| `bazelisk build //:capabilities` | fails with `TS5083` (sandbox missing `.svelte-kit/tsconfig.json`) — pre-existing infra behavior shared by the untouched sibling targets (`//:payments`, `//:core` fail identically on main); the canonical `//:pkg` path is unaffected, and `//:capabilities` is not in the CI target set |

No version bump (release PRs own that). Diff is disjoint from #96 and #97.

Merge-order note: the red `package / validate` lanes are inherited from the pre-existing `availability-engine.test.ts` failures on main; land #97 first (or rebase this branch after it merges) — do not merge red.

Refs: TIN-88, TIN-1994, Jesssullivan/scheduling-bridge#82
