### PR TITLE
fix(bazel): make //:pkg consumable as an external Bzlmod module

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -134,6 +134,21 @@ js_library(
     name = "scheduling_kit",
     srcs = [":scheduling_kit_build"],
     tags = ["manual"],
+    # Runtime dependencies (package.json "dependencies") that consumers do not
+    # provide themselves. Declaring them here carries their npm package store
+    # infos through //:pkg so Bazel consumers that link this module via
+    # npm_link_package (e.g. scheduling-bridge) get the dep store entries
+    # linked next to the package.
+    #
+    # `effect` is intentionally NOT linked: consumers declare their own copy
+    # and effect values cross the package boundary (e.g. re-exported Errors),
+    # so a second linked copy would fork runtime identity (instanceof) and
+    # break consumer declaration emit (TS2742) with duplicate type roots.
+    # Peer dependencies are likewise excluded; consumers provide them.
+    deps = [
+        ":node_modules/drizzle-orm",
+        ":node_modules/zod",
+    ],
     visibility = ["//visibility:public"],
 )
 

--- a/scripts/svelte-package-bazel-wrapper.mjs
+++ b/scripts/svelte-package-bazel-wrapper.mjs
@@ -122,7 +122,7 @@ function prepareWritableProject(inputDir) {
   return { tempRoot, workDir };
 }
 
-const forwardedArgs = [];
+const parsedArgs = [];
 let resolvedInput;
 let outputDir = "dist";
 for (let index = 0; index < process.argv.length - 2; index += 1) {
@@ -130,36 +130,59 @@ for (let index = 0; index < process.argv.length - 2; index += 1) {
 
   if (arg === "-i" || arg === "--input") {
     resolvedInput = resolveExistingPath(process.argv[index + 3]);
-    forwardedArgs.push(arg, "src");
+    parsedArgs.push({ kind: "input", flag: arg });
     index += 1;
     continue;
   }
 
   if (arg.startsWith("--input=")) {
     resolvedInput = resolveExistingPath(arg.slice("--input=".length));
-    forwardedArgs.push("--input=src");
+    parsedArgs.push({ kind: "input", flag: "--input=" });
     continue;
   }
 
   if (arg === "-o" || arg === "--output") {
     outputDir = process.argv[index + 3];
-    forwardedArgs.push(arg, path.resolve(originalCwd, outputDir));
+    parsedArgs.push({ kind: "output", flag: arg });
     index += 1;
     continue;
   }
 
   if (arg.startsWith("--output=")) {
     outputDir = arg.slice("--output=".length);
-    forwardedArgs.push(`--output=${path.resolve(originalCwd, outputDir)}`);
+    parsedArgs.push({ kind: "output", flag: "--output=" });
     continue;
   }
 
-  forwardedArgs.push(arg);
+  parsedArgs.push({ kind: "raw", value: arg });
 }
 
 if (!resolvedInput) {
   throw new Error("Missing required svelte-package input directory");
 }
+
+// Anchor the output directory next to the resolved input tree artifact, which
+// lives in the declared output package directory of this module. Resolving
+// against the action cwd (BAZEL_BINDIR) breaks when this module is built as a
+// Bazel external module (bazel_dep consumer): declared outputs live under
+// bazel-out/.../bin/external/<repo>/, while cwd stays at the bindir root, so
+// svelte-package would write outside the declared output tree and Bazel would
+// silently package an empty dist/.
+const resolvedOutput = path.isAbsolute(outputDir)
+  ? outputDir
+  : path.resolve(path.dirname(resolvedInput), outputDir);
+
+const forwardedArgs = parsedArgs.flatMap((entry) => {
+  if (entry.kind === "input") {
+    return entry.flag === "--input=" ? ["--input=src"] : [entry.flag, "src"];
+  }
+  if (entry.kind === "output") {
+    return entry.flag === "--output="
+      ? [`--output=${resolvedOutput}`]
+      : [entry.flag, resolvedOutput];
+  }
+  return [entry.value];
+});
 
 const { tempRoot, workDir } = prepareWritableProject(resolvedInput);
 const result = spawnSync(


### PR DESCRIPTION
## Summary

scheduling-bridge is adopting pure-Bazel consumption of the kit (`bazel_dep` + `npm_link_package` of `@tummycrypt_scheduling_kit//:pkg`, refs Jesssullivan/scheduling-bridge#82). As the first non-leaf module consumed through the tinyland-inc/bazel-registry module graph, two latent defects surfaced:

1. **Empty `dist/` in external-module builds.** `scripts/svelte-package-bazel-wrapper.mjs` resolved `-o dist` against the action cwd (`BAZEL_BINDIR` root). When this module is built as an external module, declared outputs live under `bazel-out/.../bin/external/tummycrypt_scheduling_kit+/`, so svelte-package wrote outside the declared tree and Bazel silently packaged an empty `dist/` (declared tree artifacts are tolerated empty). The wrapper now anchors the output next to the resolved input tree artifact, which is correct in both the own-workspace and external-module contexts.

2. **No npm store entries for runtime deps.** `//:scheduling_kit` declared no npm deps, so consumers linking `//:pkg` had no package-store siblings for the kit's runtime dependencies and failed at import time (`ERR_MODULE_NOT_FOUND: zod`). `drizzle-orm` and `zod` are now declared on the packaged `js_library`. `effect` is deliberately NOT linked: consumers declare their own copy and effect values cross the package boundary (re-exported `Errors`), so a second linked copy forks runtime identity (instanceof) and breaks consumer declaration emit (TS2742).

## Validation

- This workspace: `bazel build //:pkg //:typecheck` and `bazel test //:test` green (local, disk cache, no RBE); `bazel-bin/pkg/dist` populated as before.
- Consumer proof: scheduling-bridge `//:pkg`, `//:typecheck`, `//:test` (158 vitest tests) green consuming this tree via `--override_module=tummycrypt_scheduling_kit=<this checkout>`.

Release plan: 0.9.1 patch release follows, then registration in tinyland-inc/bazel-registry, then the bridge bumps its `bazel_dep` to 0.9.1.

Refs Jesssullivan/scheduling-bridge#82