### PR TITLE
Release scheduling kit 0.9.0

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -151,7 +151,7 @@ npm_package(
     ],
     package = "@tummycrypt/scheduling-kit",
     tags = ["manual"],
-    version = "0.8.0",
+    version = "0.9.0",
     visibility = ["//visibility:public"],
 )
 

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -22,7 +22,7 @@ Subpackage targets (finer-grained caching):
 
 module(
     name = "tummycrypt_scheduling_kit",
-    version = "0.8.0",
+    version = "0.9.0",
     compatibility_level = 1,
 )
 

--- a/docs/generated/package-surface.md
+++ b/docs/generated/package-surface.md
@@ -11,7 +11,7 @@ Generated from `package.json` and the current `src/` tree.
 | Field | Value |
 | --- | --- |
 | Package | `@tummycrypt/scheduling-kit` |
-| Version | `0.8.0` |
+| Version | `0.9.0` |
 | Description | Backend-agnostic scheduling components with alternative payment support |
 | Node range | `>=20 <25` |
 | Repository | https://github.com/Jesssullivan/scheduling-kit.git |
@@ -22,6 +22,7 @@ Generated from `package.json` and the current `src/` tree.
 | --- | --- | --- | --- |
 | `.` | `./dist/index.d.ts` | `./dist/index.js` | `./dist/index.js` |
 | `./adapters` | `./dist/adapters/index.d.ts` | `./dist/adapters/index.js` |  |
+| `./capabilities` | `./dist/capabilities/index.d.ts` | `./dist/capabilities/index.js` |  |
 | `./components` | `./dist/components/index.d.ts` | `./dist/components/index.js` | `./dist/components/index.js` |
 | `./core` | `./dist/core/index.d.ts` | `./dist/core/index.js` |  |
 | `./lib` | `./dist/lib/index.d.ts` | `./dist/lib/index.js` |  |
@@ -37,15 +38,16 @@ Generated from `package.json` and the current `src/` tree.
 | Area | Files | Notes |
 | --- | --- | --- |
 | `src/adapters` | 8 | Scheduling provider integrations and availability helpers |
+| `src/capabilities` | 3 | Repo source area |
 | `src/components` | 13 | Svelte checkout and booking UI |
-| `src/core` | 5 | Effect-powered orchestration, error types, and utilities |
+| `src/core` | 6 | Effect-powered orchestration, error types, and utilities |
 | `src/lib` | 3 | Small reusable helpers and Acuity iframe listener |
 | `src/onboarding` | 11 | Settings-driven onboarding and credential helpers |
-| `src/payments` | 5 | Payment adapters and capability contracts |
+| `src/payments` | 6 | Payment adapters and capability contracts |
 | `src/reconciliation` | 4 | Alternative-payment matching and webhook helpers |
 | `src/stores` | 2 | Svelte runes-based state |
 | `src/testing` | 5 | Cassette recording, replay, and masking utilities |
-| `src/tests` | 37 | Vitest helpers, mocks, fixtures, and unit coverage |
+| `src/tests` | 42 | Vitest helpers, mocks, fixtures, and unit coverage |
 
 ## Script Entry Points
 

--- a/docs/generated/release-metadata.md
+++ b/docs/generated/release-metadata.md
@@ -11,9 +11,9 @@ Generated from `package.json`, `MODULE.bazel`, `BUILD.bazel`,
 
 | Surface | Value |
 | --- | --- |
-| package.json version | `0.8.0` |
-| MODULE.bazel version | `0.8.0` |
-| BUILD.bazel npm_package version | `0.8.0` |
+| package.json version | `0.9.0` |
+| MODULE.bazel version | `0.9.0` |
+| BUILD.bazel npm_package version | `0.9.0` |
 | BUILD.bazel package name | `@tummycrypt/scheduling-kit` |
 | .bazelversion | `8.1.1` |
 | pnpm packageManager | `pnpm@9.15.9` |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tummycrypt/scheduling-kit",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "Backend-agnostic scheduling components with alternative payment support",
   "type": "module",
   "packageManager": "pnpm@9.15.9",


### PR DESCRIPTION
## scheduling-kit 0.9.0

First release after the merged train #96 #97 #98 #99 #101 #102.

### Breaking / migration required

- **Public payment ids normalized `stripe` -> `card`** (#99). Public payment
  surfaces (payment method options, selector ids, booking payloads) now emit
  the canonical `card` id; internal adapter naming is unchanged. Consumers
  asserting or matching on `stripe` in public surfaces must switch to `card`.
- **Structured `PaymentReference` codec with typed parse failures** (#101,
  breaking). Payment references are now a structured codec; malformed input
  yields typed parse failures instead of silent passthrough. The legacy string
  format is still accepted on parse, so stored references keep working.
- **Confirmation-code prefix default changed `MI` -> `BK`** (#102). Adopters
  that want to keep `MI` confirmation codes must set
  `confirmationCodePrefix: 'MI'` explicitly.
- **Branded component defaults removed** (#102). `BookingConfirmation` and
  `AcuityEmbedHandoff` no longer ship business-specific default copy/props;
  pass business props explicitly.
- **`defaultPractitionerHandle` `'jen'` fallback removed** (#102). A missing
  practitioner handle now fails with a typed `ValidationError` instead of
  silently falling back.

### MassageIthaca migration checklist

- set `confirmationCodePrefix: 'MI'`
- pass business props explicitly to `BookingConfirmation` / `AcuityEmbedHandoff`
- expect `card` (not `stripe`) in public payment surfaces

### Added

- **New `./capabilities` subpath** — `extractCapabilities` is now
  kit-canonical (#98). Bridge delegation to the kit implementation is pending
  bridge#82.
- **`idempotencyKey` now deduplicates `createBooking`** (#102). Replayed
  create requests with the same key return the original booking instead of
  double-booking.

### Changed / fixed

- Homegrown adapter maps failures to typed errors instead of
  `InfrastructureError('UNKNOWN')` (#102).
- Availability-engine tests are clock-deterministic (#97); unit suite is fully
  green.
- Docs and toolchain truth normalization (#96): Node 22 LTS devShell, doc
  surfaces generated from package truth (`pnpm docs:generate`).
