### PR TITLE
fix(payments): normalize public card payment method boundary

### DIFF
--- a/src/components/CheckoutDrawer.svelte
+++ b/src/components/CheckoutDrawer.svelte
@@ -6,7 +6,7 @@
   import { Effect } from 'effect';
   import type { SchedulingKit } from '../core/pipelines.js';
   import { Errors, type Service, type Provider, type ClientInfo, type AvailableDate, type TimeSlot, type SchedulingError } from '../core/types.js';
-  import type { PaymentMethodOption } from '../payments/types.js';
+  import { toPublicPaymentMethodOption, type PaymentMethodOption } from '../payments/types.js';
   import { createCheckoutStore, setCheckoutContext } from '../stores/checkout.svelte.js';
   import { generateIdempotencyKey } from '../core/utils.js';
   import ServicePicker from './ServicePicker.svelte';
@@ -159,14 +159,8 @@
 
     const methods: PaymentMethodOption[] = [];
     for (const adapter of kit.payments.getAll()) {
-      const config = adapter.getClientConfig();
-      methods.push({
-        id: adapter.name,
-        name: adapter.name,
-        displayName: config.displayName,
-        icon: config.icon,
-        available: true,
-      });
+      // Emit canonical public ids ('card', never internal 'stripe')
+      methods.push(toPublicPaymentMethodOption(adapter));
     }
 
     paymentMethods = methods;

--- a/src/components/HybridCheckoutDrawer.svelte
+++ b/src/components/HybridCheckoutDrawer.svelte
@@ -21,7 +21,12 @@
   import VenmoCheckout from './VenmoCheckout.svelte';
   import StripeCheckout from './StripeCheckout.svelte';
   import type { PaymentCapabilities } from '../payments/types.js';
-  import { getDefaultCapabilities } from '../payments/types.js';
+  import {
+    getDefaultCapabilities,
+    isCardPaymentMethodId,
+    isManualPaymentMethodId,
+    toPublicPaymentMethodId,
+  } from '../payments/types.js';
 
   // =============================================================================
   // TYPES
@@ -226,12 +231,19 @@
   };
 
   const handlePaymentSelect = async (paymentId: string) => {
-    selectedPayment = paymentId;
+    // Selector state always holds the canonical public id ('card', never the
+    // internal 'stripe' adapter name).
+    selectedPayment = toPublicPaymentMethodId(paymentId);
 
     if (paymentId === 'venmo' && capabilities.venmo?.available && onCreatePaymentOrder && onCapturePayment) {
       // Use PayPal SDK flow for Venmo — requires client-side approval
       step = 'venmo-checkout';
-    } else if (paymentId === 'stripe' && capabilities.stripe?.available && onCreateStripeIntent && selectedService) {
+    } else if (paymentId === 'venmo') {
+      // Venmo selected but not available — never fall through to manual completion
+      errorMessage = 'Venmo payments are not available right now.';
+      step = 'error';
+    } else if (isCardPaymentMethodId(paymentId) && capabilities.stripe?.available && onCreateStripeIntent && selectedService) {
+      // Public 'card' (and the legacy 'stripe' alias) -> Stripe Elements flow.
       // Create PaymentIntent server-side, then show Stripe Elements
       step = 'processing';
       try {
@@ -245,8 +257,16 @@
         errorMessage = e instanceof Error ? e.message : 'Failed to initialize payment';
         step = 'error';
       }
-    } else {
+    } else if (isCardPaymentMethodId(paymentId)) {
+      // Card selected but Stripe is unavailable — never fall through to manual completion
+      errorMessage = 'Card payments are not available right now.';
+      step = 'error';
+    } else if (isManualPaymentMethodId(paymentId)) {
+      // Only explicit manual methods may complete in-app
       processCustomPayment(paymentId);
+    } else {
+      errorMessage = 'This payment method is not supported in the current checkout flow.';
+      step = 'error';
     }
   };
 

--- a/src/components/PaymentSelector.svelte
+++ b/src/components/PaymentSelector.svelte
@@ -36,7 +36,8 @@
   const getIcon = (method: PaymentMethodOption): string => {
     const icons: Record<string, string> = {
       venmo: '💙',
-      stripe: '💳',
+      card: '💳',
+      stripe: '💳', // legacy internal alias of the public 'card' id
       cash: '💵',
       zelle: '⚡',
       check: '📝',

--- a/src/core/pipelines.ts
+++ b/src/core/pipelines.ts
@@ -353,9 +353,16 @@ export const createSchedulingKit = (
   const payments = new Map<string, PaymentAdapter>();
   for (const a of registry.getAll()) {
     payments.set(a.name, a);
-    // Alias the canonical public id ('card' -> stripe adapter) so booking
-    // flows driven by public selections resolve the correct processor.
-    payments.set(toPublicPaymentMethodId(a.name), a);
+  }
+  // Alias the canonical public id ('card' -> stripe adapter) so booking
+  // flows driven by public selections resolve the correct processor. Aliases
+  // only claim unclaimed ids: a literally named adapter always wins over an
+  // alias regardless of registration order, matching registry.get() precedence.
+  for (const a of registry.getAll()) {
+    const publicId = toPublicPaymentMethodId(a.name);
+    if (!payments.has(publicId)) {
+      payments.set(publicId, a);
+    }
   }
 
   return {

--- a/src/core/pipelines.ts
+++ b/src/core/pipelines.ts
@@ -18,7 +18,7 @@ import { Errors } from './types.js';
 import { validateWith, generateIdempotencyKey, withCorrelationId } from './utils.js';
 import type { SchedulingAdapter } from '../adapters/types.js';
 import type { PaymentAdapter, PaymentRegistry as CanonicalPaymentRegistry } from '../payments/types.js';
-import { createPaymentRegistry } from '../payments/types.js';
+import { createPaymentRegistry, toInternalPaymentMethodId, toPublicPaymentMethodId } from '../payments/types.js';
 import { z } from 'zod';
 
 // =============================================================================
@@ -93,7 +93,10 @@ export const completeBookingWithAltPayment = (
   const { scheduler, payments, correlationId } = ctx;
   const { request, paymentMethod } = input;
 
-  const paymentAdapter = payments.get(paymentMethod);
+  // Public ids ('card') resolve to internally named adapters ('stripe').
+  // Unsupported selections fail with a typed error — never a manual fallback.
+  const paymentAdapter =
+    payments.get(paymentMethod) ?? payments.get(toInternalPaymentMethodId(paymentMethod));
   if (!paymentAdapter) {
     return Effect.fail(Errors.payment('INVALID_METHOD', `Unknown payment method: ${paymentMethod}`, paymentMethod, false));
   }
@@ -288,7 +291,9 @@ export const cancelBookingWithRefund = (
     // Extract payment processor from notes
     const processorMatch = booking.paymentRef?.match(/\[(\w+)\]/);
     const processor = processorMatch?.[1]?.toLowerCase();
-    const paymentAdapter = processor ? payments.get(processor) : undefined;
+    const paymentAdapter = processor
+      ? payments.get(processor) ?? payments.get(toInternalPaymentMethodId(processor))
+      : undefined;
 
     if (!paymentAdapter) {
       return { cancelled: true, refund: { success: false } } satisfies CancellationResult;
@@ -348,6 +353,9 @@ export const createSchedulingKit = (
   const payments = new Map<string, PaymentAdapter>();
   for (const a of registry.getAll()) {
     payments.set(a.name, a);
+    // Alias the canonical public id ('card' -> stripe adapter) so booking
+    // flows driven by public selections resolve the correct processor.
+    payments.set(toPublicPaymentMethodId(a.name), a);
   }
 
   return {

--- a/src/payments/manual.ts
+++ b/src/payments/manual.ts
@@ -18,6 +18,7 @@ import type {
   PaymentClientConfig,
   ManualPaymentConfig,
 } from './types.js';
+import { DEFAULT_MANUAL_ADAPTER_NAME } from './types.js';
 
 // =============================================================================
 // MANUAL PAYMENT ADAPTER
@@ -29,7 +30,7 @@ import type {
  */
 export const createManualPaymentAdapter = (
   config: ManualPaymentConfig,
-  methodName: string = 'manual',
+  methodName: string = DEFAULT_MANUAL_ADAPTER_NAME,
   displayName: string = 'Pay Later'
 ): PaymentAdapter => {
   return {

--- a/src/payments/types.ts
+++ b/src/payments/types.ts
@@ -186,6 +186,15 @@ export const MANUAL_PAYMENT_METHOD_IDS = [
 
 export type ManualPaymentMethodId = (typeof MANUAL_PAYMENT_METHOD_IDS)[number];
 
+/**
+ * Default adapter name shipped by `createManualPaymentAdapter`.
+ *
+ * Kept separate from `MANUAL_PAYMENT_METHOD_IDS` because that list types
+ * `ManualPaymentConfig.methods` values, while 'manual' is an adapter name —
+ * but both must be routable as manual completions on checkout surfaces.
+ */
+export const DEFAULT_MANUAL_ADAPTER_NAME = 'manual';
+
 /** Map an internal adapter name to the canonical public payment method id. */
 export const toPublicPaymentMethodId = (paymentMethodId: string): string =>
   paymentMethodId === INTERNAL_STRIPE_PAYMENT_METHOD_ID
@@ -203,8 +212,12 @@ export const isCardPaymentMethodId = (paymentMethodId: string): boolean =>
   paymentMethodId === PUBLIC_CARD_PAYMENT_METHOD_ID ||
   paymentMethodId === INTERNAL_STRIPE_PAYMENT_METHOD_ID;
 
-/** True only for explicit manual methods; unknown ids are NOT manual. */
+/**
+ * True only for explicit manual methods (including the kit's own default
+ * manual adapter name); unknown ids are NOT manual.
+ */
 export const isManualPaymentMethodId = (paymentMethodId: string): boolean =>
+  paymentMethodId === DEFAULT_MANUAL_ADAPTER_NAME ||
   (MANUAL_PAYMENT_METHOD_IDS as readonly string[]).includes(paymentMethodId);
 
 // =============================================================================
@@ -301,11 +314,21 @@ export const toPublicPaymentMethodOption = (adapter: PaymentAdapter): PaymentMet
   const config = adapter.getClientConfig();
   const publicId = toPublicPaymentMethodId(adapter.name);
 
+  // Icon tokens are a separate domain from method ids — do not reuse the id
+  // normalizer here. Only the stripe adapter's own legacy 'stripe' icon token
+  // is rewritten to the public 'card' token; emoji, URLs, and custom tokens
+  // (even one literally named 'stripe' on another adapter) pass through.
+  const icon =
+    adapter.name === INTERNAL_STRIPE_PAYMENT_METHOD_ID &&
+    config.icon === INTERNAL_STRIPE_PAYMENT_METHOD_ID
+      ? PUBLIC_CARD_PAYMENT_METHOD_ID
+      : config.icon;
+
   return {
     id: publicId,
     name: publicId,
     displayName: config.displayName,
-    icon: config.icon ? toPublicPaymentMethodId(config.icon) : undefined,
+    icon,
     available: true,
   };
 };
@@ -324,20 +347,26 @@ export const createPaymentRegistry = (): PaymentRegistry => {
     getAll: () => Array.from(adapters.values()),
 
     getAvailableMethods: async () => {
-      const methods: PaymentMethodOption[] = [];
+      // Keyed by public id so two adapters can never emit duplicate ids
+      // (e.g. a literal 'card' adapter alongside 'stripe'). A literally
+      // named adapter wins over an aliased one, matching get() precedence.
+      const methodsById = new Map<string, PaymentMethodOption>();
 
       for (const adapter of adapters.values()) {
         try {
           const available = await Effect.runPromise(adapter.isAvailable());
-          if (available) {
-            methods.push(toPublicPaymentMethodOption(adapter));
+          if (!available) continue;
+
+          const option = toPublicPaymentMethodOption(adapter);
+          if (!methodsById.has(option.id) || adapter.name === option.id) {
+            methodsById.set(option.id, option);
           }
         } catch {
           // Adapter unavailable — skip
         }
       }
 
-      return methods;
+      return Array.from(methodsById.values());
     },
   };
 };

--- a/src/payments/types.ts
+++ b/src/payments/types.ts
@@ -151,7 +151,7 @@ export interface StripeAdapterConfig {
 
 export interface ManualPaymentConfig {
   readonly type: 'manual';
-  readonly methods: ('cash' | 'check' | 'zelle' | 'venmo-direct' | 'other')[];
+  readonly methods: ManualPaymentMethodId[];
   readonly instructions?: Record<string, string>;
 }
 
@@ -159,6 +159,53 @@ export type PaymentAdapterConfig =
   | VenmoAdapterConfig
   | StripeAdapterConfig
   | ManualPaymentConfig;
+
+// =============================================================================
+// PUBLIC PAYMENT METHOD ID NORMALIZATION
+// =============================================================================
+//
+// Public booking surfaces use canonical public ids ('card', 'venmo', ...).
+// 'stripe' is an internal adapter/processor name and must never leak as a
+// public payment method id. This is the single owner of that normalization;
+// consumers must not carry their own copies.
+
+/** Canonical public id for card payments on booking surfaces. */
+export const PUBLIC_CARD_PAYMENT_METHOD_ID = 'card';
+
+/** Internal adapter name for the Stripe processor. Never a public id. */
+export const INTERNAL_STRIPE_PAYMENT_METHOD_ID = 'stripe';
+
+/** Manual payment methods that complete in-app without a processor SDK. */
+export const MANUAL_PAYMENT_METHOD_IDS = [
+  'cash',
+  'check',
+  'zelle',
+  'venmo-direct',
+  'other',
+] as const;
+
+export type ManualPaymentMethodId = (typeof MANUAL_PAYMENT_METHOD_IDS)[number];
+
+/** Map an internal adapter name to the canonical public payment method id. */
+export const toPublicPaymentMethodId = (paymentMethodId: string): string =>
+  paymentMethodId === INTERNAL_STRIPE_PAYMENT_METHOD_ID
+    ? PUBLIC_CARD_PAYMENT_METHOD_ID
+    : paymentMethodId;
+
+/** Map a public payment method id back to the internal adapter name. */
+export const toInternalPaymentMethodId = (paymentMethodId: string): string =>
+  paymentMethodId === PUBLIC_CARD_PAYMENT_METHOD_ID
+    ? INTERNAL_STRIPE_PAYMENT_METHOD_ID
+    : paymentMethodId;
+
+/** True for the public card id and the legacy internal stripe alias. */
+export const isCardPaymentMethodId = (paymentMethodId: string): boolean =>
+  paymentMethodId === PUBLIC_CARD_PAYMENT_METHOD_ID ||
+  paymentMethodId === INTERNAL_STRIPE_PAYMENT_METHOD_ID;
+
+/** True only for explicit manual methods; unknown ids are NOT manual. */
+export const isManualPaymentMethodId = (paymentMethodId: string): boolean =>
+  (MANUAL_PAYMENT_METHOD_IDS as readonly string[]).includes(paymentMethodId);
 
 // =============================================================================
 // PAYMENT METHOD SELECTION
@@ -244,6 +291,25 @@ export const getDefaultCapabilities = (): PaymentCapabilities => ({
   cash: false,
 });
 
+/**
+ * Build the public-facing method option for an adapter.
+ *
+ * Shared by the registry and checkout surfaces so the public id never
+ * diverges from the internal adapter name in one place but not another.
+ */
+export const toPublicPaymentMethodOption = (adapter: PaymentAdapter): PaymentMethodOption => {
+  const config = adapter.getClientConfig();
+  const publicId = toPublicPaymentMethodId(adapter.name);
+
+  return {
+    id: publicId,
+    name: publicId,
+    displayName: config.displayName,
+    icon: config.icon ? toPublicPaymentMethodId(config.icon) : undefined,
+    available: true,
+  };
+};
+
 export const createPaymentRegistry = (): PaymentRegistry => {
   const adapters = new Map<string, PaymentAdapter>();
 
@@ -252,7 +318,8 @@ export const createPaymentRegistry = (): PaymentRegistry => {
       adapters.set(adapter.name, adapter);
     },
 
-    get: (name) => adapters.get(name),
+    // Resolve public ids ('card') to internally named adapters ('stripe')
+    get: (name) => adapters.get(name) ?? adapters.get(toInternalPaymentMethodId(name)),
 
     getAll: () => Array.from(adapters.values()),
 
@@ -263,14 +330,7 @@ export const createPaymentRegistry = (): PaymentRegistry => {
         try {
           const available = await Effect.runPromise(adapter.isAvailable());
           if (available) {
-            const config = adapter.getClientConfig();
-            methods.push({
-              id: adapter.name,
-              name: adapter.name,
-              displayName: config.displayName,
-              icon: config.icon,
-              available: true,
-            });
+            methods.push(toPublicPaymentMethodOption(adapter));
           }
         } catch {
           // Adapter unavailable — skip

--- a/src/stores/checkout.svelte.ts
+++ b/src/stores/checkout.svelte.ts
@@ -4,6 +4,7 @@
  */
 
 import { getContext, setContext } from 'svelte';
+import { toPublicPaymentMethodId } from '../payments/types.js';
 import type {
   CheckoutStep,
   CheckoutState,
@@ -183,7 +184,9 @@ export const createCheckoutStore = (): CheckoutStore => {
     },
 
     selectPaymentMethod(method: string) {
-      paymentMethod = method;
+      // Selector state always holds the canonical public id ('card', never
+      // the internal 'stripe' adapter name).
+      paymentMethod = toPublicPaymentMethodId(method);
       step = 'confirm';
     },
 

--- a/src/tests/components/hybrid-checkout-state.test.ts
+++ b/src/tests/components/hybrid-checkout-state.test.ts
@@ -3,8 +3,17 @@
  *
  * The component lives in a .svelte file, so we re-implement the pure
  * state transition functions here and test them in a Node environment.
+ * The payment-method guards are NOT re-implemented: routePayment uses the
+ * real isCardPaymentMethodId/isManualPaymentMethodId from payments/types.js
+ * (the single owner of that normalization), so guard drift fails this suite.
+ * Render-level coverage of the real handlePaymentSelect lives in
+ * tests/e2e/hybrid-checkout-drawer.test.ts.
  */
 import { describe, it, expect } from 'vitest';
+import {
+  isCardPaymentMethodId,
+  isManualPaymentMethodId,
+} from '../../payments/types.js';
 
 // ---------------------------------------------------------------------------
 // Re-implemented pure logic from HybridCheckoutDrawer.svelte
@@ -99,12 +108,8 @@ const buildPaymentOptions = (opts: { hasVenmo?: boolean; hasStripe?: boolean } =
 // Default: Venmo + Cash (no Stripe, matching original behavior)
 const paymentOptions = buildPaymentOptions();
 
-const isCardPaymentMethodId = (paymentId: string): boolean =>
-  paymentId === 'card' || paymentId === 'stripe';
-
-const isManualPaymentMethodId = (paymentId: string): boolean =>
-  ['cash', 'check', 'zelle', 'venmo-direct', 'other'].includes(paymentId);
-
+// Mirrors HybridCheckoutDrawer.handlePaymentSelect's branch ordering, but
+// routes through the REAL shared guards imported from payments/types.js.
 const routePayment = (paymentId: string, hasPaypalSdk: boolean, hasStripeSdk: boolean = false): HybridStep => {
   if (paymentId === 'venmo' && hasPaypalSdk) return 'venmo-checkout';
   if (paymentId === 'venmo') return 'error';
@@ -332,6 +337,12 @@ describe('HybridCheckoutDrawer state machine', () => {
       expect(routePayment('zelle', false)).toBe('processing');
       expect(routePayment('venmo-direct', false)).toBe('processing');
       expect(routePayment('other', false)).toBe('processing');
+    });
+
+    it("should route the kit's default manual adapter name to processing", () => {
+      // createManualPaymentAdapter ships with methodName 'manual'; the
+      // drawer must not hard-error the kit's own factory default.
+      expect(routePayment('manual', false)).toBe('processing');
     });
 
     it('should fail unknown payment methods instead of manual completion', () => {

--- a/src/tests/components/hybrid-checkout-state.test.ts
+++ b/src/tests/components/hybrid-checkout-state.test.ts
@@ -85,12 +85,13 @@ interface PaymentOption {
   id: string;
 }
 
-// Simulates the $derived paymentOptions with all adapters configured
+// Simulates the $derived paymentOptions with all adapters configured.
+// Capabilities emit the canonical public 'card' id, never internal 'stripe'.
 const buildPaymentOptions = (opts: { hasVenmo?: boolean; hasStripe?: boolean } = {}): PaymentOption[] => {
   const { hasVenmo = true, hasStripe = false } = opts;
   const result: PaymentOption[] = [];
   if (hasVenmo) result.push({ id: 'venmo' });
-  if (hasStripe) result.push({ id: 'stripe' });
+  if (hasStripe) result.push({ id: 'card' });
   result.push({ id: 'cash' });
   return result;
 };
@@ -98,10 +99,19 @@ const buildPaymentOptions = (opts: { hasVenmo?: boolean; hasStripe?: boolean } =
 // Default: Venmo + Cash (no Stripe, matching original behavior)
 const paymentOptions = buildPaymentOptions();
 
+const isCardPaymentMethodId = (paymentId: string): boolean =>
+  paymentId === 'card' || paymentId === 'stripe';
+
+const isManualPaymentMethodId = (paymentId: string): boolean =>
+  ['cash', 'check', 'zelle', 'venmo-direct', 'other'].includes(paymentId);
+
 const routePayment = (paymentId: string, hasPaypalSdk: boolean, hasStripeSdk: boolean = false): HybridStep => {
   if (paymentId === 'venmo' && hasPaypalSdk) return 'venmo-checkout';
-  if (paymentId === 'stripe' && hasStripeSdk) return 'stripe-checkout';
-  return 'processing';
+  if (paymentId === 'venmo') return 'error';
+  if (isCardPaymentMethodId(paymentId) && hasStripeSdk) return 'stripe-checkout';
+  if (isCardPaymentMethodId(paymentId)) return 'error';
+  if (isManualPaymentMethodId(paymentId)) return 'processing';
+  return 'error';
 };
 
 const formatPrice = (cents: number): string =>
@@ -290,25 +300,26 @@ describe('HybridCheckoutDrawer state machine', () => {
   // 5. Payment routing
   // -----------------------------------------------------------------------
   describe('routePayment', () => {
-    it('should route card to processing when no SDK', () => {
-      expect(routePayment('card', false)).toBe('processing');
-      expect(routePayment('card', true)).toBe('processing');
+    it('should route the public card id with Stripe SDK to stripe-checkout', () => {
+      expect(routePayment('card', false, true)).toBe('stripe-checkout');
     });
 
-    it('should route stripe with Stripe SDK to stripe-checkout', () => {
+    it('should keep the legacy stripe alias routing to stripe-checkout', () => {
       expect(routePayment('stripe', false, true)).toBe('stripe-checkout');
     });
 
-    it('should route stripe without Stripe SDK to processing', () => {
-      expect(routePayment('stripe', false, false)).toBe('processing');
+    it('should fail card-like selections when Stripe is unavailable (no manual fallback)', () => {
+      expect(routePayment('card', false, false)).toBe('error');
+      expect(routePayment('card', true, false)).toBe('error');
+      expect(routePayment('stripe', false, false)).toBe('error');
     });
 
     it('should route venmo with PayPal SDK to venmo-checkout', () => {
       expect(routePayment('venmo', true)).toBe('venmo-checkout');
     });
 
-    it('should route venmo without PayPal SDK to processing', () => {
-      expect(routePayment('venmo', false)).toBe('processing');
+    it('should fail venmo when PayPal is unavailable (no manual fallback)', () => {
+      expect(routePayment('venmo', false)).toBe('error');
     });
 
     it('should route cash to processing', () => {
@@ -316,9 +327,16 @@ describe('HybridCheckoutDrawer state machine', () => {
       expect(routePayment('cash', true)).toBe('processing');
     });
 
-    it('should route unknown payment methods to processing', () => {
-      expect(routePayment('bitcoin', false)).toBe('processing');
+    it('should route explicit manual payment methods to processing', () => {
       expect(routePayment('check', true)).toBe('processing');
+      expect(routePayment('zelle', false)).toBe('processing');
+      expect(routePayment('venmo-direct', false)).toBe('processing');
+      expect(routePayment('other', false)).toBe('processing');
+    });
+
+    it('should fail unknown payment methods instead of manual completion', () => {
+      expect(routePayment('bitcoin', false)).toBe('error');
+      expect(routePayment('', true)).toBe('error');
     });
   });
 
@@ -420,7 +438,7 @@ describe('HybridCheckoutDrawer state machine', () => {
       expect(stepTitles[step]).toBe('Booking Confirmed');
     });
 
-    it('should complete a stripe flow: service -> ... -> stripe-checkout -> complete', () => {
+    it('should complete a card flow: service -> ... -> stripe-checkout -> complete', () => {
       let step: HybridStep = 'service';
 
       step = forwardTransitions[step] as HybridStep;
@@ -429,7 +447,7 @@ describe('HybridCheckoutDrawer state machine', () => {
       step = forwardTransitions[step] as HybridStep;
       expect(step).toBe('payment');
 
-      step = routePayment('stripe', false, true);
+      step = routePayment('card', false, true);
       expect(step).toBe('stripe-checkout');
       expect(canGoBack(step)).toBe(false);
 
@@ -442,7 +460,7 @@ describe('HybridCheckoutDrawer state machine', () => {
       expect(stepTitles[step]).toBe('Booking Confirmed');
     });
 
-    it('should complete a card flow: service -> ... -> processing -> complete', () => {
+    it('should fail a card flow when Stripe is unavailable instead of manual completion', () => {
       let step: HybridStep = 'service';
 
       step = forwardTransitions[step] as HybridStep;
@@ -452,11 +470,11 @@ describe('HybridCheckoutDrawer state machine', () => {
       expect(step).toBe('payment');
 
       step = routePayment('card', false);
-      expect(step).toBe('processing');
-      expect(canGoBack(step)).toBe(false);
+      expect(step).toBe('error');
 
-      step = 'complete';
-      expect(stepTitles[step]).toBe('Booking Confirmed');
+      // Error is recoverable back to payment selection
+      expect(canGoBack(step)).toBe(true);
+      expect(handleBack(step)).toBe('payment');
     });
 
     it('should complete a cash flow: service -> ... -> processing -> complete', () => {
@@ -531,10 +549,11 @@ describe('HybridCheckoutDrawer state machine', () => {
       expect(ids).toContain('cash');
     });
 
-    it('should include stripe when configured', () => {
+    it('should include the public card id when Stripe is configured', () => {
       const opts = buildPaymentOptions({ hasVenmo: true, hasStripe: true });
       expect(opts).toHaveLength(3);
-      expect(opts.map((p) => p.id)).toEqual(['venmo', 'stripe', 'cash']);
+      expect(opts.map((p) => p.id)).toEqual(['venmo', 'card', 'cash']);
+      expect(opts.map((p) => p.id)).not.toContain('stripe');
     });
 
     it('should show only cash when no adapters configured', () => {

--- a/src/tests/unit/core/pipelines.test.ts
+++ b/src/tests/unit/core/pipelines.test.ts
@@ -171,6 +171,51 @@ describe('completeBookingWithAltPayment', () => {
     }
   });
 
+  it('resolves the public card id to the internally named stripe adapter', async () => {
+    const stripe = createMockPaymentAdapter('stripe');
+    const cardCtx: PipelineContext = {
+      scheduler,
+      payments: new Map([['stripe', stripe]]),
+      correlationId: 'test-correlation-id',
+    };
+
+    const result = await expectSuccess(
+      completeBookingWithAltPayment(cardCtx, { ...input, paymentMethod: 'card' })
+    );
+
+    expect(result.payment.success).toBe(true);
+    expect(stripe.createIntent).toHaveBeenCalled();
+    expect(stripe.capturePayment).toHaveBeenCalled();
+  });
+
+  it('fails unsupported card selection with a typed error instead of a manual adapter', async () => {
+    // Only a manual cash adapter is registered; the public 'card' selection
+    // must NOT fall through to it.
+    const error = await expectFailureTag(
+      completeBookingWithAltPayment(ctx, { ...input, paymentMethod: 'card' }),
+      'PaymentError'
+    );
+
+    expect(error._tag).toBe('PaymentError');
+    if (error._tag === 'PaymentError') {
+      expect(error.code).toBe('INVALID_METHOD');
+    }
+    expect(paymentAdapter.createIntent).not.toHaveBeenCalled();
+  });
+
+  it('fails unsupported venmo selection with a typed error instead of a manual adapter', async () => {
+    const error = await expectFailureTag(
+      completeBookingWithAltPayment(ctx, { ...input, paymentMethod: 'venmo' }),
+      'PaymentError'
+    );
+
+    expect(error._tag).toBe('PaymentError');
+    if (error._tag === 'PaymentError') {
+      expect(error.code).toBe('INVALID_METHOD');
+    }
+    expect(paymentAdapter.createIntent).not.toHaveBeenCalled();
+  });
+
   it('returns validation error for invalid request', async () => {
     const invalidInput: BookingPipelineInput = {
       ...input,
@@ -498,6 +543,45 @@ describe('createSchedulingKit', () => {
     );
 
     expect(result.booking).toBeDefined();
+  });
+
+  it('aliases stripe adapters behind the public card id', async () => {
+    const stripe = createMockPaymentAdapter('stripe');
+    const kit = createSchedulingKit(scheduler, [stripe]);
+
+    expect(kit.payments.get('stripe')).toBe(stripe);
+    expect(kit.payments.get('card')).toBe(stripe);
+
+    const methods = await kit.payments.getAvailableMethods();
+    expect(methods.map((m) => m.id)).toEqual(['card']);
+    expect(methods.map((m) => m.id)).not.toContain('stripe');
+  });
+
+  it('completeBooking accepts the public card id for stripe-backed flows', async () => {
+    const stripe = createMockPaymentAdapter('stripe');
+    const kit = createSchedulingKit(scheduler, [stripe]);
+
+    const result = await expectSuccess(
+      kit.completeBooking(createBookingRequest(), 'card')
+    );
+
+    expect(result.booking).toBeDefined();
+    expect(stripe.createIntent).toHaveBeenCalled();
+    expect(stripe.capturePayment).toHaveBeenCalled();
+  });
+
+  it('completeBooking rejects card when no card-capable adapter is registered', async () => {
+    const kit = createSchedulingKit(scheduler, [paymentAdapter]);
+
+    const error = await expectFailureTag(
+      kit.completeBooking(createBookingRequest(), 'card'),
+      'PaymentError'
+    );
+
+    if (error._tag === 'PaymentError') {
+      expect(error.code).toBe('INVALID_METHOD');
+    }
+    expect(paymentAdapter.createIntent).not.toHaveBeenCalled();
   });
 
   it('getAvailability delegates to pipeline', async () => {

--- a/src/tests/unit/core/pipelines.test.ts
+++ b/src/tests/unit/core/pipelines.test.ts
@@ -557,6 +557,28 @@ describe('createSchedulingKit', () => {
     expect(methods.map((m) => m.id)).not.toContain('stripe');
   });
 
+  it('never lets the stripe alias clobber a literally named card adapter', async () => {
+    // Registration order must not decide who owns the 'card' id: the
+    // literally named adapter wins, matching registry.get() precedence.
+    for (const order of ['card-first', 'stripe-first'] as const) {
+      const card = createMockPaymentAdapter('card');
+      const stripe = createMockPaymentAdapter('stripe');
+      const adapters = order === 'card-first' ? [card, stripe] : [stripe, card];
+      const kit = createSchedulingKit(scheduler, adapters);
+
+      expect(kit.payments.get('card')).toBe(card);
+      expect(kit.payments.get('stripe')).toBe(stripe);
+
+      const result = await expectSuccess(
+        kit.completeBooking(createBookingRequest(), 'card')
+      );
+
+      expect(result.booking).toBeDefined();
+      expect(card.createIntent).toHaveBeenCalled();
+      expect(stripe.createIntent).not.toHaveBeenCalled();
+    }
+  });
+
   it('completeBooking accepts the public card id for stripe-backed flows', async () => {
     const stripe = createMockPaymentAdapter('stripe');
     const kit = createSchedulingKit(scheduler, [stripe]);

--- a/src/tests/unit/payments/method-normalization.test.ts
+++ b/src/tests/unit/payments/method-normalization.test.ts
@@ -12,6 +12,7 @@ import {
   PUBLIC_CARD_PAYMENT_METHOD_ID,
   INTERNAL_STRIPE_PAYMENT_METHOD_ID,
   MANUAL_PAYMENT_METHOD_IDS,
+  DEFAULT_MANUAL_ADAPTER_NAME,
   toPublicPaymentMethodId,
   toInternalPaymentMethodId,
   isCardPaymentMethodId,
@@ -142,6 +143,13 @@ describe('payment method id normalization', () => {
       }
     });
 
+    it("accepts the kit's default manual adapter name", () => {
+      // createManualPaymentAdapter defaults to methodName 'manual'; checkout
+      // surfaces must be able to route the kit's own factory default.
+      expect(isManualPaymentMethodId(DEFAULT_MANUAL_ADAPTER_NAME)).toBe(true);
+      expect(isManualPaymentMethodId('manual')).toBe(true);
+    });
+
     it('rejects card-like and venmo ids so they cannot reach manual completion', () => {
       expect(isManualPaymentMethodId('card')).toBe(false);
       expect(isManualPaymentMethodId('stripe')).toBe(false);
@@ -189,6 +197,21 @@ describe('toPublicPaymentMethodOption', () => {
     const cash = createMockAdapter('cash');
     expect(toPublicPaymentMethodOption(cash).icon).toBeUndefined();
   });
+
+  it('passes emoji and custom icon tokens through untouched', () => {
+    const venmo = createMockAdapter('venmo', { icon: '💙' });
+    expect(toPublicPaymentMethodOption(venmo).icon).toBe('💙');
+
+    const stripeWithEmoji = createMockAdapter('stripe', { icon: '💳' });
+    expect(toPublicPaymentMethodOption(stripeWithEmoji).icon).toBe('💳');
+  });
+
+  it("does not rewrite another adapter's icon that is literally 'stripe'", () => {
+    // Icon tokens are a separate domain from method ids: only the stripe
+    // adapter's own legacy 'stripe' icon token maps to 'card'.
+    const unrelated = createMockAdapter('venmo', { icon: 'stripe' });
+    expect(toPublicPaymentMethodOption(unrelated).icon).toBe('stripe');
+  });
 });
 
 // =============================================================================
@@ -223,6 +246,30 @@ describe('createPaymentRegistry public id resolution', () => {
 
     expect(ids).toEqual(['card', 'venmo']);
     expect(ids).not.toContain('stripe');
+  });
+
+  it('prefers a literally named card adapter over the stripe alias, in either registration order', async () => {
+    for (const order of [
+      ['card', 'stripe'],
+      ['stripe', 'card'],
+    ] as const) {
+      const registry = createPaymentRegistry();
+      const adaptersByName = {
+        card: createMockAdapter('card', { displayName: 'Literal Card' }),
+        stripe: createMockAdapter('stripe', { displayName: 'Stripe Card' }),
+      };
+      for (const name of order) registry.register(adaptersByName[name]);
+
+      // get() precedence: literal registration wins over the alias
+      expect(registry.get('card')).toBe(adaptersByName.card);
+
+      // No duplicate ids emitted (would break keyed {#each} blocks), and
+      // the surviving option belongs to the literally named adapter.
+      const methods = await registry.getAvailableMethods();
+      const cardOptions = methods.filter((m) => m.id === 'card');
+      expect(cardOptions).toHaveLength(1);
+      expect(cardOptions[0].displayName).toBe('Literal Card');
+    }
   });
 
   it('aligns emitted ids with the PaymentCapabilities contract (card/venmo, cash false)', async () => {

--- a/src/tests/unit/payments/method-normalization.test.ts
+++ b/src/tests/unit/payments/method-normalization.test.ts
@@ -1,0 +1,241 @@
+/**
+ * Tests for public payment method id normalization
+ *
+ * Public booking surfaces use canonical public ids ('card', 'venmo').
+ * The internal 'stripe' adapter name must never leak as a public id, and
+ * unsupported selections must never be treated as manual methods.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { Effect } from 'effect';
+import {
+  PUBLIC_CARD_PAYMENT_METHOD_ID,
+  INTERNAL_STRIPE_PAYMENT_METHOD_ID,
+  MANUAL_PAYMENT_METHOD_IDS,
+  toPublicPaymentMethodId,
+  toInternalPaymentMethodId,
+  isCardPaymentMethodId,
+  isManualPaymentMethodId,
+  toPublicPaymentMethodOption,
+  createPaymentRegistry,
+  getDefaultCapabilities,
+} from '../../../payments/types.js';
+import type { PaymentAdapter } from '../../../payments/types.js';
+
+// =============================================================================
+// MOCK ADAPTER
+// =============================================================================
+
+const createMockAdapter = (
+  name: string,
+  overrides: { displayName?: string; icon?: string } = {}
+): PaymentAdapter => ({
+  name,
+  displayName: overrides.displayName ?? name,
+  icon: overrides.icon,
+  isAvailable: vi.fn(() => Effect.succeed(true)),
+  createIntent: vi.fn(() =>
+    Effect.succeed({
+      id: 'pi_test',
+      amount: 1000,
+      currency: 'USD',
+      status: 'pending' as const,
+      processor: name,
+      createdAt: new Date().toISOString(),
+    })
+  ),
+  capturePayment: vi.fn(() =>
+    Effect.succeed({
+      success: true,
+      transactionId: 'txn_test',
+      processor: name,
+      amount: 1000,
+      currency: 'USD',
+      timestamp: new Date().toISOString(),
+    })
+  ),
+  cancelIntent: vi.fn(() => Effect.succeed(undefined)),
+  refund: vi.fn(() =>
+    Effect.succeed({
+      success: true,
+      refundId: 'refund_test',
+      originalTransactionId: 'txn_test',
+      amount: 1000,
+      currency: 'USD',
+      timestamp: new Date().toISOString(),
+    })
+  ),
+  verifyWebhook: vi.fn(() => Effect.succeed(true)),
+  parseWebhook: vi.fn(() =>
+    Effect.succeed({
+      type: 'payment.completed' as const,
+      transactionId: 'txn_test',
+      amount: 1000,
+      currency: 'USD',
+      timestamp: new Date().toISOString(),
+      raw: {},
+    })
+  ),
+  getClientConfig: () => ({
+    name,
+    displayName: overrides.displayName ?? name,
+    icon: overrides.icon,
+    environment: 'production' as const,
+    supportedCurrencies: ['USD'],
+  }),
+});
+
+// =============================================================================
+// ID NORMALIZATION
+// =============================================================================
+
+describe('payment method id normalization', () => {
+  describe('toPublicPaymentMethodId', () => {
+    it('maps the internal stripe name to the public card id', () => {
+      expect(toPublicPaymentMethodId('stripe')).toBe('card');
+      expect(toPublicPaymentMethodId(INTERNAL_STRIPE_PAYMENT_METHOD_ID)).toBe(
+        PUBLIC_CARD_PAYMENT_METHOD_ID
+      );
+    });
+
+    it('keeps already-public ids unchanged', () => {
+      expect(toPublicPaymentMethodId('card')).toBe('card');
+      expect(toPublicPaymentMethodId('venmo')).toBe('venmo');
+      expect(toPublicPaymentMethodId('cash')).toBe('cash');
+    });
+  });
+
+  describe('toInternalPaymentMethodId', () => {
+    it('maps the public card id to the internal stripe name', () => {
+      expect(toInternalPaymentMethodId('card')).toBe('stripe');
+    });
+
+    it('keeps other ids unchanged', () => {
+      expect(toInternalPaymentMethodId('stripe')).toBe('stripe');
+      expect(toInternalPaymentMethodId('venmo')).toBe('venmo');
+      expect(toInternalPaymentMethodId('zelle')).toBe('zelle');
+    });
+
+    it('round-trips with toPublicPaymentMethodId', () => {
+      expect(toInternalPaymentMethodId(toPublicPaymentMethodId('stripe'))).toBe('stripe');
+      expect(toPublicPaymentMethodId(toInternalPaymentMethodId('card'))).toBe('card');
+    });
+  });
+
+  describe('isCardPaymentMethodId', () => {
+    it('accepts the public card id and the legacy stripe alias', () => {
+      expect(isCardPaymentMethodId('card')).toBe(true);
+      expect(isCardPaymentMethodId('stripe')).toBe(true);
+    });
+
+    it('rejects non-card ids', () => {
+      expect(isCardPaymentMethodId('venmo')).toBe(false);
+      expect(isCardPaymentMethodId('cash')).toBe(false);
+      expect(isCardPaymentMethodId('bitcoin')).toBe(false);
+    });
+  });
+
+  describe('isManualPaymentMethodId', () => {
+    it('accepts exactly the manual method ids', () => {
+      for (const id of MANUAL_PAYMENT_METHOD_IDS) {
+        expect(isManualPaymentMethodId(id)).toBe(true);
+      }
+    });
+
+    it('rejects card-like and venmo ids so they cannot reach manual completion', () => {
+      expect(isManualPaymentMethodId('card')).toBe(false);
+      expect(isManualPaymentMethodId('stripe')).toBe(false);
+      expect(isManualPaymentMethodId('venmo')).toBe(false);
+    });
+
+    it('rejects unknown ids', () => {
+      expect(isManualPaymentMethodId('bitcoin')).toBe(false);
+      expect(isManualPaymentMethodId('')).toBe(false);
+    });
+  });
+});
+
+// =============================================================================
+// PUBLIC METHOD OPTION
+// =============================================================================
+
+describe('toPublicPaymentMethodOption', () => {
+  it('emits the public card id for stripe adapters', () => {
+    const stripe = createMockAdapter('stripe', {
+      displayName: 'Credit/Debit Card',
+      icon: 'stripe',
+    });
+
+    const option = toPublicPaymentMethodOption(stripe);
+
+    expect(option.id).toBe('card');
+    expect(option.name).toBe('card');
+    expect(option.displayName).toBe('Credit/Debit Card');
+    expect(option.icon).toBe('card');
+    expect(option.available).toBe(true);
+  });
+
+  it('keeps non-stripe adapters unchanged', () => {
+    const venmo = createMockAdapter('venmo', { displayName: 'Venmo', icon: 'venmo' });
+
+    const option = toPublicPaymentMethodOption(venmo);
+
+    expect(option.id).toBe('venmo');
+    expect(option.name).toBe('venmo');
+    expect(option.icon).toBe('venmo');
+  });
+
+  it('omits the icon when the adapter config has none', () => {
+    const cash = createMockAdapter('cash');
+    expect(toPublicPaymentMethodOption(cash).icon).toBeUndefined();
+  });
+});
+
+// =============================================================================
+// REGISTRY RESOLUTION
+// =============================================================================
+
+describe('createPaymentRegistry public id resolution', () => {
+  it('resolves the public card id to the stripe adapter', () => {
+    const registry = createPaymentRegistry();
+    const stripe = createMockAdapter('stripe');
+    registry.register(stripe);
+
+    expect(registry.get('card')).toBe(stripe);
+    expect(registry.get('stripe')).toBe(stripe);
+  });
+
+  it('returns undefined for unsupported public selections', () => {
+    const registry = createPaymentRegistry();
+    registry.register(createMockAdapter('cash'));
+
+    expect(registry.get('card')).toBeUndefined();
+    expect(registry.get('venmo')).toBeUndefined();
+  });
+
+  it('emits public ids from getAvailableMethods', async () => {
+    const registry = createPaymentRegistry();
+    registry.register(createMockAdapter('stripe', { displayName: 'Credit/Debit Card' }));
+    registry.register(createMockAdapter('venmo', { displayName: 'Venmo' }));
+
+    const methods = await registry.getAvailableMethods();
+    const ids = methods.map((m) => m.id);
+
+    expect(ids).toEqual(['card', 'venmo']);
+    expect(ids).not.toContain('stripe');
+  });
+
+  it('aligns emitted ids with the PaymentCapabilities contract (card/venmo, cash false)', async () => {
+    const registry = createPaymentRegistry();
+    registry.register(createMockAdapter('stripe'));
+    registry.register(createMockAdapter('venmo'));
+
+    const capabilities = {
+      ...getDefaultCapabilities(),
+      methods: await registry.getAvailableMethods(),
+    };
+
+    expect(capabilities.methods.map((m) => m.id)).toEqual(['card', 'venmo']);
+    expect(capabilities.cash).toBe(false);
+  });
+});

--- a/src/tests/unit/stores/checkout-store.test.ts
+++ b/src/tests/unit/stores/checkout-store.test.ts
@@ -1,0 +1,55 @@
+/**
+ * Tests for the checkout store payment selector state
+ *
+ * Selector state must hold the canonical public payment method id:
+ * the internal 'stripe' adapter name normalizes to the public 'card' id.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { createCheckoutStore } from '../../../stores/checkout.svelte.js';
+
+describe('checkout store payment selector state', () => {
+  it('normalizes the internal stripe name to the public card id', () => {
+    const store = createCheckoutStore();
+
+    store.selectPaymentMethod('stripe');
+
+    expect(store.paymentMethod).toBe('card');
+  });
+
+  it('keeps the public card id as-is', () => {
+    const store = createCheckoutStore();
+
+    store.selectPaymentMethod('card');
+
+    expect(store.paymentMethod).toBe('card');
+  });
+
+  it('keeps non-card public ids unchanged', () => {
+    const store = createCheckoutStore();
+
+    store.selectPaymentMethod('venmo');
+    expect(store.paymentMethod).toBe('venmo');
+
+    store.selectPaymentMethod('cash');
+    expect(store.paymentMethod).toBe('cash');
+  });
+
+  it('advances to confirm after payment selection', () => {
+    const store = createCheckoutStore();
+
+    store.selectPaymentMethod('card');
+
+    expect(store.step).toBe('confirm');
+  });
+
+  it('clears the normalized selection on reset', () => {
+    const store = createCheckoutStore();
+
+    store.selectPaymentMethod('stripe');
+    store.reset();
+
+    expect(store.paymentMethod).toBeUndefined();
+    expect(store.step).toBe('service');
+  });
+});

--- a/tests/e2e/hybrid-checkout-drawer.test.ts
+++ b/tests/e2e/hybrid-checkout-drawer.test.ts
@@ -1,0 +1,176 @@
+/**
+ * HybridCheckoutDrawer Component Tests
+ *
+ * Render-level coverage of the real handlePaymentSelect routing (no
+ * simulation): unavailable card/venmo selections and unknown method ids
+ * must land on the error step and never fabricate a local booking via
+ * manual completion; only explicit manual ids may complete in-app.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/svelte';
+import HybridCheckoutDrawer from '../../src/components/HybridCheckoutDrawer.svelte';
+import { getDefaultCapabilities } from '../../src/payments/types.js';
+import type { PaymentCapabilities, PaymentMethodOption } from '../../src/payments/types.js';
+import type { Service } from '../../src/core/types.js';
+
+const service: Service = {
+  id: 'svc-1',
+  name: 'Consultation',
+  duration: 60,
+  price: 15000,
+  currency: 'USD',
+  active: true,
+};
+
+const AVAILABLE_DATE = '2026-06-30';
+// 2:00 PM America/New_York (drawer default timezone)
+const SLOT_DATETIME = '2026-06-30T18:00:00.000Z';
+
+const buildCapabilities = (methods: PaymentMethodOption[]): PaymentCapabilities => ({
+  ...getDefaultCapabilities(),
+  methods,
+});
+
+const renderDrawer = (capabilities: PaymentCapabilities) => {
+  const onBookingComplete = vi.fn();
+  const onCreateStripeIntent = vi.fn();
+
+  render(HybridCheckoutDrawer, {
+    props: {
+      open: true,
+      services: [service],
+      skipProvider: true,
+      capabilities,
+      onLoadDates: vi.fn(async () => [AVAILABLE_DATE]),
+      onLoadSlots: vi.fn(async () => [{ datetime: SLOT_DATETIME, available: true }]),
+      onCreateStripeIntent,
+      onBookingComplete,
+    },
+  });
+
+  return { onBookingComplete, onCreateStripeIntent };
+};
+
+/** Walk the real drawer from service selection to the payment step. */
+const advanceToPaymentStep = async () => {
+  // Service step
+  const serviceCard = (await screen.findByText('Consultation')).closest('button');
+  await fireEvent.click(serviceCard!);
+
+  // Datetime step (skipProvider: true jumps straight here)
+  const dayButton = await screen.findByRole('button', { name: /June 30, available/ });
+  await fireEvent.click(dayButton);
+  const slotButton = await screen.findByRole('button', { name: '2:00 PM' });
+  await fireEvent.click(slotButton);
+
+  // Details step (showIntakeFields is hardcoded true in the drawer)
+  await screen.findByLabelText(/first name/i);
+  await fireEvent.input(screen.getByLabelText(/first name/i), { target: { value: 'Pat' } });
+  await fireEvent.input(screen.getByLabelText(/last name/i), { target: { value: 'Tester' } });
+  await fireEvent.input(screen.getByLabelText(/email/i), { target: { value: 'pat@example.com' } });
+
+  for (const radio of Array.from(
+    document.querySelectorAll<HTMLInputElement>('input[type="radio"][value="no"]')
+  )) {
+    await fireEvent.click(radio);
+  }
+  const checkboxes = Array.from(
+    document.querySelectorAll<HTMLInputElement>('input[type="checkbox"]')
+  );
+  // First "how did you hear" option + the terms acknowledgement (last checkbox)
+  await fireEvent.click(checkboxes[0]);
+  await fireEvent.click(checkboxes[checkboxes.length - 1]);
+  await fireEvent.input(screen.getByLabelText(/current medications/i), {
+    target: { value: 'None' },
+  });
+
+  await fireEvent.submit(document.querySelector('form.client-form, form')!);
+
+  // Payment step
+  await screen.findByText('Select Payment Method');
+};
+
+const selectPaymentOption = async (displayName: string) => {
+  const optionButton = screen.getByText(displayName).closest('button');
+  await fireEvent.click(optionButton!);
+};
+
+describe('HybridCheckoutDrawer payment routing', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(2026, 5, 1, 12, 0, 0, 0));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('errors card selections when Stripe is unavailable and never completes a booking', async () => {
+    const { onBookingComplete, onCreateStripeIntent } = renderDrawer(
+      buildCapabilities([
+        { id: 'card', name: 'card', displayName: 'Credit/Debit Card', available: true },
+      ])
+    );
+
+    await advanceToPaymentStep();
+    await selectPaymentOption('Credit/Debit Card');
+
+    expect(
+      await screen.findByText('Card payments are not available right now.')
+    ).toBeInTheDocument();
+    // Step title + error heading both show the error step
+    expect(screen.getAllByText('Something Went Wrong').length).toBeGreaterThan(0);
+    expect(onCreateStripeIntent).not.toHaveBeenCalled();
+    expect(onBookingComplete).not.toHaveBeenCalled();
+  });
+
+  it('errors venmo selections when Venmo is unavailable instead of manual completion', async () => {
+    const { onBookingComplete } = renderDrawer(
+      buildCapabilities([{ id: 'venmo', name: 'venmo', displayName: 'Venmo', available: true }])
+    );
+
+    await advanceToPaymentStep();
+    await selectPaymentOption('Venmo');
+
+    expect(
+      await screen.findByText('Venmo payments are not available right now.')
+    ).toBeInTheDocument();
+    expect(screen.getAllByText('Something Went Wrong').length).toBeGreaterThan(0);
+    expect(onBookingComplete).not.toHaveBeenCalled();
+  });
+
+  it('errors unknown method ids instead of manual completion', async () => {
+    const { onBookingComplete } = renderDrawer(
+      buildCapabilities([
+        { id: 'bitcoin', name: 'bitcoin', displayName: 'Bitcoin', available: true },
+      ])
+    );
+
+    await advanceToPaymentStep();
+    await selectPaymentOption('Bitcoin');
+
+    expect(
+      await screen.findByText(
+        'This payment method is not supported in the current checkout flow.'
+      )
+    ).toBeInTheDocument();
+    expect(screen.getAllByText('Something Went Wrong').length).toBeGreaterThan(0);
+    expect(onBookingComplete).not.toHaveBeenCalled();
+  });
+
+  it('completes explicit manual selections (cash) in-app', async () => {
+    const { onBookingComplete } = renderDrawer(
+      buildCapabilities([{ id: 'cash', name: 'cash', displayName: 'Cash', available: true }])
+    );
+
+    await advanceToPaymentStep();
+    await selectPaymentOption('Cash');
+
+    expect(await screen.findByText('Booking Confirmed!')).toBeInTheDocument();
+    expect(onBookingComplete).toHaveBeenCalledTimes(1);
+    expect(onBookingComplete).toHaveBeenCalledWith(
+      expect.objectContaining({ serviceId: 'svc-1', paymentStatus: 'paid' })
+    );
+  });
+});

--- a/tests/e2e/payment-selector.test.ts
+++ b/tests/e2e/payment-selector.test.ts
@@ -6,8 +6,27 @@
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/svelte';
 import PaymentSelector from '../../src/components/PaymentSelector.svelte';
+import { toPublicPaymentMethodOption } from '../../src/payments/types.js';
+import type { PaymentAdapter } from '../../src/payments/types.js';
 
-// Mock payment methods
+// Stripe-named adapter stub: only the members consumed by
+// toPublicPaymentMethodOption matter for these tests.
+const stripeAdapterStub = {
+  name: 'stripe',
+  displayName: 'Credit/Debit Card',
+  icon: 'stripe',
+  getClientConfig: () => ({
+    name: 'stripe',
+    displayName: 'Credit/Debit Card',
+    icon: 'stripe',
+    environment: 'production' as const,
+    supportedCurrencies: ['USD'],
+  }),
+} as unknown as PaymentAdapter;
+
+// Mock payment methods. The card option is built by the kit's own boundary
+// mapper from an internally named 'stripe' adapter, so the canonical-id
+// assertions below cover the real normalization, not a hand-written fixture.
 const createMockPaymentMethods = () => [
   {
     id: 'venmo',
@@ -24,13 +43,10 @@ const createMockPaymentMethods = () => [
     icon: 'cash',
   },
   {
-    // Canonical public card id — internal 'stripe' must not leak here
-    id: 'card',
-    displayName: 'Credit/Debit Card',
+    // Kit-built option: id/name must be the public 'card', never 'stripe'
+    ...toPublicPaymentMethodOption(stripeAdapterStub),
     description: 'Pay with card',
-    available: true,
     processingFeePercent: 2.9,
-    icon: 'card',
   },
   {
     id: 'disabled',

--- a/tests/e2e/payment-selector.test.ts
+++ b/tests/e2e/payment-selector.test.ts
@@ -24,12 +24,13 @@ const createMockPaymentMethods = () => [
     icon: 'cash',
   },
   {
-    id: 'stripe',
-    displayName: 'Credit Card',
+    // Canonical public card id — internal 'stripe' must not leak here
+    id: 'card',
+    displayName: 'Credit/Debit Card',
     description: 'Pay with card',
     available: true,
     processingFeePercent: 2.9,
-    icon: 'stripe',
+    icon: 'card',
   },
   {
     id: 'disabled',
@@ -57,7 +58,20 @@ describe('PaymentSelector Component', () => {
 
     expect(screen.getByText('Venmo')).toBeInTheDocument();
     expect(screen.getByText('Cash')).toBeInTheDocument();
-    expect(screen.getByText('Credit Card')).toBeInTheDocument();
+    expect(screen.getByText('Credit/Debit Card')).toBeInTheDocument();
+  });
+
+  it('reports the canonical card id when the card method is selected', async () => {
+    const onSelect = vi.fn();
+    render(PaymentSelector, {
+      props: { methods: createMockPaymentMethods(), amount: 10000, onSelect },
+    });
+
+    const cardButton = screen.getByText('Credit/Debit Card').closest('button');
+    await fireEvent.click(cardButton!);
+
+    expect(onSelect).toHaveBeenCalledWith('card');
+    expect(onSelect).not.toHaveBeenCalledWith('stripe');
   });
 
   it('shows loading state', () => {

--- a/vitest.component.config.ts
+++ b/vitest.component.config.ts
@@ -19,6 +19,13 @@ export default defineConfig({
   ],
   test: {
     include: ['tests/e2e/**/*.test.ts'],
+    server: {
+      deps: {
+        // skeleton-svelte ships raw .svelte sources; inline so the svelte
+        // plugin compiles them (needed by Dialog-based drawer tests)
+        inline: ['@skeletonlabs/skeleton-svelte', /@zag-js\//],
+      },
+    },
     environment: 'jsdom',
     globals: true,
     setupFiles: ['src/tests/setup.ts', 'tests/e2e/setup.ts'],


### PR DESCRIPTION
## What changed

Recasts the dead draft #63 against current main (`aa07055`). The kit now owns the canonical public `card` payment method id; consumers no longer need their own normalization copies.

Closes #79.

## Requirement -> implementation mapping

| Requirement (#79) | Implementation |
| --- | --- |
| Public booking surfaces use the canonical `card` id | `toPublicPaymentMethodId` / `toPublicPaymentMethodOption` in `src/payments/types.ts`; registry `getAvailableMethods()` and `CheckoutDrawer` emit public ids; checkout store normalizes selector state (`src/stores/checkout.svelte.ts`) |
| Internal Stripe adapter semantics must not leak as a public `stripe` id | Registry `get()` and the booking pipeline resolve `card` -> internally named `stripe` adapter (`src/core/pipelines.ts`); `createSchedulingKit` aliases each adapter behind its public id (aliases only claim unclaimed ids — a literally named adapter always wins, matching `registry.get()` precedence); `getAvailableMethods()` dedupes by public id; the stripe icon token maps `stripe` -> `card` in the icon domain (id normalizer is not reused for icons) |
| Unsupported public `card`/`venmo` selections must NOT fall through to manual completion | `HybridCheckoutDrawer.handlePaymentSelect` routes card-like ids to Stripe Elements only when `capabilities.stripe.available`; otherwise a typed error step. Venmo likewise. Only explicit manual ids (`cash`/`check`/`zelle`/`venmo-direct`/`other`, plus the kit's own default `manual` adapter name) reach `processCustomPayment`; unknown ids error. Pipeline fails unsupported selections with `PaymentError INVALID_METHOD` and never invokes a manual adapter |
| Normalization lives in the kit | All helpers exported from `src/payments/types.ts` (re-exported via package root); components/store/pipeline consume the shared helpers — and so do the tests (no local guard mirrors) |
| Align with bridge `extractCapabilities` public ids (`card`, `venmo`, `cash: false`) | Covered by `src/tests/unit/payments/method-normalization.test.ts` capability-alignment case against `PaymentCapabilities` |

## Tests

- `tests/e2e/hybrid-checkout-drawer.test.ts` (new): renders the real `HybridCheckoutDrawer` through the full booking flow — unavailable `card`/`venmo` and unknown ids land on the error step and never call `onBookingComplete`; explicit manual (`cash`) completes in-app
- `src/tests/unit/payments/method-normalization.test.ts` (new): id mapping round-trips, card/manual guards (incl. default `manual` adapter name), public option builder + icon-domain mapping, registry resolution, literal-vs-alias precedence/dedupe, capability id alignment
- `src/tests/unit/stores/checkout-store.test.ts` (new): payment selector state normalization (`stripe` -> `card`)
- `src/tests/unit/core/pipelines.test.ts`: public id -> correct adapter; unsupported `card`/`venmo` -> typed `INVALID_METHOD` error, manual adapter never invoked; factory alias precedence (literal `card` adapter never clobbered by the stripe alias, either registration order) + public method emission
- `src/tests/components/hybrid-checkout-state.test.ts`: routing mirrors the drawer's branch ordering but uses the REAL guards imported from `src/payments/types.js` — guard drift fails this suite
- `tests/e2e/payment-selector.test.ts`: selector renders/reports the canonical `card` id from an option built by `toPublicPaymentMethodOption` over an internally named stripe adapter (kit boundary, not a hand-written fixture)

## Validation matrix

| Check | Result |
| --- | --- |
| `pnpm check` (svelte-check) | 0 errors / 0 warnings (1931 files) |
| `pnpm lint` (eslint) | clean |
| `pnpm test:unit` | 644 passed; 12 pre-existing failures in `src/adapters/__tests__/availability-engine.test.ts` (file owned by #97, untouched here). Root cause: the suite hardcodes `TEST_DATE = '2026-06-01'`, now in the past, so slot generation returns 0 — a date time-bomb that turned red on rollover, not a regression from this PR. CI stays red on both Node lanes until #97 (or a date fix) lands; merge after #97 and re-run |
| targeted payment suites (normalization, store, pipelines, hybrid state) | 136/136 passed |
| `pnpm test:component` (tests/e2e) | 55/55 passed (includes the new drawer render suite) |
| `pnpm build` (svelte-package) | clean |
| `pnpm exec publint` | All good |
| `bazelisk build //:pkg` | success, 42s; local sandboxed execution + disk cache, no remote cache/RBE configured |

## Notes

- Diff is disjoint from open PRs #96 (docs/toolchain + `src/adapters/homegrown.ts`, `vitest.config.ts`, `vitest.integration.config.ts`) and #97 (`src/adapters/__tests__/availability-engine.test.ts`). `vitest.component.config.ts` (touched here to inline skeleton/zag for jsdom) is owned by neither.
- Legacy `stripe` id remains readable internally (and in the hybrid drawer routing) for transitional consumers; it is simply never emitted publicly.
- **Release-note callout for the eventual release PR**: `getAvailableMethods()` and `CheckoutDrawer` now emit `id`/`name` `card` where they previously emitted `stripe`. Inputs stay back-compatible (`registry.get`/pipeline/drawer still accept `stripe`), but adopters matching `method.id === 'stripe'` on **emitted** options break at runtime with no type error — grep apps for `=== 'stripe'` before the version lands. (The bridge already emits `card`.)
- Follow-up #100 (blocked on #96): remove the stale `src/payments/types.ts` coverage exclude in `vitest.config.ts` and add `pnpm test:component` to CI.
- No version bump — release PRs handle that separately.

Source draft: #63
