### PR TITLE
release: bump scheduling-kit to 0.9.1

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -166,7 +166,7 @@ npm_package(
     ],
     package = "@tummycrypt/scheduling-kit",
     tags = ["manual"],
-    version = "0.9.0",
+    version = "0.9.1",
     visibility = ["//visibility:public"],
 )
 

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -22,7 +22,7 @@ Subpackage targets (finer-grained caching):
 
 module(
     name = "tummycrypt_scheduling_kit",
-    version = "0.9.0",
+    version = "0.9.1",
     compatibility_level = 1,
 )
 

--- a/docs/generated/package-surface.md
+++ b/docs/generated/package-surface.md
@@ -11,7 +11,7 @@ Generated from `package.json` and the current `src/` tree.
 | Field | Value |
 | --- | --- |
 | Package | `@tummycrypt/scheduling-kit` |
-| Version | `0.9.0` |
+| Version | `0.9.1` |
 | Description | Backend-agnostic scheduling components with alternative payment support |
 | Node range | `>=20 <25` |
 | Repository | https://github.com/Jesssullivan/scheduling-kit.git |

--- a/docs/generated/release-metadata.md
+++ b/docs/generated/release-metadata.md
@@ -11,9 +11,9 @@ Generated from `package.json`, `MODULE.bazel`, `BUILD.bazel`,
 
 | Surface | Value |
 | --- | --- |
-| package.json version | `0.9.0` |
-| MODULE.bazel version | `0.9.0` |
-| BUILD.bazel npm_package version | `0.9.0` |
+| package.json version | `0.9.1` |
+| MODULE.bazel version | `0.9.1` |
+| BUILD.bazel npm_package version | `0.9.1` |
 | BUILD.bazel package name | `@tummycrypt/scheduling-kit` |
 | .bazelversion | `8.1.1` |
 | pnpm packageManager | `pnpm@9.15.9` |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tummycrypt/scheduling-kit",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "Backend-agnostic scheduling components with alternative payment support",
   "type": "module",
   "packageManager": "pnpm@9.15.9",


### PR DESCRIPTION
Patch release: 0.9.0 -> 0.9.1.

Carries #106 (external-Bzlmod-module packaging fix: svelte-package output anchored to the declared output tree; drizzle-orm/zod store deps declared on the packaged js_library) so scheduling-bridge can consume `@tummycrypt_scheduling_kit//:pkg` from the tinyland-inc/bazel-registry module graph.

- package.json, MODULE.bazel, BUILD.bazel aligned at 0.9.1
- docs/generated surfaces regenerated
- `pnpm check:release-metadata` green locally

After merge: tag `v0.9.1`, publish workflow ships the derived GitHub Packages artifact, then 0.9.1 is registered in tinyland-inc/bazel-registry and scheduling-bridge bumps its `bazel_dep`.

Refs Jesssullivan/scheduling-bridge#82