### PR TITLE
docs: align kit release truth with 0.9.1

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,7 +56,7 @@ Closed but still relevant context:
 - `TIN-103` closed the release-authority ambiguity for `Jesssullivan/scheduling-kit`
 - `TIN-104` was canceled as a duplicate during that convergence work
 - `TIN-165` is done: the tinyland bazel-registry is generated from standalone
-  package truth and currently carries scheduling-kit `0.9.0+` and
+  package truth and currently carries scheduling-kit `0.9.1+` and
   scheduling-bridge `0.5.11+`; the registry line is in `.bazelrc`
 - `TIN-677` is done: HomegrownAdapter takes injected schemas from
   `@tummycrypt/tinyland-business-pg`, with `tinyland-auth-pg` kept only as an
@@ -66,9 +66,9 @@ Current operational truth:
 
 - local development should default to `jesssullivan/main`
 - that branch is the current functional release line
-- current released version is `0.9.0`: git tag plus GitHub Release, GitHub
+- current released version is `0.9.1`: git tag plus GitHub Release, GitHub
   Packages `@jesssullivan/scheduling-kit`, and the active tinyland Bazel
-  registry (`0.9.0+`)
+  registry (`0.9.1+`)
 - npmjs `@tummycrypt/scheduling-kit` is retired for new versions and frozen at
   `0.8.0`; `npm_publish_mode: disabled` is permanent policy, not a temporary
   outage

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ The Bazel module graph is the canonical delivery mechanism. Depend on the
 module through the tinyland Bazel registry:
 
 ```starlark
-bazel_dep(name = "tummycrypt_scheduling_kit", version = "0.9.0")
+bazel_dep(name = "tummycrypt_scheduling_kit", version = "0.9.1")
 ```
 
 with the registry line (already in this repo's `.bazelrc`):
@@ -105,7 +105,7 @@ Current reality:
 - the functional release line is `Jesssullivan/scheduling-kit`
 - `tinyland-inc/scheduling-kit` is now a downstream mirror and validation
   surface, not a second publish authority
-- the active tinyland Bazel registry carries `scheduling-kit` `0.9.0+` (and
+- the active tinyland Bazel registry carries `scheduling-kit` `0.9.1+` (and
   `scheduling-bridge` `0.5.11+`); the registry line is already in `.bazelrc`
 
 Treat `Jesssullivan/main` as the release authority for package publication and


### PR DESCRIPTION
## Summary
- update AGENTS.md and README release-truth references from scheduling-kit 0.9.0 to 0.9.1
- keep npmjs frozen-at-0.8.0 doctrine unchanged

## Validation
- rg stale-version scan over AGENTS.md / README.md / release metadata / package metadata
- git diff --check