### PR TITLE
feat(core)!: structured PaymentReference codec (TIN-1995)

### DIFF
--- a/src/adapters/acuity.ts
+++ b/src/adapters/acuity.ts
@@ -16,6 +16,7 @@ import type {
   ClientInfo,
 } from '../core/types.js';
 import { Errors } from '../core/types.js';
+import { formatPaymentRef } from '../core/payment-ref.js';
 import { fromPromise, withRetry, withTimeout } from '../core/utils.js';
 import type { SchedulingAdapter, AcuityAdapterConfig } from './types.js';
 
@@ -351,7 +352,11 @@ export const createAcuityAdapter = (config: AcuityAdapterConfig): SchedulingAdap
       ),
 
     createBookingWithPaymentRef: (request, paymentRef, paymentProcessor) => {
-      const paymentNote = `[${paymentProcessor.toUpperCase()}] Transaction: ${paymentRef}`;
+      // Canonical wire format — Acuity can only persist strings (notes field).
+      const paymentNote = formatPaymentRef({
+        processor: paymentProcessor,
+        transactionId: paymentRef,
+      });
       const combinedNotes = request.client.notes
         ? `${request.client.notes}\n\n${paymentNote}`
         : paymentNote;

--- a/src/adapters/homegrown.ts
+++ b/src/adapters/homegrown.ts
@@ -411,6 +411,7 @@ export const createHomegrownAdapter = (
       confirmationCode: row.confirmationCode,
       paymentStatus: row.paymentStatus as PaymentStatus,
       paymentRef: row.paymentRef ?? undefined,
+      paymentMethod: row.paymentMethod ?? undefined,
       createdAt: row.createdAt,
     } satisfies Booking;
   };
@@ -708,6 +709,7 @@ export const createHomegrownAdapter = (
           status: row.status as BookingStatus,
           confirmationCode: row.confirmationCode,
           paymentStatus: row.paymentStatus as PaymentStatus,
+          paymentMethod: row.paymentMethod ?? undefined,
           createdAt: row.createdAt,
         } satisfies Booking;
       }),
@@ -736,6 +738,7 @@ export const createHomegrownAdapter = (
           return {
             ...booking,
             paymentRef,
+            paymentMethod: paymentProcessor,
             paymentStatus: "paid" as const,
           };
         }),

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -5,6 +5,14 @@
 // Types
 export * from './types.js';
 
+// Payment reference codec
+export {
+  formatPaymentRef,
+  parsePaymentRef,
+  type PaymentProcessor,
+  type PaymentReference,
+} from './payment-ref.js';
+
 // Utilities
 export {
   fromPromise,

--- a/src/core/payment-ref.ts
+++ b/src/core/payment-ref.ts
@@ -1,0 +1,142 @@
+/**
+ * Canonical payment-reference codec
+ *
+ * Some scheduling backends (Acuity) can only persist payment metadata as a
+ * freeform string (the appointment notes field), so the production wire
+ * format is a human-readable marker:
+ *
+ *   `[PROCESSOR] Transaction: <transactionId>`
+ *
+ * That format is already deployed in stored production bookings and MUST NOT
+ * change. What this module changes is ownership: formatting and parsing live
+ * in one tested codec instead of scattered string templates and regexes
+ * (previously `src/adapters/acuity.ts` and `src/core/pipelines.ts` each had
+ * their own half of the contract).
+ *
+ * Encoding rules:
+ * - `formatPaymentRef` is byte-identical to the legacy template
+ *   `` `[${processor.toUpperCase()}] Transaction: ${transactionId}` ``.
+ * - `parsePaymentRef` accepts every string the legacy pipeline regexes
+ *   (`/\[(\w+)\]/` and `/Transaction:\s*(\S+)/`, first match each) accepted,
+ *   including markers embedded in surrounding note text, and returns a typed
+ *   `ValidationError` instead of silently yielding `undefined` halves.
+ *
+ * Round-trip guarantee: `parse(format(x))` deep-equals `x` for every
+ * `PaymentReference` whose `processor` matches `/^[a-z0-9_]+$/` (canonical
+ * lowercase form) and whose `transactionId` matches `/^\S+$/`. Outside that
+ * domain (e.g. the hyphenated `venmo-direct` manual method) the wire string
+ * is still produced exactly as the legacy template did, but it is not
+ * machine-recoverable — same as before this codec existed.
+ */
+
+import { Effect } from 'effect';
+import type { ValidationError } from './types.js';
+import { Errors } from './types.js';
+
+// =============================================================================
+// TYPES
+// =============================================================================
+
+/**
+ * Canonical (lowercase) payment processor identifier.
+ *
+ * This is intentionally an open string, not a closed union: processors are
+ * keyed by `PaymentAdapter.name`, which consuming sites choose at
+ * registration time. The codec uppercases on encode and lowercases on decode.
+ */
+export type PaymentProcessor = string;
+
+/**
+ * Structured payment reference — the typed form of the
+ * `[PROCESSOR] Transaction: <id>` wire string.
+ */
+export interface PaymentReference {
+  readonly processor: PaymentProcessor;
+  readonly transactionId: string;
+}
+
+// =============================================================================
+// WIRE PATTERNS
+// =============================================================================
+
+/**
+ * The intact canonical marker, wherever it sits inside surrounding note text
+ * (Acuity prepends client notes; refund annotations may follow).
+ */
+const CANONICAL_MARKER = /\[(\w+)\]\s*Transaction:\s*(\S+)/;
+
+/** Legacy independent scans — exactly what cancelBookingWithRefund used. */
+const LEGACY_PROCESSOR = /\[(\w+)\]/;
+const LEGACY_TRANSACTION = /Transaction:\s*(\S+)/;
+
+// =============================================================================
+// CODEC
+// =============================================================================
+
+/**
+ * Encode a payment reference into the production wire format.
+ *
+ * Byte-identical to the legacy template, so newly written strings are
+ * indistinguishable from existing stored ones.
+ */
+export const formatPaymentRef = (ref: PaymentReference): string =>
+  `[${ref.processor.toUpperCase()}] Transaction: ${ref.transactionId}`;
+
+/**
+ * Decode a payment reference from the production wire format.
+ *
+ * Resolution order:
+ * 1. First intact canonical marker (`[PROC] Transaction: id`). This is what
+ *    every writer produces, and preferring it makes parsing robust against
+ *    stray `[brackets]` or `Transaction:` text appearing earlier in
+ *    client-authored notes (the legacy regexes would have matched those
+ *    fragments instead and silently mis-resolved).
+ * 2. Legacy fallback: first `/\[(\w+)\]/` + first `/Transaction:\s*(\S+)/`
+ *    independently, preserving compatibility with every stored string the
+ *    old pipeline could extract.
+ *
+ * Failures are typed `ValidationError`s (`field: 'paymentRef'`) rather than
+ * the legacy behavior of silently producing `undefined` halves. A
+ * `ValidationError` is used (not `PaymentError`) because the failure is about
+ * the shape of a stored value, and `PaymentError` requires the `processor`
+ * field — exactly the datum a parse failure could not determine.
+ */
+export const parsePaymentRef = (
+  raw: string | undefined | null
+): Effect.Effect<PaymentReference, ValidationError> => {
+  if (!raw) {
+    return Effect.fail(
+      Errors.validation('paymentRef', 'Payment reference is missing or empty', raw ?? undefined)
+    );
+  }
+
+  const canonical = CANONICAL_MARKER.exec(raw);
+  if (canonical) {
+    return Effect.succeed({
+      processor: canonical[1].toLowerCase(),
+      transactionId: canonical[2],
+    });
+  }
+
+  const processor = LEGACY_PROCESSOR.exec(raw)?.[1]?.toLowerCase();
+  const transactionId = LEGACY_TRANSACTION.exec(raw)?.[1];
+
+  if (processor && transactionId) {
+    return Effect.succeed({ processor, transactionId });
+  }
+
+  const missing =
+    !processor && !transactionId
+      ? 'no [PROCESSOR] marker or transaction id'
+      : !processor
+        ? 'no [PROCESSOR] marker'
+        : 'no transaction id';
+
+  return Effect.fail(
+    Errors.validation(
+      'paymentRef',
+      `Unparseable payment reference (${missing}); expected '[PROCESSOR] Transaction: <id>'`,
+      raw
+    )
+  );
+};

--- a/src/core/pipelines.ts
+++ b/src/core/pipelines.ts
@@ -20,6 +20,7 @@ import type { SchedulingAdapter } from '../adapters/types.js';
 import type { PaymentAdapter, PaymentRegistry as CanonicalPaymentRegistry } from '../payments/types.js';
 import { createPaymentRegistry } from '../payments/types.js';
 import { z } from 'zod';
+import { parsePaymentRef } from './payment-ref.js';
 
 // =============================================================================
 // VALIDATION SCHEMAS
@@ -270,6 +271,16 @@ export interface CancellationResult {
 
 /**
  * Cancel booking with optional refund
+ *
+ * Refund semantics: when `refund: true` and the booking carries a
+ * `paymentRef`, the reference is decoded with the canonical codec BEFORE any
+ * state is mutated. An unparseable reference fails the whole pipeline with a
+ * typed `ValidationError` (field `'paymentRef'`) and the booking is left
+ * uncancelled — previously this cancelled the booking and silently reported
+ * `refund.success: false`. Callers that want to cancel anyway can retry with
+ * `refund: false`. A reference that parses to a processor with no registered
+ * adapter keeps the legacy soft behavior (`refund.success: false`), since the
+ * stored data itself is intact.
  */
 export const cancelBookingWithRefund = (
   ctx: PipelineContext,
@@ -279,27 +290,26 @@ export const cancelBookingWithRefund = (
 
   return Effect.gen(function* () {
     const booking = yield* scheduler.getBooking(input.bookingId);
+
+    // Decode the payment reference up front so a refund we cannot honor
+    // refuses the operation before the booking is cancelled.
+    const paymentRef =
+      input.refund && booking.paymentRef ? yield* parsePaymentRef(booking.paymentRef) : undefined;
+
     yield* scheduler.cancelBooking(input.bookingId, input.reason);
 
-    if (!input.refund || !booking.paymentRef) {
+    if (!paymentRef) {
       return { cancelled: true } satisfies CancellationResult;
     }
 
-    // Extract payment processor from notes
-    const processorMatch = booking.paymentRef?.match(/\[(\w+)\]/);
-    const processor = processorMatch?.[1]?.toLowerCase();
+    const processor = paymentRef.processor;
     const paymentAdapter = processor ? payments.get(processor) : undefined;
 
     if (!paymentAdapter) {
       return { cancelled: true, refund: { success: false } } satisfies CancellationResult;
     }
 
-    const txMatch = booking.paymentRef?.match(/Transaction:\s*(\S+)/);
-    const transactionId = txMatch?.[1];
-
-    if (!transactionId) {
-      return { cancelled: true, refund: { success: false } } satisfies CancellationResult;
-    }
+    const transactionId = paymentRef.transactionId;
 
     const refundResult = yield* pipe(
       paymentAdapter.refund({ transactionId, reason: input.reason ?? 'Booking cancelled' }),

--- a/src/core/pipelines.ts
+++ b/src/core/pipelines.ts
@@ -21,6 +21,7 @@ import type { PaymentAdapter, PaymentRegistry as CanonicalPaymentRegistry } from
 import { createPaymentRegistry } from '../payments/types.js';
 import { z } from 'zod';
 import { parsePaymentRef } from './payment-ref.js';
+import type { PaymentReference } from './payment-ref.js';
 
 // =============================================================================
 // VALIDATION SCHEMAS
@@ -273,14 +274,23 @@ export interface CancellationResult {
  * Cancel booking with optional refund
  *
  * Refund semantics: when `refund: true` and the booking carries a
- * `paymentRef`, the reference is decoded with the canonical codec BEFORE any
- * state is mutated. An unparseable reference fails the whole pipeline with a
- * typed `ValidationError` (field `'paymentRef'`) and the booking is left
- * uncancelled — previously this cancelled the booking and silently reported
+ * `paymentRef`, the reference is resolved BEFORE any state is mutated:
+ *
+ * 1. The canonical codec decodes the `[PROCESSOR] Transaction: <id>` wire
+ *    format (what Acuity-backed bookings store).
+ * 2. If the string does not parse and the backend surfaced the processor as
+ *    a structured field (`booking.paymentMethod` — the homegrown adapter
+ *    stores the bare transaction id in `paymentRef` and the processor in its
+ *    own column), the refund is routed with
+ *    `{ processor: booking.paymentMethod, transactionId: booking.paymentRef }`.
+ *
+ * Only when neither resolves does the pipeline fail with a typed
+ * `ValidationError` (field `'paymentRef'`), leaving the booking uncancelled —
+ * previously this cancelled the booking and silently reported
  * `refund.success: false`. Callers that want to cancel anyway can retry with
- * `refund: false`. A reference that parses to a processor with no registered
- * adapter keeps the legacy soft behavior (`refund.success: false`), since the
- * stored data itself is intact.
+ * `refund: false`. A reference that resolves to a processor with no
+ * registered adapter keeps the legacy soft behavior
+ * (`refund.success: false`), since the stored data itself is intact.
  */
 export const cancelBookingWithRefund = (
   ctx: PipelineContext,
@@ -291,10 +301,25 @@ export const cancelBookingWithRefund = (
   return Effect.gen(function* () {
     const booking = yield* scheduler.getBooking(input.bookingId);
 
-    // Decode the payment reference up front so a refund we cannot honor
-    // refuses the operation before the booking is cancelled.
+    // Resolve the payment reference up front so a refund we cannot honor
+    // refuses the operation before the booking is cancelled. Backends that
+    // store the reference structurally (homegrown) never wrote the wire
+    // format, so a failed parse falls back to their structured halves.
+    const storedRef = booking.paymentRef;
+    const structuredFallback: PaymentReference | undefined =
+      storedRef && booking.paymentMethod
+        ? { processor: booking.paymentMethod, transactionId: storedRef }
+        : undefined;
+
     const paymentRef =
-      input.refund && booking.paymentRef ? yield* parsePaymentRef(booking.paymentRef) : undefined;
+      input.refund && storedRef
+        ? yield* pipe(
+            parsePaymentRef(storedRef),
+            Effect.catchAll((parseError) =>
+              structuredFallback ? Effect.succeed(structuredFallback) : Effect.fail(parseError)
+            )
+          )
+        : undefined;
 
     yield* scheduler.cancelBooking(input.bookingId, input.reason);
 
@@ -302,8 +327,7 @@ export const cancelBookingWithRefund = (
       return { cancelled: true } satisfies CancellationResult;
     }
 
-    const processor = paymentRef.processor;
-    const paymentAdapter = processor ? payments.get(processor) : undefined;
+    const paymentAdapter = payments.get(paymentRef.processor);
 
     if (!paymentAdapter) {
       return { cancelled: true, refund: { success: false } } satisfies CancellationResult;

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -232,6 +232,15 @@ export interface Booking {
   readonly confirmationCode?: string;
   readonly paymentStatus: PaymentStatus;
   readonly paymentRef?: string;
+  /**
+   * Payment processor / adapter name, when the backend stores it as a
+   * structured field (the homegrown adapter persists it in its own
+   * `paymentMethod` column alongside the bare transaction id in
+   * `paymentRef`). Backends that can only persist one freeform string
+   * (Acuity) leave this unset and encode the processor inside `paymentRef`
+   * via the canonical wire format instead.
+   */
+  readonly paymentMethod?: string;
   readonly createdAt: string;
 }
 

--- a/src/tests/unit/core/payment-ref.test.ts
+++ b/src/tests/unit/core/payment-ref.test.ts
@@ -168,6 +168,32 @@ describe('parsePaymentRef — legacy stored strings', () => {
       transactionId: 'cash_77777',
     });
   });
+
+  it('prefers the canonical marker transaction id over stray earlier Transaction: text', () => {
+    // Canonical-first changes the transactionId half too, not just the
+    // processor: the legacy independent scans took the FIRST
+    // 'Transaction: <tok>' anywhere, so this string resolved
+    // {cash, tx_early} — a refund aimed at the wrong transaction. The codec
+    // takes the id bound to the intact marker.
+    expect(
+      parseOk('Client says Transaction: tx_early was declined\n\n[CASH] Transaction: tx_late')
+    ).toEqual({
+      processor: 'cash',
+      transactionId: 'tx_late',
+    });
+  });
+
+  it('prefers a later intact marker over an earlier split marker (both halves change)', () => {
+    // Full extent of the canonical-first deviation: the legacy scans
+    // resolved {cash, cash_9} here; the codec resolves the intact later
+    // marker, changing BOTH the processor and the transaction id. No
+    // production writer emits split markers, so this shape is contrived,
+    // but the preference is pinned deliberately.
+    expect(parseOk('[CASH] paid, Transaction: cash_9\n\n[STRIPE] Transaction: pi_1')).toEqual({
+      processor: 'stripe',
+      transactionId: 'pi_1',
+    });
+  });
 });
 
 // =============================================================================

--- a/src/tests/unit/core/payment-ref.test.ts
+++ b/src/tests/unit/core/payment-ref.test.ts
@@ -1,0 +1,209 @@
+/**
+ * Tests for core/payment-ref.ts
+ *
+ * The wire format `[PROCESSOR] Transaction: <id>` is deployed in production
+ * bookings (Acuity notes fields). These tests pin:
+ * 1. byte-identical encoding vs. the legacy string template
+ * 2. parse compatibility with every string the legacy pipeline regexes
+ *    (`/\[(\w+)\]/`, `/Transaction:\s*(\S+)/`) could extract
+ * 3. the property `parse(format(x)) deepEquals x` over the canonical domain
+ * 4. typed ValidationError failures instead of silent undefined halves
+ */
+
+import { describe, it, expect } from 'vitest';
+import * as fc from 'fast-check';
+import { Cause, Effect, Exit, Option } from 'effect';
+import {
+  formatPaymentRef,
+  parsePaymentRef,
+  type PaymentReference,
+} from '../../../core/payment-ref.js';
+import type { SchedulingError, ValidationError } from '../../../core/types.js';
+
+// =============================================================================
+// SYNC HELPERS
+// =============================================================================
+
+const parseOk = (raw: string): PaymentReference => Effect.runSync(parsePaymentRef(raw));
+
+const parseErr = (raw: string | undefined | null): ValidationError => {
+  const exit = Effect.runSyncExit(parsePaymentRef(raw));
+  if (Exit.isSuccess(exit)) {
+    throw new Error(`Expected parse failure for: ${String(raw)}`);
+  }
+  const failure = Cause.failureOption(exit.cause);
+  if (Option.isNone(failure)) {
+    throw new Error('Expected a typed failure, got a defect');
+  }
+  const error: SchedulingError = failure.value;
+  expect(error._tag).toBe('ValidationError');
+  return error as ValidationError;
+};
+
+// =============================================================================
+// CANONICAL DOMAIN ARBITRARIES
+// =============================================================================
+
+/** Canonical processor: lowercase word characters, as adapter names are keyed. */
+const processorArb = fc.stringMatching(/^[a-z0-9_]+$/);
+
+/** Transaction id: any non-empty run of printable, non-space ASCII. */
+const transactionIdArb = fc.stringMatching(/^[\x21-\x7e]+$/);
+
+const paymentReferenceArb: fc.Arbitrary<PaymentReference> = fc.record({
+  processor: processorArb,
+  transactionId: transactionIdArb,
+});
+
+// =============================================================================
+// FORMAT
+// =============================================================================
+
+describe('formatPaymentRef', () => {
+  it('is byte-identical to the legacy production template', () => {
+    expect(formatPaymentRef({ processor: 'cash', transactionId: 'cash_100001' })).toBe(
+      '[CASH] Transaction: cash_100001'
+    );
+    expect(formatPaymentRef({ processor: 'stripe', transactionId: 'pi_3MtwBw' })).toBe(
+      '[STRIPE] Transaction: pi_3MtwBw'
+    );
+  });
+
+  it('matches the legacy template for arbitrary inputs', () => {
+    fc.assert(
+      fc.property(paymentReferenceArb, (ref) => {
+        const legacy = `[${ref.processor.toUpperCase()}] Transaction: ${ref.transactionId}`;
+        expect(formatPaymentRef(ref)).toBe(legacy);
+      })
+    );
+  });
+});
+
+// =============================================================================
+// ROUND TRIP
+// =============================================================================
+
+describe('round trip', () => {
+  it('parse(format(x)) deep-equals x over the canonical domain', () => {
+    fc.assert(
+      fc.property(paymentReferenceArb, (ref) => {
+        expect(parseOk(formatPaymentRef(ref))).toEqual(ref);
+      })
+    );
+  });
+
+  it('round-trips when embedded in surrounding note text', () => {
+    // Acuity prepends client notes (and other tooling appends annotations);
+    // the marker must survive embedding. Prefix is bracket-free prose.
+    const proseArb = fc.stringMatching(/^[a-zA-Z0-9 .,]*$/);
+    fc.assert(
+      fc.property(paymentReferenceArb, proseArb, (ref, notes) => {
+        const stored = notes ? `${notes}\n\n${formatPaymentRef(ref)}` : formatPaymentRef(ref);
+        expect(parseOk(stored)).toEqual(ref);
+      })
+    );
+  });
+});
+
+// =============================================================================
+// LEGACY STORED-STRING FIXTURES
+// =============================================================================
+
+describe('parsePaymentRef — legacy stored strings', () => {
+  it('parses the plain production format', () => {
+    expect(parseOk('[CASH] Transaction: cash_100001')).toEqual({
+      processor: 'cash',
+      transactionId: 'cash_100001',
+    });
+  });
+
+  it('parses a ref with a trailing refund annotation (first marker wins)', () => {
+    expect(parseOk('[ZELLE] Transaction: zelle_100003 [REFUND] refund_100003')).toEqual({
+      processor: 'zelle',
+      transactionId: 'zelle_100003',
+    });
+  });
+
+  it('parses an Acuity notes field with client notes after the marker', () => {
+    expect(parseOk('[CASH] Transaction: cash_100001\nNew patient, referred by Dr. Smith')).toEqual({
+      processor: 'cash',
+      transactionId: 'cash_100001',
+    });
+  });
+
+  it('parses an Acuity notes field with client notes before the marker', () => {
+    expect(parseOk('Prefers afternoons\n\n[VENMO] Transaction: venmo_100004')).toEqual({
+      processor: 'venmo',
+      transactionId: 'venmo_100004',
+    });
+  });
+
+  it('lowercases the processor token like the legacy parser', () => {
+    expect(parseOk('[stripe] Transaction: pi_123')).toEqual({
+      processor: 'stripe',
+      transactionId: 'pi_123',
+    });
+  });
+
+  it('accepts zero whitespace after Transaction: (legacy \\s*)', () => {
+    expect(parseOk('[CASH]Transaction:cash_1')).toEqual({
+      processor: 'cash',
+      transactionId: 'cash_1',
+    });
+  });
+
+  it('falls back to independent legacy scans when the marker is split', () => {
+    // Legacy behavior: first [token] + first 'Transaction: id' anywhere.
+    expect(parseOk('[CASH] paid in person, Transaction: cash_9')).toEqual({
+      processor: 'cash',
+      transactionId: 'cash_9',
+    });
+  });
+
+  it('prefers the intact canonical marker over a stray earlier bracket token', () => {
+    // The legacy regexes would have resolved processor 'vip' here and the
+    // refund would have been silently skipped. The codec finds the marker.
+    expect(parseOk('Client note [VIP]\n\n[CASH] Transaction: cash_77777')).toEqual({
+      processor: 'cash',
+      transactionId: 'cash_77777',
+    });
+  });
+});
+
+// =============================================================================
+// TYPED FAILURES
+// =============================================================================
+
+describe('parsePaymentRef — typed failures', () => {
+  it('fails on empty, undefined, and null input', () => {
+    for (const raw of ['', undefined, null] as const) {
+      const error = parseErr(raw);
+      expect(error.field).toBe('paymentRef');
+    }
+  });
+
+  it('fails when the transaction id is missing', () => {
+    const error = parseErr('[CASH] No transaction here');
+    expect(error.field).toBe('paymentRef');
+    expect(error.message).toContain('no transaction id');
+    expect(error.value).toBe('[CASH] No transaction here');
+  });
+
+  it('fails when the processor marker is missing', () => {
+    const error = parseErr('Transaction: tx_1 with no processor');
+    expect(error.message).toContain('no [PROCESSOR] marker');
+  });
+
+  it('fails on a raw transaction id with no wire formatting', () => {
+    const error = parseErr('pi_3MtwBwLkdIwHu7ix28a3tqPa');
+    expect(error.field).toBe('paymentRef');
+    expect(error.value).toBe('pi_3MtwBwLkdIwHu7ix28a3tqPa');
+  });
+
+  it('fails on hyphenated processor tokens (outside the \\w+ wire grammar)', () => {
+    // '[VENMO-DIRECT]' was never parseable by the legacy regexes either —
+    // the codec keeps that grammar but makes the failure loud and typed.
+    const error = parseErr('[VENMO-DIRECT] Transaction: tx_1');
+    expect(error.message).toContain('no [PROCESSOR] marker');
+  });
+});

--- a/src/tests/unit/core/pipelines.test.ts
+++ b/src/tests/unit/core/pipelines.test.ts
@@ -447,11 +447,14 @@ describe('cancelBookingWithRefund', () => {
     expect(paymentAdapter.refund).not.toHaveBeenCalled();
   });
 
-  it('fails with typed ValidationError for a raw (unformatted) payment ref', async () => {
+  it('fails with typed ValidationError for a raw payment ref with no structured paymentMethod', async () => {
+    // No wire format AND no structured processor field — there is nothing to
+    // route the refund with, so the operation is refused before mutation.
     vi.mocked(scheduler.getBooking).mockReturnValue(
       Effect.succeed(
         createBooking({
           paymentRef: 'pi_3MtwBwLkdIwHu7ix28a3tqPa',
+          paymentMethod: undefined,
         })
       )
     );
@@ -463,6 +466,71 @@ describe('cancelBookingWithRefund', () => {
 
     expect(error._tag === 'ValidationError' && error.value).toBe('pi_3MtwBwLkdIwHu7ix28a3tqPa');
     expect(scheduler.cancelBooking).not.toHaveBeenCalled();
+  });
+
+  it('refunds via the structured paymentMethod when the stored ref is a raw transaction id', async () => {
+    // The homegrown adapter never writes the wire format: it stores the bare
+    // transaction id in paymentRef and the processor in its own
+    // paymentMethod column. This is the steady state for every paid booking
+    // the kit's own happy path creates on a homegrown backend.
+    vi.mocked(scheduler.getBooking).mockReturnValue(
+      Effect.succeed(
+        createBooking({
+          paymentRef: 'txn_homegrown_1',
+          paymentMethod: 'cash',
+        })
+      )
+    );
+
+    const result = await expectSuccess(
+      cancelBookingWithRefund(ctx, { bookingId: '100001', refund: true })
+    );
+
+    expect(result.cancelled).toBe(true);
+    expect(result.refund?.success).toBe(true);
+    expect(paymentAdapter.refund).toHaveBeenCalledWith(
+      expect.objectContaining({ transactionId: 'txn_homegrown_1' })
+    );
+  });
+
+  it('keeps the soft refund failure when the structured paymentMethod has no registered adapter', async () => {
+    vi.mocked(scheduler.getBooking).mockReturnValue(
+      Effect.succeed(
+        createBooking({
+          paymentRef: 'txn_homegrown_2',
+          paymentMethod: 'venmo',
+        })
+      )
+    );
+
+    const result = await expectSuccess(
+      cancelBookingWithRefund(ctx, { bookingId: '100001', refund: true })
+    );
+
+    expect(result.cancelled).toBe(true);
+    expect(result.refund?.success).toBe(false);
+    expect(paymentAdapter.refund).not.toHaveBeenCalled();
+  });
+
+  it('prefers the wire-format ref over the structured paymentMethod when both resolve', async () => {
+    vi.mocked(scheduler.getBooking).mockReturnValue(
+      Effect.succeed(
+        createBooking({
+          paymentRef: '[CASH] Transaction: cash_55',
+          paymentMethod: 'venmo',
+        })
+      )
+    );
+
+    const result = await expectSuccess(
+      cancelBookingWithRefund(ctx, { bookingId: '100001', refund: true })
+    );
+
+    expect(result.cancelled).toBe(true);
+    expect(result.refund?.success).toBe(true);
+    expect(paymentAdapter.refund).toHaveBeenCalledWith(
+      expect.objectContaining({ transactionId: 'cash_55' })
+    );
   });
 
   it('still cancels a booking with an unparseable ref when no refund is requested', async () => {

--- a/src/tests/unit/core/pipelines.test.ts
+++ b/src/tests/unit/core/pipelines.test.ts
@@ -15,6 +15,7 @@ import {
   type BookingPipelineInput,
 } from '../../../core/pipelines.js';
 import { Errors } from '../../../core/types.js';
+import { formatPaymentRef } from '../../../core/payment-ref.js';
 import type { SchedulingAdapter } from '../../../adapters/types.js';
 import type { PaymentAdapter, PaymentWebhookEvent } from '../../../payments/types.js';
 import {
@@ -67,7 +68,7 @@ const createMockScheduler = (): SchedulingAdapter => ({
   // Bookings
   createBooking: vi.fn(() => Effect.succeed(createBooking())),
   createBookingWithPaymentRef: vi.fn((_, ref, processor) =>
-    Effect.succeed(createBooking({ paymentRef: `[${processor.toUpperCase()}] Transaction: ${ref}` }))
+    Effect.succeed(createBooking({ paymentRef: formatPaymentRef({ processor, transactionId: ref }) }))
   ),
   getBooking: vi.fn(() => Effect.succeed(createBooking())),
   cancelBooking: vi.fn(() => Effect.succeed(undefined)),
@@ -421,7 +422,10 @@ describe('cancelBookingWithRefund', () => {
     expect(result.refund?.success).toBe(false);
   });
 
-  it('returns success with failed refund when transaction ID not found', async () => {
+  it('fails with typed ValidationError and does not cancel when payment ref is unparseable', async () => {
+    // Legacy behavior: cancelled the booking and silently reported
+    // refund.success: false. New behavior: a refund that cannot be honored
+    // refuses the whole operation before any state is mutated.
     vi.mocked(scheduler.getBooking).mockReturnValue(
       Effect.succeed(
         createBooking({
@@ -430,15 +434,78 @@ describe('cancelBookingWithRefund', () => {
       )
     );
 
-    const result = await expectSuccess(
+    const error = await expectFailureTag(
       cancelBookingWithRefund(ctx, {
         bookingId: '100001',
         refund: true,
-      })
+      }),
+      'ValidationError'
+    );
+
+    expect(error._tag === 'ValidationError' && error.field).toBe('paymentRef');
+    expect(scheduler.cancelBooking).not.toHaveBeenCalled();
+    expect(paymentAdapter.refund).not.toHaveBeenCalled();
+  });
+
+  it('fails with typed ValidationError for a raw (unformatted) payment ref', async () => {
+    vi.mocked(scheduler.getBooking).mockReturnValue(
+      Effect.succeed(
+        createBooking({
+          paymentRef: 'pi_3MtwBwLkdIwHu7ix28a3tqPa',
+        })
+      )
+    );
+
+    const error = await expectFailureTag(
+      cancelBookingWithRefund(ctx, { bookingId: '100001', refund: true }),
+      'ValidationError'
+    );
+
+    expect(error._tag === 'ValidationError' && error.value).toBe('pi_3MtwBwLkdIwHu7ix28a3tqPa');
+    expect(scheduler.cancelBooking).not.toHaveBeenCalled();
+  });
+
+  it('still cancels a booking with an unparseable ref when no refund is requested', async () => {
+    vi.mocked(scheduler.getBooking).mockReturnValue(
+      Effect.succeed(
+        createBooking({
+          paymentRef: 'not a wire-format ref',
+        })
+      )
+    );
+
+    const result = await expectSuccess(
+      cancelBookingWithRefund(ctx, { bookingId: '100001', refund: false })
     );
 
     expect(result.cancelled).toBe(true);
-    expect(result.refund?.success).toBe(false);
+    expect(result.refund).toBeUndefined();
+    expect(scheduler.cancelBooking).toHaveBeenCalledWith('100001', undefined);
+  });
+
+  it('refunds using the canonical marker when the ref is embedded in note text', async () => {
+    // Acuity stores the payment marker inside the appointment notes field,
+    // surrounded by client notes and refund annotations. The stray [VIP]
+    // token would have been mis-parsed as the processor by the legacy regex;
+    // the codec prefers the intact canonical marker.
+    vi.mocked(scheduler.getBooking).mockReturnValue(
+      Effect.succeed(
+        createBooking({
+          paymentRef:
+            'Client prefers afternoons [VIP]\n\n[CASH] Transaction: cash_77777 [REFUND] refund_77777',
+        })
+      )
+    );
+
+    const result = await expectSuccess(
+      cancelBookingWithRefund(ctx, { bookingId: '100001', refund: true })
+    );
+
+    expect(result.cancelled).toBe(true);
+    expect(result.refund?.success).toBe(true);
+    expect(paymentAdapter.refund).toHaveBeenCalledWith(
+      expect.objectContaining({ transactionId: 'cash_77777' })
+    );
   });
 
   it('propagates booking not found error', async () => {

--- a/src/tests/unit/core/wizard-pipeline.test.ts
+++ b/src/tests/unit/core/wizard-pipeline.test.ts
@@ -16,6 +16,7 @@ import {
   type SchedulingKit,
 } from '../../../core/pipelines.js';
 import { Errors } from '../../../core/types.js';
+import { formatPaymentRef } from '../../../core/payment-ref.js';
 import type { SchedulingAdapter } from '../../../adapters/types.js';
 import type { PaymentAdapter } from '../../../payments/types.js';
 import {
@@ -106,7 +107,7 @@ const createMockWizardAdapter = (overrides?: Partial<SchedulingAdapter>): Schedu
       client: request.client,
       status: 'confirmed',
       paymentStatus: 'paid',
-      paymentRef: `[${processor.toUpperCase()}] Transaction: ${paymentRef}`,
+      paymentRef: formatPaymentRef({ processor, transactionId: paymentRef }),
     }))
   ),
   getBooking: vi.fn(() =>


### PR DESCRIPTION
Structured-paymentRef half of TIN-1995: a single canonical codec for the `[PROCESSOR] Transaction: <id>` wire format, replacing the scattered string template in `src/adapters/acuity.ts` and the ad-hoc regexes in `src/core/pipelines.ts` — plus a structured `Booking.paymentMethod` field so homegrown-backed refunds resolve without the wire format at all.

## BREAKING CHANGE

`cancelBookingWithRefund` (and `kit.cancelBooking({ refund: true })`) now resolves the payment reference BEFORE any state is mutated. A reference that cannot be resolved fails the whole pipeline with a typed `ValidationError` (field `'paymentRef'`) and leaves the booking uncancelled; legacy behavior was to cancel the booking and silently report `refund.success: false`. Guidance: `refund: false` still cancels unconditionally.

Resolution order (new):
1. canonical wire format `[PROC] Transaction: <id>` (what Acuity-backed bookings store);
2. structured fallback `{ processor: booking.paymentMethod, transactionId: booking.paymentRef }` when the string does not parse but the backend surfaced the processor structurally.

**Homegrown impact (the kit's primary adapter):** homegrown never writes the wire format — it stores the bare transaction id in `paymentRef` and the processor in its own `paymentMethod` column (`src/adapters/homegrown.ts` `createBookingWithPaymentRef`). Without the structured fallback, the parse-before-cancel rule would have hard-failed cancel-with-refund for **every** paid booking the kit's own happy path creates on a homegrown backend (an earlier revision of this PR had exactly that bug). This PR adds `Booking.paymentMethod` (`src/core/types.ts`), surfaces it from homegrown's three Booking-building sites, and routes the refund through it — so homegrown refunds now actually reach the right adapter (legacy always reported `refund.success: false` for them; that silent failure is also a behavior change, in the correct direction). No follow-up issue is needed for surfacing homegrown's structured ref: it is resolved in this PR, with zero DDL (the `paymentMethod` column already exists; no business-pg schema change).

The remaining hard-fail class is: `refund: true` + a `paymentRef` that neither parses nor comes with a structured `paymentMethod` (e.g. corrupted Acuity notes). Pinned in `pipelines.test.ts`.

## Requirement mapping

| Spec requirement | Where |
| --- | --- |
| `PaymentReference` type + `formatPaymentRef`/`parsePaymentRef` in src/core | `src/core/payment-ref.ts` (exported via `src/core/index.ts`) |
| Parse returns a typed failure (no throw/null) | `parsePaymentRef` returns `Effect.Effect<PaymentReference, ValidationError>`; failures are `Errors.validation('paymentRef', …, raw)` carrying the offending value |
| Round-trip property (fast-check) | `src/tests/unit/core/payment-ref.test.ts`: `parse(format(x))` deep-equals `x` over the canonical domain, plus an embedded-in-notes round-trip property and a format-vs-legacy-template property |
| Accepts the EXACT legacy production format incl. edge cases | Legacy fixtures pinned: plain marker, trailing `[REFUND]` annotation, notes before/after marker, lowercase processor token, zero whitespace (`[CASH]Transaction:cash_1`), split marker (`[CASH] paid in person, Transaction: cash_9`), hyphenated-processor rejection |
| Replace every scattered format/parse site | `acuity.ts` note-stuffing → `formatPaymentRef`; `pipelines.ts cancelBookingWithRefund` regexes → `parsePaymentRef`; test mocks in `pipelines.test.ts`/`wizard-pipeline.test.ts` → codec. `grep -rn 'Transaction:' src/` now hits only the codec, its tests, and stored-string test fixtures. `homegrown.ts`/`calcom.ts` pass raw refs and never wrote the wire format — and (corrected from an earlier revision of this body) those raw refs DO flow into `parsePaymentRef` via `getBooking`, which is exactly why the structured `Booking.paymentMethod` fallback exists |
| Unparseable refs in cancel = explicit typed error with documented semantics | Documented on `cancelBookingWithRefund` JSDoc and in the BREAKING CHANGE section above. Parseable/resolvable ref with no registered adapter keeps the legacy soft `refund.success: false`. Tested in `pipelines.test.ts` (typed-failure paths assert `cancelBooking`/`refund` were never called) |

## Legacy-compat evidence

`main`'s `cancelBookingWithRefund` used `booking.paymentRef?.match(/\[(\w+)\]/)` + `.toLowerCase()` and `booking.paymentRef?.match(/Transaction:\s*(\S+)/)`. The codec embeds those two regexes character-for-character as `LEGACY_PROCESSOR` / `LEGACY_TRANSACTION` fallback scans, so every string the old pipeline could extract still parses — including zero-whitespace and split-marker shapes. `formatPaymentRef` is byte-identical to the legacy template `` `[${processor.toUpperCase()}] Transaction: ${transactionId}` `` (property-tested), so newly written strings are indistinguishable from stored production ones.

**One deliberate, documented resolution deviation — full class, both halves:** the parser prefers the first intact canonical marker over the independent legacy scans. For strings containing stray `[brackets]` or `Transaction:` text plus an intact marker, the resolved reference can differ from legacy in the processor, the transactionId, or BOTH:

- processor half: `'Client note [VIP]\n\n[CASH] Transaction: cash_77777'` — legacy resolved `vip` (no adapter → silent refund failure); codec resolves `cash` and the refund succeeds.
- transactionId half: `'… Transaction: tx_early …\n\n[CASH] Transaction: tx_late'` — legacy refunded `tx_early`; codec refunds `tx_late`, the id bound to the intact marker.
- both halves: `'[CASH] paid, Transaction: cash_9\n\n[STRIPE] Transaction: pi_1'` — legacy `{cash, cash_9}`; codec `{stripe, pi_1}` (contrived: no production writer emits split markers).

Every string legacy could fully extract still parses; only the resolution of these mixed/ambiguous shapes changes. All three cases are pinned by fixtures in `payment-ref.test.ts` (and the processor case end-to-end in `pipelines.test.ts`).

## Overlap with the kit PR board

- **#99 — `src/core/pipelines.ts`: one real conflict hunk.** Verified via `gh pr diff 99`. Its hunk `@@ -288,7 +291,9 @@` adds `?? payments.get(toInternalPaymentMethodId(processor))` to the legacy-regex block this PR rewrites in `cancelBookingWithRefund`. Whichever lands second resolves it as: `payments.get(paymentRef.processor) ?? payments.get(toInternalPaymentMethodId(paymentRef.processor))`. #99's other pipelines.ts hunks (imports, `completeBookingWithAltPayment` ~L93, `createSchedulingKit` ~L349) are region-disjoint.
- **#99 — `src/tests/unit/core/pipelines.test.ts`: region-disjoint.** #99 adds tests at old L171 and old L500; this PR edits the mock at old L68 and the `cancelBookingWithRefund` block (old L421–444, now expanded). Clean merge either order.
- **#96 — `src/adapters/homegrown.ts`: file overlap, disjoint regions.** #96 touches the header comment only; this PR adds `paymentMethod` surfacing in `rowToBooking`, `createBooking`, and `createBookingWithPaymentRef` (body of the adapter). Expect a clean merge in either order; if git is conservative, the resolution is trivial (keep both).
- **#97 — no file overlap, but a merge-order gate (see CI note below).**
- **#98 — no overlap.** `src/core/types.ts` (Booking.paymentMethod) is not on the board for any open PR.

## CI status / merge order

`package/validate` is currently red on this PR with exactly the 12 pre-existing, clock-dependent failures in `src/adapters/__tests__/availability-engine.test.ts` (`TEST_DATE` rollover; that file is byte-identical to merge-base `aa07055` here). The fix is owned by **#97** ("make availability-engine tests clock-deterministic"). Implication: **this PR cannot merge with green required checks until #97 lands** (or this branch rebases onto it, or the engine tests are quarantined). Suggested order: #97 → this PR ↔ #99 (either order, second-lander applies the one-hunk pipelines.ts resolution above).

## Validation (at c065523)

| Check | Result |
| --- | --- |
| `pnpm check` (svelte-kit sync + svelte-check) | 1931 files, 0 errors, 0 warnings |
| `pnpm lint` (eslint) | clean |
| `pnpm test:unit` (vitest) | 634 passed, 12 failed — all 12 in `src/adapters/__tests__/availability-engine.test.ts`, pre-existing and owned by #97 (see CI note). 21/22 test files green incl. `payment-ref.test.ts` and the expanded `pipelines.test.ts` |
| `pnpm build` (svelte-package) | clean |
| `pnpm exec publint` | "All good!" |
| `bazelisk build //:pkg` | success in 16.1s — local execution (darwin-sandbox + local), no RBE (`.bazelrc` has only `--disk_cache`, no remote/bes flags) |
