### PR TITLE
feat(fuzzy): graduate matcher scorers to kit (TIN-2098)

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,10 @@
       "types": "./dist/capabilities/index.d.ts",
       "default": "./dist/capabilities/index.js"
     },
+    "./fuzzy": {
+      "types": "./dist/fuzzy/index.d.ts",
+      "default": "./dist/fuzzy/index.js"
+    },
     "./recurrence": {
       "types": "./dist/adapters/recurrence.d.ts",
       "default": "./dist/adapters/recurrence.js"

--- a/src/fuzzy/__tests__/date-matcher.test.ts
+++ b/src/fuzzy/__tests__/date-matcher.test.ts
@@ -1,0 +1,287 @@
+/**
+ * DateMatcher tests (design §6 fuzzy-in for dates/slots; §11 property tests).
+ *
+ * Unit coverage for the TZ-suffix normalization + slot-membership cascade and the
+ * tolerant month/day targeting, plus fast-check property suites for the §11 invariants:
+ * confidence bounds [0,1], threshold monotonicity, and strategy-cascade ordering.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { Effect, Exit } from 'effect';
+import fc from 'fast-check';
+import {
+	DEFAULT_DATE_MIN_CONFIDENCE,
+	DateMatcher,
+	DateMatcherLive,
+	makeDateMatcher,
+	matchSlotMembership,
+	parseMonthLabel,
+	parseYearMonthKey,
+	scoreMonthTarget,
+	scoreSlot,
+	stripTzSuffix,
+	type SlotCandidate,
+} from '../date-matcher.js';
+import { FuzzyMatchError } from '../fuzzy.js';
+
+const slots: readonly SlotCandidate[] = [
+	{ datetime: '2026-03-07T14:00:00', available: true },
+	{ datetime: '2026-03-07T15:30:00', available: true },
+	{ datetime: '2026-03-08T09:00:00', available: false },
+];
+
+describe('stripTzSuffix', () => {
+	it('strips a trailing Z', () => {
+		expect(stripTzSuffix('2026-03-07T14:00:00Z')).toBe('2026-03-07T14:00:00');
+	});
+	it('strips a trailing +/- offset', () => {
+		expect(stripTzSuffix('2026-03-07T14:00:00-05:00')).toBe('2026-03-07T14:00:00');
+		expect(stripTzSuffix('2026-03-07T14:00:00+02:00')).toBe('2026-03-07T14:00:00');
+	});
+	it('leaves a local (suffix-free) datetime untouched', () => {
+		expect(stripTzSuffix('2026-03-07T14:00:00')).toBe('2026-03-07T14:00:00');
+	});
+});
+
+describe('parseMonthLabel', () => {
+	it('parses "March 2026" / "March\\n2026" / nested-span "March2026"', () => {
+		expect(parseMonthLabel('March 2026')).toEqual({ month: 2, year: 2026 });
+		expect(parseMonthLabel('March\n2026')).toEqual({ month: 2, year: 2026 });
+		expect(parseMonthLabel('March2026')).toEqual({ month: 2, year: 2026 });
+	});
+	it('returns null for unparseable labels', () => {
+		expect(parseMonthLabel('not a month')).toBeNull();
+		expect(parseMonthLabel('')).toBeNull();
+	});
+});
+
+describe('parseYearMonthKey', () => {
+	it('parses an exact YYYY-MM into a 0-based month', () => {
+		expect(parseYearMonthKey('2026-03')).toEqual({ month: 2, year: 2026 });
+	});
+	it('rejects out-of-range months and non-exact keys (YYYY-MM-DD fails the guard)', () => {
+		expect(parseYearMonthKey('2026-13')).toBeNull();
+		expect(parseYearMonthKey('2026-00')).toBeNull();
+		expect(parseYearMonthKey('2026-03-15')).toBeNull();
+		expect(parseYearMonthKey('garbage')).toBeNull();
+	});
+});
+
+describe('scoreSlot cascade', () => {
+	it('id-match (1.0) on a byte-equal datetime', () => {
+		expect(scoreSlot({ datetime: '2026-03-07T14:00:00' }, slots[0])).toEqual({
+			strategy: 'id-match',
+			confidence: 1,
+		});
+	});
+	it('normalized-exact (1.0) when only the TZ suffix differs', () => {
+		expect(scoreSlot({ datetime: '2026-03-07T14:00:00Z' }, slots[0])).toEqual({
+			strategy: 'normalized-exact',
+			confidence: 1,
+		});
+	});
+	it('token-overlap (0.9) on same date + same hour, minutes differ', () => {
+		expect(scoreSlot({ datetime: '2026-03-07T14:45:00' }, slots[0])).toEqual({
+			strategy: 'token-overlap',
+			confidence: 0.9,
+		});
+	});
+	it('fuzzy (0.5) on same date, hour differs', () => {
+		expect(scoreSlot({ datetime: '2026-03-07T18:00:00' }, slots[0])).toEqual({
+			strategy: 'fuzzy',
+			confidence: 0.5,
+		});
+	});
+	it('floors unavailable slots at 0 regardless of string match', () => {
+		expect(scoreSlot({ datetime: '2026-03-08T09:00:00' }, slots[2]).confidence).toBe(0);
+	});
+});
+
+describe('makeDateMatcher membership (behavior-preserving with the wizard inline test)', () => {
+	it('admits the TZ-normalized exact at the default threshold (1.0)', async () => {
+		const matcher = makeDateMatcher();
+		const resolution = await Effect.runPromise(
+			matcher.match({ datetime: '2026-03-07T14:00:00Z' }, slots),
+		);
+		expect(resolution.strategy).toBe('normalized-exact');
+		expect(resolution.confidence).toBe(1);
+		expect(resolution.value.datetime).toBe('2026-03-07T14:00:00');
+		expect(resolution.matchedLabel).toBe('2026-03-07T14:00:00');
+	});
+
+	it('matchSlotMembership returns true with a resolution for an exact slot, false otherwise', async () => {
+		const matcher = makeDateMatcher();
+		const hit = await Effect.runPromise(
+			matchSlotMembership(matcher, '2026-03-07T15:30:00', slots),
+		);
+		expect(hit.member).toBe(true);
+		expect(hit.resolution?.value.datetime).toBe('2026-03-07T15:30:00');
+
+		const miss = await Effect.runPromise(
+			matchSlotMembership(matcher, '2026-09-09T10:00:00', slots),
+		);
+		expect(miss.member).toBe(false);
+		expect(miss.resolution).toBeUndefined();
+	});
+
+	it('never admits an unavailable slot even on an exact string (inline AND on available)', async () => {
+		const matcher = makeDateMatcher();
+		const result = await Effect.runPromise(
+			matchSlotMembership(matcher, '2026-03-08T09:00:00', slots),
+		);
+		expect(result.member).toBe(false);
+	});
+
+	it('a loosened threshold admits same-date jitter the strict membership rejects', async () => {
+		const strict = makeDateMatcher(); // 1.0
+		const loose = makeDateMatcher(0.5);
+		const jitter = '2026-03-07T14:45:00';
+		expect(
+			(await Effect.runPromise(matchSlotMembership(strict, jitter, slots))).member,
+		).toBe(false);
+		expect(
+			(await Effect.runPromise(matchSlotMembership(loose, jitter, slots))).member,
+		).toBe(true);
+	});
+
+	it('fails with FuzzyMatchError carrying the threshold when nothing clears it', async () => {
+		const matcher = makeDateMatcher();
+		const exit = await Effect.runPromiseExit(
+			matcher.match({ datetime: '2026-12-31T23:59:00' }, slots),
+		);
+		expect(Exit.isFailure(exit)).toBe(true);
+		if (Exit.isFailure(exit) && exit.cause._tag === 'Fail') {
+			expect(exit.cause.error).toBeInstanceOf(FuzzyMatchError);
+			expect(exit.cause.error.threshold).toBe(DEFAULT_DATE_MIN_CONFIDENCE);
+		}
+	});
+
+	it('is providable through DateMatcherLive behind the scheduling-kit tag', async () => {
+		const resolution = await Effect.runPromise(
+			Effect.gen(function* () {
+				const matcher = yield* DateMatcher;
+				return yield* matcher.match({ datetime: '2026-03-07T14:00:00' }, slots);
+			}).pipe(Effect.provide(DateMatcherLive)),
+		);
+		expect(resolution.strategy).toBe('id-match');
+		expect(DateMatcher.key).toBe('scheduling-kit/DateMatcher');
+	});
+});
+
+// =============================================================================
+// PROPERTY TESTS (design §11: bounds, threshold monotonicity, cascade ordering)
+// =============================================================================
+
+/** Arbitrary ISO-ish local datetime in 2026, optionally TZ-suffixed. */
+const isoDatetimeArb = fc
+	.record({
+		month: fc.integer({ min: 1, max: 12 }),
+		day: fc.integer({ min: 1, max: 28 }),
+		hour: fc.integer({ min: 0, max: 23 }),
+		minute: fc.constantFrom(0, 15, 30, 45),
+		suffix: fc.constantFrom('', 'Z', '-05:00', '+02:00'),
+	})
+	.map(({ month, day, hour, minute, suffix }) => {
+		const p = (n: number) => String(n).padStart(2, '0');
+		return `2026-${p(month)}-${p(day)}T${p(hour)}:${p(minute)}:00${suffix}`;
+	});
+
+const slotArb = fc.record({
+	datetime: isoDatetimeArb,
+	available: fc.boolean(),
+});
+
+const slotsArb = fc.array(slotArb, { minLength: 0, maxLength: 8 });
+
+describe('DateMatcher property tests (§11)', () => {
+	it('scoreSlot confidence is always within [0,1]', () => {
+		fc.assert(
+			fc.property(isoDatetimeArb, slotArb, (datetime, candidate) => {
+				const { confidence } = scoreSlot({ datetime }, candidate);
+				return confidence >= 0 && confidence <= 1;
+			}),
+		);
+	});
+
+	it('an admitted resolution confidence is within [threshold, 1] and alternates are sorted desc', () => {
+		fc.assert(
+			fc.property(
+				isoDatetimeArb,
+				slotsArb,
+				fc.constantFrom(0, 0.25, 0.5, 0.9, 1),
+				(datetime, candidates, threshold) => {
+					const matcher = makeDateMatcher(threshold);
+					const exit = Effect.runSyncExit(matcher.match({ datetime }, candidates));
+					if (Exit.isFailure(exit)) return true; // nothing cleared the threshold
+					const r = exit.value;
+					if (r.confidence < threshold || r.confidence > 1) return false;
+					const confs = r.alternates.map((a) => a.confidence);
+					for (let i = 1; i < confs.length; i++) {
+						if (confs[i] > confs[i - 1]) return false;
+					}
+					return true;
+				},
+			),
+		);
+	});
+
+	it('threshold monotonicity: a higher threshold never admits where a lower one rejected', () => {
+		fc.assert(
+			fc.property(
+				isoDatetimeArb,
+				slotsArb,
+				fc.tuple(
+					fc.constantFrom(0, 0.25, 0.5),
+					fc.constantFrom(0.5, 0.9, 1),
+				),
+				(datetime, candidates, [lo, hi]) => {
+					const low = lo <= hi ? lo : hi;
+					const high = lo <= hi ? hi : lo;
+					const lowAdmits = Exit.isSuccess(
+						Effect.runSyncExit(makeDateMatcher(low).match({ datetime }, candidates)),
+					);
+					const highAdmits = Exit.isSuccess(
+						Effect.runSyncExit(makeDateMatcher(high).match({ datetime }, candidates)),
+					);
+					// high admits ⇒ low admits (monotone non-increasing rejection).
+					return !highAdmits || lowAdmits;
+				},
+			),
+		);
+	});
+
+	it('cascade ordering: id-match ≥ normalized-exact ≥ token-overlap ≥ fuzzy by confidence', () => {
+		const rank = { 'id-match': 3, 'normalized-exact': 2, 'token-overlap': 1, fuzzy: 0 } as const;
+		fc.assert(
+			fc.property(isoDatetimeArb, slotArb, (datetime, candidate) => {
+				const { strategy, confidence } = scoreSlot({ datetime }, candidate);
+				// Higher-ranked strategies carry ≥ confidence than lower-ranked floors.
+				const floors: Record<keyof typeof rank, number> = {
+					'id-match': 1,
+					'normalized-exact': 1,
+					'token-overlap': 0.9,
+					fuzzy: 0,
+				};
+				void rank;
+				return confidence >= floors[strategy] - 1e-9 || confidence === 0;
+			}),
+		);
+	});
+
+	it('scoreMonthTarget is within [0,1] and peaks at exact month', () => {
+		fc.assert(
+			fc.property(
+				fc.record({ month: fc.integer({ min: 0, max: 11 }), year: fc.integer({ min: 2020, max: 2030 }) }),
+				fc.record({ month: fc.integer({ min: 0, max: 11 }), year: fc.integer({ min: 2020, max: 2030 }) }),
+				(current, target) => {
+					const score = scoreMonthTarget(current, target);
+					if (score < 0 || score > 1) return false;
+					if (current.month === target.month && current.year === target.year) {
+						return score === 1;
+					}
+					return score < 1;
+				},
+			),
+		);
+	});
+});

--- a/src/fuzzy/__tests__/field-matcher.test.ts
+++ b/src/fuzzy/__tests__/field-matcher.test.ts
@@ -1,0 +1,220 @@
+/**
+ * FieldMatcher tests (design §6 fuzzy-in for intake fields; §11 property tests).
+ *
+ * Unit coverage proving result-equivalence with the legacy `fillRequiredTextareas`
+ * keyword ladder, plus fast-check property suites for the §11 invariants: confidence
+ * bounds [0,1], threshold monotonicity, and strategy-cascade ordering.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { Effect, Exit } from 'effect';
+import fc from 'fast-check';
+import {
+	DEFAULT_DEFERRED_VALUE,
+	DEFAULT_FIELD_RULES,
+	FieldMatcher,
+	FieldMatcherLive,
+	makeFieldMatcher,
+	resolveFieldAnswer,
+	scoreFieldRule,
+	type FieldRule,
+} from '../field-matcher.js';
+import { FuzzyMatchError } from '../fuzzy.js';
+
+describe('scoreFieldRule', () => {
+	const workOn = DEFAULT_FIELD_RULES[0];
+	const sleep = DEFAULT_FIELD_RULES[1];
+	const fallback = DEFAULT_FIELD_RULES[2];
+
+	it('substring keyword hit scores normalized-exact (0.95)', () => {
+		expect(scoreFieldRule('What would you like to work on?', workOn)).toEqual({
+			strategy: 'normalized-exact',
+			confidence: 0.95,
+		});
+		expect(scoreFieldRule('Describe your session goals', workOn).strategy).toBe(
+			'normalized-exact',
+		);
+		expect(scoreFieldRule('Hours of restful sleep?', sleep).strategy).toBe('normalized-exact');
+	});
+
+	it('the fallback rule always returns a low fuzzy floor', () => {
+		expect(scoreFieldRule('anything at all', fallback)).toEqual({
+			strategy: 'fuzzy',
+			confidence: 0.1,
+		});
+	});
+
+	it('a non-matching label against a keyword rule scores 0', () => {
+		expect(scoreFieldRule('totally unrelated', sleep).confidence).toBe(0);
+	});
+});
+
+describe('resolveFieldAnswer (result-equivalent to the legacy keyword ladder)', () => {
+	const matcher = makeFieldMatcher();
+
+	it('"work on"/"session" labels resolve to client notes, else "General wellness"', async () => {
+		const withNotes = await Effect.runPromise(
+			resolveFieldAnswer(matcher, 'What would you like to work on?', 'lower back'),
+		);
+		expect(withNotes.value).toBe('lower back');
+		expect(withNotes.resolution?.value.id).toBe('work-on');
+
+		const noNotes = await Effect.runPromise(
+			resolveFieldAnswer(matcher, 'Goals for this session', undefined),
+		);
+		expect(noNotes.value).toBe(DEFAULT_DEFERRED_VALUE);
+		expect(noNotes.value).toBe('General wellness');
+	});
+
+	it('"sleep" labels resolve to "7-8 hours"', async () => {
+		const r = await Effect.runPromise(
+			resolveFieldAnswer(matcher, 'How many hours of restful sleep?', 'ignored notes'),
+		);
+		expect(r.value).toBe('7-8 hours');
+		expect(r.resolution?.value.id).toBe('sleep');
+	});
+
+	it('unrecognized labels fall to the "N/A" fallback (matcher stays total)', async () => {
+		const r = await Effect.runPromise(
+			resolveFieldAnswer(matcher, 'Any allergies?', 'lower back'),
+		);
+		expect(r.value).toBe('N/A');
+		expect(r.resolution?.value.id).toBe('fallback');
+		expect(r.resolution?.strategy).toBe('fuzzy');
+	});
+
+	it('keyword hits beat the fallback floor', async () => {
+		const r = await Effect.runPromise(resolveFieldAnswer(matcher, 'sleep', 'x'));
+		expect(r.resolution?.value.id).toBe('sleep');
+		expect(r.resolution?.alternates.some((a) => a.label === 'N/A')).toBe(true);
+	});
+
+	it('a floorless ruleset degrades to the inline default without throwing', async () => {
+		const floorless = makeFieldMatcher(
+			[DEFAULT_FIELD_RULES[0], DEFAULT_FIELD_RULES[1]],
+			0,
+		);
+		const r = await Effect.runPromise(resolveFieldAnswer(floorless, 'unknown label', undefined));
+		expect(r.value).toBe('N/A');
+		expect(r.resolution).toBeUndefined();
+	});
+});
+
+describe('makeFieldMatcher / FieldMatcherLive', () => {
+	it('fails with FuzzyMatchError when even the floor cannot clear a positive threshold', async () => {
+		const matcher = makeFieldMatcher([DEFAULT_FIELD_RULES[2]], 0.5); // fallback only, threshold 0.5
+		const exit = await Effect.runPromiseExit(matcher.match({ label: 'whatever' }, []));
+		expect(Exit.isFailure(exit)).toBe(true);
+		if (Exit.isFailure(exit) && exit.cause._tag === 'Fail') {
+			expect(exit.cause.error).toBeInstanceOf(FuzzyMatchError);
+			expect(exit.cause.error.threshold).toBe(0.5);
+		}
+	});
+
+	it('is providable through FieldMatcherLive behind the scheduling-kit tag', async () => {
+		const resolution = await Effect.runPromise(
+			Effect.gen(function* () {
+				const matcher = yield* FieldMatcher;
+				return yield* matcher.match({ label: 'work on' }, []);
+			}).pipe(Effect.provide(FieldMatcherLive)),
+		);
+		expect(resolution.value.id).toBe('work-on');
+		expect(FieldMatcher.key).toBe('scheduling-kit/FieldMatcher');
+	});
+});
+
+// =============================================================================
+// PROPERTY TESTS (design §11: bounds, threshold monotonicity, cascade ordering)
+// =============================================================================
+
+const ruleArb: fc.Arbitrary<FieldRule> = fc.record({
+	id: fc.string({ minLength: 1, maxLength: 8 }),
+	label: fc.string({ minLength: 1, maxLength: 16 }),
+	keywords: fc.array(fc.constantFrom('work on', 'session', 'sleep', 'allergy', ''), {
+		maxLength: 3,
+	}),
+	value: fc.option(fc.string({ maxLength: 12 }), { nil: null }),
+	minConfidence: fc.constantFrom(0, 0.25, 0.5, 0.95),
+	fallback: fc.constant(false),
+});
+
+const labelArb = fc.oneof(
+	fc.constantFrom(
+		'What would you like to work on?',
+		'How many hours of restful sleep?',
+		'Goals for this session',
+		'Any allergies?',
+		'',
+	),
+	fc.string({ maxLength: 24 }),
+);
+
+describe('FieldMatcher property tests (§11)', () => {
+	it('scoreFieldRule confidence is always within [0,1]', () => {
+		fc.assert(
+			fc.property(labelArb, ruleArb, (label, rule) => {
+				const { confidence } = scoreFieldRule(label, rule);
+				return confidence >= 0 && confidence <= 1;
+			}),
+		);
+	});
+
+	it('the default matcher is total (always admits) and resolution confidence is within [0,1]', () => {
+		fc.assert(
+			fc.property(labelArb, (label) => {
+				const matcher = makeFieldMatcher();
+				const exit = Effect.runSyncExit(matcher.match({ label }, []));
+				if (Exit.isFailure(exit)) return false; // fallback keeps it total
+				const r = exit.value;
+				if (r.confidence < 0 || r.confidence > 1) return false;
+				const confs = r.alternates.map((a) => a.confidence);
+				for (let i = 1; i < confs.length; i++) {
+					if (confs[i] > confs[i - 1]) return false; // sorted desc
+				}
+				return true;
+			}),
+		);
+	});
+
+	it('threshold monotonicity: a higher matcher threshold never admits where a lower one rejected', () => {
+		const rules = [DEFAULT_FIELD_RULES[0], DEFAULT_FIELD_RULES[1]]; // no fallback ⇒ can reject
+		fc.assert(
+			fc.property(
+				labelArb,
+				fc.tuple(fc.constantFrom(0, 0.25, 0.5), fc.constantFrom(0.5, 0.95, 1)),
+				(label, [lo, hi]) => {
+					const low = Math.min(lo, hi);
+					const high = Math.max(lo, hi);
+					const lowAdmits = Exit.isSuccess(
+						Effect.runSyncExit(makeFieldMatcher(rules, low).match({ label }, [])),
+					);
+					const highAdmits = Exit.isSuccess(
+						Effect.runSyncExit(makeFieldMatcher(rules, high).match({ label }, [])),
+					);
+					return !highAdmits || lowAdmits;
+				},
+			),
+		);
+	});
+
+	it('cascade ordering: a substring keyword hit (normalized-exact 0.95) outranks any token/fuzzy result', () => {
+		fc.assert(
+			fc.property(
+				fc.constantFrom('work on', 'sleep', 'session'),
+				(keyword) => {
+					const rule: FieldRule = {
+						id: 'k',
+						label: 'k',
+						keywords: [keyword],
+						value: 'v',
+						minConfidence: 0,
+					};
+					// A label containing the keyword substring must score normalized-exact 0.95,
+					// strictly above any token-overlap (≤0.9) or fuzzy (≤0.1) result.
+					const hit = scoreFieldRule(`prefix ${keyword} suffix`, rule);
+					return hit.strategy === 'normalized-exact' && hit.confidence === 0.95;
+				},
+			),
+		);
+	});
+});

--- a/src/fuzzy/__tests__/fuzzy.test.ts
+++ b/src/fuzzy/__tests__/fuzzy.test.ts
@@ -1,0 +1,181 @@
+import { describe, expect, it } from 'vitest';
+import { Effect, Exit } from 'effect';
+import fc from 'fast-check';
+import {
+	FuzzyMatchError,
+	ServiceMatcher,
+	ServiceMatcherLive,
+	makeServiceMatcher,
+	scoreLabel,
+} from '../fuzzy.js';
+
+const candidates = [
+	{ label: 'Deep Tissue Massage', ref: '53178494' },
+	{ label: 'Swedish Massage', ref: '11111111' },
+	{ label: 'Acupuncture Consult', ref: '22222222' },
+];
+
+describe('scoreLabel cascade', () => {
+	it('admits normalized-exact at 0.95 ahead of token overlap', () => {
+		const score = scoreLabel('deep tissue massage!!', 'Deep Tissue Massage');
+		expect(score).toEqual({ strategy: 'normalized-exact', confidence: 0.95 });
+	});
+
+	it('scales token overlap onto 0.5-0.9', () => {
+		const score = scoreLabel('Deep Tissue', 'Deep Tissue Massage');
+		expect(score.strategy).toBe('token-overlap');
+		expect(score.confidence).toBeGreaterThanOrEqual(0.5);
+		expect(score.confidence).toBeLessThanOrEqual(0.9);
+	});
+
+	it('scales Levenshtein fuzz onto 0.3-0.7 and floors hopeless queries at 0', () => {
+		const fuzzy = scoreLabel('Massagee', 'Massage');
+		expect(fuzzy.strategy).toBe('fuzzy');
+		expect(fuzzy.confidence).toBeGreaterThanOrEqual(0.3);
+		expect(fuzzy.confidence).toBeLessThanOrEqual(0.7);
+		expect(scoreLabel('Yoga', 'Deep Tissue Massage').confidence).toBe(0);
+	});
+});
+
+describe('makeServiceMatcher', () => {
+	it('resolves by appointmentTypeId with confidence 1.0 (id-match)', async () => {
+		const matcher = makeServiceMatcher();
+		const resolution = await Effect.runPromise(
+			matcher.match({ serviceName: 'whatever', appointmentTypeId: '53178494' }, candidates),
+		);
+		expect(resolution.strategy).toBe('id-match');
+		expect(resolution.confidence).toBe(1.0);
+		expect(resolution.value.ref).toBe('53178494');
+		expect(resolution.alternates).toEqual([]);
+	});
+
+	it('falls through the cascade and reports alternates sorted by confidence', async () => {
+		const matcher = makeServiceMatcher();
+		const resolution = await Effect.runPromise(
+			matcher.match({ serviceName: 'Deep Tissue Massage' }, candidates),
+		);
+		expect(resolution.strategy).toBe('normalized-exact');
+		expect(resolution.matchedLabel).toBe('Deep Tissue Massage');
+		expect(resolution.threshold).toBe(matcher.threshold);
+		expect(resolution.alternates).toHaveLength(2);
+		const confidences = resolution.alternates.map((a) => a.confidence);
+		expect([...confidences].sort((a, b) => b - a)).toEqual(confidences);
+	});
+
+	it('fails with FuzzyMatchError when nothing clears the threshold', async () => {
+		const matcher = makeServiceMatcher();
+		const exit = await Effect.runPromiseExit(
+			matcher.match({ serviceName: 'completely unrelated thing' }, candidates),
+		);
+		expect(Exit.isFailure(exit)).toBe(true);
+		if (Exit.isFailure(exit) && exit.cause._tag === 'Fail') {
+			expect(exit.cause.error).toBeInstanceOf(FuzzyMatchError);
+			expect(exit.cause.error.threshold).toBe(matcher.threshold);
+		}
+	});
+
+	it('keeps every admitted confidence within [threshold, 1]', async () => {
+		const matcher = makeServiceMatcher();
+		for (const query of ['Deep Tissue Massage', 'Deep Tissue', 'Swedish Massagee', 'acupuncture consult']) {
+			const resolution = await Effect.runPromise(matcher.match({ serviceName: query }, candidates));
+			expect(resolution.confidence).toBeGreaterThanOrEqual(matcher.threshold);
+			expect(resolution.confidence).toBeLessThanOrEqual(1);
+		}
+	});
+
+	it('is providable through the ServiceMatcherLive layer behind the scheduling-kit tag', async () => {
+		const resolution = await Effect.runPromise(
+			Effect.gen(function* () {
+				const matcher = yield* ServiceMatcher;
+				return yield* matcher.match({ serviceName: 'Swedish Massage' }, candidates);
+			}).pipe(Effect.provide(ServiceMatcherLive)),
+		);
+		expect(resolution.strategy).toBe('normalized-exact');
+		expect(ServiceMatcher.key).toBe('scheduling-kit/ServiceMatcher');
+	});
+});
+
+// =============================================================================
+// PROPERTY TESTS (design §11: bounds, threshold monotonicity, cascade ordering).
+// The ServiceMatcher reuses the shared scorers; covered here alongside the new
+// Date/Field matcher property suites so all three fuzzy lanes share the discipline.
+// =============================================================================
+
+const labelArb = fc.oneof(
+	fc.constantFrom('Deep Tissue Massage', 'Swedish Massage', 'Acupuncture Consult', 'Massage'),
+	fc.string({ maxLength: 24 }),
+);
+
+const candidatesArb = fc.array(
+	fc.record({ label: fc.string({ minLength: 1, maxLength: 24 }), ref: fc.string({ minLength: 1, maxLength: 8 }) }),
+	{ minLength: 0, maxLength: 6 },
+);
+
+describe('ServiceMatcher property tests (§11)', () => {
+	it('scoreLabel confidence is always within [0,1]', () => {
+		fc.assert(
+			fc.property(labelArb, fc.string({ minLength: 1, maxLength: 24 }), (query, label) => {
+				const { confidence } = scoreLabel(query, label);
+				return confidence >= 0 && confidence <= 1;
+			}),
+		);
+	});
+
+	it('an admitted resolution confidence is within [threshold,1] and alternates sorted desc', () => {
+		fc.assert(
+			fc.property(
+				labelArb,
+				candidatesArb,
+				fc.constantFrom(0, 0.3, 0.5, 0.95, 1),
+				(serviceName, candidates, threshold) => {
+					const matcher = makeServiceMatcher(threshold);
+					const exit = Effect.runSyncExit(matcher.match({ serviceName }, candidates));
+					if (Exit.isFailure(exit)) return true;
+					const r = exit.value;
+					if (r.confidence < threshold || r.confidence > 1) return false;
+					const confs = r.alternates.map((a) => a.confidence);
+					for (let i = 1; i < confs.length; i++) {
+						if (confs[i] > confs[i - 1]) return false;
+					}
+					return true;
+				},
+			),
+		);
+	});
+
+	it('threshold monotonicity: a higher threshold never admits where a lower one rejected', () => {
+		fc.assert(
+			fc.property(
+				labelArb,
+				candidatesArb,
+				fc.tuple(fc.constantFrom(0, 0.3, 0.5), fc.constantFrom(0.5, 0.95, 1)),
+				(serviceName, candidates, [lo, hi]) => {
+					const low = Math.min(lo, hi);
+					const high = Math.max(lo, hi);
+					const lowAdmits = Exit.isSuccess(
+						Effect.runSyncExit(makeServiceMatcher(low).match({ serviceName }, candidates)),
+					);
+					const highAdmits = Exit.isSuccess(
+						Effect.runSyncExit(makeServiceMatcher(high).match({ serviceName }, candidates)),
+					);
+					return !highAdmits || lowAdmits;
+				},
+			),
+		);
+	});
+
+	it('cascade ordering: a normalized-exact match outranks token-overlap and fuzzy strategies', () => {
+		fc.assert(
+			fc.property(labelArb, (label) => {
+				// An identical label must resolve normalized-exact at 0.95 (id-match needs a ref).
+				const exact = scoreLabel(label, label);
+				if (normalizeForTest(label).length === 0) return true;
+				return exact.strategy === 'normalized-exact' && exact.confidence === 0.95;
+			}),
+		);
+	});
+});
+
+/** Mirror of the scorer's normalize (lowercase, strip punctuation) for the empty guard. */
+const normalizeForTest = (s: string): string =>
+	s.toLowerCase().replace(/[^\w\s]/g, '').replace(/\s+/g, ' ').trim();

--- a/src/fuzzy/date-matcher.ts
+++ b/src/fuzzy/date-matcher.ts
@@ -1,0 +1,273 @@
+/**
+ * DateMatcher — fuzzy-in for dates and time slots (design §6 "Dates/slots (0.7.0)").
+ *
+ * Formalizes two fragments that today live inline in the adapter:
+ *  - the TZ-suffix normalization + slot-membership test duplicated in
+ *    `src/adapters/acuity/wizard.ts` (`checkSlotAvailability`, both the numeric-id and
+ *    service-name branches): strip a trailing `Z` or `±HH:MM` offset from both the
+ *    requested datetime and each candidate slot, then test membership against the
+ *    available slots;
+ *  - the tolerant month/day targeting scattered across `wizard-calendar.ts`
+ *    (`parseMonthLabel`/`parseYearMonthKey`/`navigateToMonth`), `read-availability.ts`,
+ *    `read-slots.ts` (`getCalendarMonth`), and `read-via-url.ts` (`MONTH_INDEX_BY_NAME`):
+ *    parse a "March 2026" calendar label, normalize a `YYYY-MM`/`YYYY-MM-DD` target.
+ *
+ * Shaped as a `FuzzyMatcher<DateMatchQuery, SlotCandidate>` exactly like `ServiceMatcher`
+ * (value/confidence/strategy/matchedLabel/threshold/alternates), shipping as MACHINERY —
+ * a `makeDateMatcher` factory + `DateMatcherLive` Layer + `DateMatcher` Context.Tag
+ * (judge-mandated, design §4/§6; same posture as ServiceMatcher). Thresholds are data
+ * (per-field `minConfidence`), never hardcoded into a step.
+ *
+ * The slot-membership result is behavior-preserving with the wizard inline test: an
+ * exact (TZ-normalized) match is `strategy: 'normalized-exact'`, confidence 1.0; a
+ * same-minute-different-suffix match is `normalized-exact` too (the suffix is stripped
+ * before comparison); anything below the admitting threshold is a typed `FuzzyMatchError`.
+ */
+
+import { Context, Effect, Layer } from 'effect';
+import {
+	FuzzyMatchError,
+	type FuzzyMatcher,
+	type FuzzyResolution,
+} from './fuzzy.js';
+
+// =============================================================================
+// PURE SCORING MACHINERY (date/TZ normalization + slot membership)
+// =============================================================================
+
+/** Calendar month names, lowercase, index 0 = january. SSOT for label parsing. */
+export const MONTH_NAMES: readonly string[] = [
+	'january',
+	'february',
+	'march',
+	'april',
+	'may',
+	'june',
+	'july',
+	'august',
+	'september',
+	'october',
+	'november',
+	'december',
+];
+
+/** A parsed calendar position. `month` is 0-based (january = 0). */
+export interface CalendarMonth {
+	readonly month: number;
+	readonly year: number;
+}
+
+/**
+ * Strip a trailing `Z` or `±HH:MM` timezone suffix from an ISO datetime, leaving a
+ * local-wall-clock string for comparison. Verbatim the normalizer duplicated in
+ * `wizard.ts` (`(dt) => dt.replace(/([+-]\d{2}:\d{2}|Z)$/, '')`). The two adapter
+ * copies of this regex collapse into this one function.
+ */
+export const stripTzSuffix = (datetime: string): string =>
+	datetime.replace(/([+-]\d{2}:\d{2}|Z)$/, '');
+
+/**
+ * Parse a calendar month label like "March 2026", "March\n2026", or "March2026"
+ * (nested spans) into a 0-based month + year. Consolidates the three identical
+ * `text.match(/([A-Za-z]+)\s*(\d{4})/)` copies (wizard-calendar.ts `parseMonthLabel`,
+ * read-availability.ts / read-slots.ts `getCalendarMonth` inline parsers).
+ */
+export const parseMonthLabel = (text: string): CalendarMonth | null => {
+	const match = text.trim().match(/([A-Za-z]+)\s*(\d{4})/);
+	if (!match) return null;
+
+	const monthIdx = MONTH_NAMES.indexOf(match[1].toLowerCase());
+	if (monthIdx === -1) return null;
+
+	const year = parseInt(match[2], 10);
+	if (!Number.isInteger(year)) return null;
+
+	return { month: monthIdx, year };
+};
+
+/**
+ * Parse a `YYYY-MM` target into a 0-based month + year. Consolidates
+ * `wizard-calendar.ts:parseYearMonthKey` and the inline `targetMonth.split('-')`
+ * arithmetic in the read steps. Strictly anchored (`^…$`) — byte-equivalent to the
+ * former wizard-calendar copy, so the read-via-url validation guards
+ * (`!parseYearMonthKey(targetMonth)` → "Invalid target month") keep rejecting anything
+ * that is not exactly `YYYY-MM` (a `YYYY-MM-DD` value still fails the guard, unchanged).
+ */
+export const parseYearMonthKey = (value: string): CalendarMonth | null => {
+	const match = value.match(/^(\d{4})-(\d{2})$/);
+	if (!match) return null;
+
+	const year = Number(match[1]);
+	const month = Number(match[2]) - 1;
+	if (!Number.isInteger(year) || !Number.isInteger(month) || month < 0 || month > 11) {
+		return null;
+	}
+
+	return { month, year };
+};
+
+/**
+ * Confidence that a calendar `current` position targets `target`, on a tolerant 0..1
+ * scale: exact month+year = 1.0, same year (off by ≤2 months) decays, otherwise floors
+ * at 0. Mirrors `navigateToMonth`'s "are we there yet?" predicate as a scored, journalable
+ * signal rather than a silent loop condition. Same-month is the only admit at the default
+ * threshold; the decay surfaces "how far off the requested month the calendar landed" in
+ * the audit trail.
+ */
+export const scoreMonthTarget = (current: CalendarMonth, target: CalendarMonth): number => {
+	const currentAbs = current.year * 12 + current.month;
+	const targetAbs = target.year * 12 + target.month;
+	const delta = Math.abs(currentAbs - targetAbs);
+	if (delta === 0) return 1;
+	if (delta > 2) return 0;
+	// 1 month off → 0.5, 2 months off → 0.25.
+	return 0.5 / delta;
+};
+
+// =============================================================================
+// MATCHER TYPES
+// =============================================================================
+
+/** A candidate time slot read from the page (TZ-suffixed or local). */
+export interface SlotCandidate {
+	/** ISO 8601, with or without a trailing `Z`/offset. */
+	readonly datetime: string;
+	readonly available: boolean;
+}
+
+/** A date/slot match query: the requested datetime + the admitting policy. */
+export interface DateMatchQuery {
+	/** Requested datetime (ISO 8601, with or without a TZ suffix). */
+	readonly datetime: string;
+}
+
+/**
+ * Default admitting threshold for slot membership. 1.0 by default so behavior is
+ * byte-identical to the wizard inline membership test (which only admits an exact,
+ * TZ-normalized equal). Flows loosen it as DATA (`minConfidence`) to tolerate
+ * minute-level jitter; policy tightening/loosening is a diff, never a code change.
+ */
+export const DEFAULT_DATE_MIN_CONFIDENCE = 1.0;
+
+// =============================================================================
+// SLOT-MEMBERSHIP SCORING
+// =============================================================================
+
+/**
+ * Score a candidate slot against the requested datetime through the date cascade:
+ *  - `id-match` (1.0): byte-equal datetime strings (suffix included);
+ *  - `normalized-exact` (1.0): equal after stripping the TZ suffix from both sides —
+ *    this is the wizard inline test, lifted verbatim;
+ *  - `token-overlap` (0.9): same calendar date AND same hour, minutes differ;
+ *  - `fuzzy` (0.5): same calendar date, hour differs;
+ *  - else 0.
+ * Unavailable slots floor at 0 regardless of string match (the inline test ANDs on
+ * `s.available`).
+ */
+export const scoreSlot = (
+	query: DateMatchQuery,
+	candidate: SlotCandidate,
+): { readonly strategy: FuzzyResolution<SlotCandidate>['strategy']; readonly confidence: number } => {
+	if (!candidate.available) return { strategy: 'fuzzy', confidence: 0 };
+
+	if (query.datetime === candidate.datetime) {
+		return { strategy: 'id-match', confidence: 1 };
+	}
+
+	const reqNorm = stripTzSuffix(query.datetime);
+	const candNorm = stripTzSuffix(candidate.datetime);
+	if (reqNorm === candNorm) {
+		return { strategy: 'normalized-exact', confidence: 1 };
+	}
+
+	// Same calendar date? (compare the YYYY-MM-DD prefix)
+	const reqDate = reqNorm.slice(0, 10);
+	const candDate = candNorm.slice(0, 10);
+	if (reqDate.length === 10 && reqDate === candDate) {
+		const reqHour = reqNorm.slice(11, 13);
+		const candHour = candNorm.slice(11, 13);
+		if (reqHour && reqHour === candHour) {
+			return { strategy: 'token-overlap', confidence: 0.9 };
+		}
+		return { strategy: 'fuzzy', confidence: 0.5 };
+	}
+
+	return { strategy: 'fuzzy', confidence: 0 };
+};
+
+// =============================================================================
+// MATCHER FACTORY + LAYER + TAG
+// =============================================================================
+
+/**
+ * Build a DateMatcher: scores every candidate slot against the requested datetime
+ * through `scoreSlot`, admits the best against `threshold`, and returns the
+ * `FuzzyResolution` audit record (value = the matched slot, matchedLabel = its
+ * datetime, alternates = the runners-up best-first). Fails with `FuzzyMatchError`
+ * when nothing clears the threshold — the typed analogue of the inline membership
+ * test returning `false`.
+ */
+export const makeDateMatcher = (
+	threshold = DEFAULT_DATE_MIN_CONFIDENCE,
+): FuzzyMatcher<DateMatchQuery, SlotCandidate> => ({
+	threshold,
+	match: (query, candidates) =>
+		Effect.suspend(() => {
+			const scored = candidates
+				.map((candidate) => ({ candidate, score: scoreSlot(query, candidate) }))
+				.sort((a, b) => b.score.confidence - a.score.confidence);
+			const best = scored[0];
+
+			if (!best || best.score.confidence < threshold) {
+				return Effect.fail(
+					new FuzzyMatchError({
+						query: query.datetime,
+						threshold,
+						bestConfidence: best?.score.confidence ?? 0,
+						message: `No slot candidate cleared threshold ${threshold} for '${query.datetime}'`,
+					}),
+				);
+			}
+
+			return Effect.succeed<FuzzyResolution<SlotCandidate>>({
+				value: best.candidate,
+				confidence: best.score.confidence,
+				strategy: best.score.strategy,
+				matchedLabel: best.candidate.datetime,
+				threshold,
+				alternates: scored
+					.slice(1)
+					.map(({ candidate, score }) => ({
+						label: candidate.datetime,
+						confidence: score.confidence,
+					})),
+			});
+		}),
+});
+
+/**
+ * Tolerant slot-membership test: TRUE iff some available slot clears the matcher's
+ * admitting threshold against the requested datetime. Behavior-preserving drop-in for
+ * the wizard inline `slots.some(s => s.available && normalize(s.datetime) === requestNorm)`
+ * at the default threshold (1.0 admits only the TZ-normalized exact). Returns the
+ * resolution too, so the calling step can surface it in `StepOutcome.resolutions`.
+ */
+export const matchSlotMembership = (
+	matcher: FuzzyMatcher<DateMatchQuery, SlotCandidate>,
+	datetime: string,
+	slots: readonly SlotCandidate[],
+): Effect.Effect<{ readonly member: boolean; readonly resolution?: FuzzyResolution<SlotCandidate> }> =>
+	matcher.match({ datetime }, slots).pipe(
+		Effect.map((resolution) => ({ member: true, resolution })),
+		Effect.catchTag('FuzzyMatchError', () => Effect.succeed({ member: false })),
+	);
+
+export class DateMatcher extends Context.Tag('scheduling-kit/DateMatcher')<
+	DateMatcher,
+	FuzzyMatcher<DateMatchQuery, SlotCandidate>
+>() {}
+
+/** Default DateMatcher layer (Layer substitution replaces test-seam overrides). */
+export const DateMatcherLive: Layer.Layer<DateMatcher> = Layer.sync(DateMatcher, () =>
+	makeDateMatcher(),
+);

--- a/src/fuzzy/field-matcher.ts
+++ b/src/fuzzy/field-matcher.ts
@@ -1,0 +1,235 @@
+/**
+ * FieldMatcher — fuzzy-in for intake fields (design §6 "Intake fields (0.7.0)").
+ *
+ * Generalizes the required-textarea label inference inlined in
+ * `src/adapters/acuity/steps/fill-form.ts` (`fillRequiredTextareas`): the hardcoded
+ * keyword chain that maps a textarea's `<label>` text onto a default answer —
+ * "work on"/"session" → client notes (else "General wellness"), "sleep" → "7-8 hours",
+ * else "N/A". That chain was built "because field ids change when Jen edits the Acuity
+ * intake form" (fill-form.ts comment), so the inference keys off label TEXT, not ids.
+ *
+ * This module turns that ad-hoc `if/else` ladder into shared scoring over label text,
+ * shaped as a `FuzzyMatcher<FieldMatchQuery, FieldRule>` exactly like `ServiceMatcher`
+ * and `DateMatcher` (value/confidence/strategy/matchedLabel/threshold/alternates),
+ * shipping as MACHINERY — a `makeFieldMatcher` factory + `FieldMatcherLive` Layer +
+ * `FieldMatcher` Context.Tag. Each rule carries its own keyword set and a `minConfidence`
+ * (thresholds are DATA, design §6); the catch-all "N/A" rule is the floor that always
+ * admits, so the matcher is total — every label resolves to some answer, with an honest
+ * confidence + strategy trail for the journal.
+ *
+ * The default ruleset is behavior-preserving with the inline ladder: the same labels
+ * map to the same answers, now with a confidence score and a runners-up trail.
+ */
+
+import { Context, Effect, Layer } from 'effect';
+import { normalize, tokenOverlap } from './fuzzy.js';
+import {
+	FuzzyMatchError,
+	type FuzzyMatcher,
+	type FuzzyResolution,
+} from './fuzzy.js';
+
+// =============================================================================
+// RULE MODEL
+// =============================================================================
+
+/**
+ * A field-answer rule: when a label's text matches `keywords`, the field is answered
+ * with `value`. `value: null` defers to the caller's contextual value (e.g. client
+ * notes) — the inline ladder's "work on"/"session" branch used `clientNotes` when set.
+ */
+export interface FieldRule {
+	/** Stable rule id (e.g. 'work-on', 'sleep', 'fallback'). */
+	readonly id: string;
+	/** Human-facing label this rule targets (the matchedLabel surfaced in the audit). */
+	readonly label: string;
+	/** Keyword phrases that, present in the field label, fire this rule. */
+	readonly keywords: readonly string[];
+	/** Default answer; null = use the caller-supplied contextual value. */
+	readonly value: string | null;
+	/** Per-rule admitting threshold (DATA, design §6). */
+	readonly minConfidence: number;
+	/** True for the catch-all rule that always admits at the floor. */
+	readonly fallback?: boolean;
+}
+
+/** A field-inference query: the label text read off the page. */
+export interface FieldMatchQuery {
+	/** The `<label>` text for the required field (may be empty). */
+	readonly label: string;
+}
+
+/**
+ * The default ruleset, lifted from `fillRequiredTextareas`'s keyword chain. Order is
+ * irrelevant — scoring picks the best, with the fallback flooring at its threshold.
+ * Keyword phrases are matched substring-first (the inline `.includes()` semantics),
+ * then token-overlap as a tolerant backstop.
+ */
+export const DEFAULT_FIELD_RULES: readonly FieldRule[] = [
+	{
+		id: 'work-on',
+		label: 'What would you like to work on?',
+		keywords: ['work on', 'session'],
+		value: null, // defer to client notes; falls back to 'General wellness'
+		minConfidence: 0.5,
+	},
+	{
+		id: 'sleep',
+		label: 'How many hours of restful sleep?',
+		keywords: ['sleep'],
+		value: '7-8 hours',
+		minConfidence: 0.5,
+	},
+	{
+		id: 'fallback',
+		label: 'N/A',
+		keywords: [],
+		value: 'N/A',
+		minConfidence: 0,
+		fallback: true,
+	},
+];
+
+/** The contextual answer used when the resolved rule defers (`value: null`). */
+export const DEFAULT_DEFERRED_VALUE = 'General wellness';
+
+// =============================================================================
+// PURE SCORING MACHINERY (label-text → rule)
+// =============================================================================
+
+/**
+ * Score a field label against a rule's keywords, on a 0..1 scale:
+ *  - substring hit (the inline `label.toLowerCase().includes(keyword)` semantics) →
+ *    `normalized-exact`, confidence 0.95 (highest non-id strategy);
+ *  - else best token-overlap of the label against any keyword phrase, scaled onto
+ *    0.5–0.9 above the 0.6 overlap floor → `token-overlap`;
+ *  - the fallback rule (no keywords) → `fuzzy`, confidence 0.1, so it always clears its
+ *    own zero threshold but loses to any real keyword hit;
+ *  - else 0.
+ */
+export const scoreFieldRule = (
+	label: string,
+	rule: FieldRule,
+): { readonly strategy: FuzzyResolution<FieldRule>['strategy']; readonly confidence: number } => {
+	const lower = label.toLowerCase();
+
+	if (rule.fallback && rule.keywords.length === 0) {
+		// Floor: always admits at its (zero) threshold, beaten by any keyword hit.
+		return { strategy: 'fuzzy', confidence: 0.1 };
+	}
+
+	// Substring match preserves the inline ladder's `.includes()` behavior.
+	for (const keyword of rule.keywords) {
+		if (keyword && lower.includes(keyword.toLowerCase())) {
+			return { strategy: 'normalized-exact', confidence: 0.95 };
+		}
+	}
+
+	// Tolerant backstop: token overlap of the label vs each keyword phrase.
+	let bestOverlap = 0;
+	for (const keyword of rule.keywords) {
+		const overlap = tokenOverlap(label, keyword);
+		if (overlap > bestOverlap) bestOverlap = overlap;
+	}
+	const TOKEN_FLOOR = 0.6;
+	if (bestOverlap >= TOKEN_FLOOR) {
+		const confidence = 0.5 + ((bestOverlap - TOKEN_FLOOR) / (1 - TOKEN_FLOOR)) * 0.4;
+		return { strategy: 'token-overlap', confidence };
+	}
+
+	return { strategy: 'fuzzy', confidence: 0 };
+};
+
+// =============================================================================
+// MATCHER FACTORY + LAYER + TAG
+// =============================================================================
+
+/**
+ * Build a FieldMatcher over a ruleset: scores the label against every rule, admits the
+ * best whose confidence clears BOTH the matcher threshold AND the rule's own
+ * `minConfidence`, and returns the `FuzzyResolution` (value = the matched rule). The
+ * fallback rule keeps the matcher total: an unrecognized label still resolves (to "N/A")
+ * with an honest low confidence + `fuzzy` strategy in the trail. Fails with
+ * `FuzzyMatchError` only when even the fallback is absent (an empty/floorless ruleset).
+ */
+export const makeFieldMatcher = (
+	rules: readonly FieldRule[] = DEFAULT_FIELD_RULES,
+	threshold = 0,
+): FuzzyMatcher<FieldMatchQuery, FieldRule> => ({
+	threshold,
+	match: (query, _candidates) =>
+		Effect.suspend(() => {
+			// Rules are the candidate space (the page provides label text, not rules), so
+			// the matcher scores against its OWN ruleset; the `candidates` arg is accepted
+			// for interface conformance and ignored.
+			void _candidates;
+			const scored = rules
+				.map((rule) => ({ rule, score: scoreFieldRule(query.label, rule) }))
+				// A rule only competes if it clears its own per-rule minConfidence.
+				.filter(({ rule, score }) => score.confidence >= rule.minConfidence)
+				.sort((a, b) => b.score.confidence - a.score.confidence);
+			const best = scored[0];
+
+			if (!best || best.score.confidence < threshold) {
+				return Effect.fail(
+					new FuzzyMatchError({
+						query: query.label,
+						threshold,
+						bestConfidence: best?.score.confidence ?? 0,
+						message: `No field rule cleared threshold ${threshold} for label '${query.label}'`,
+					}),
+				);
+			}
+
+			return Effect.succeed<FuzzyResolution<FieldRule>>({
+				value: best.rule,
+				confidence: best.score.confidence,
+				strategy: best.score.strategy,
+				matchedLabel: best.rule.label,
+				threshold,
+				alternates: scored
+					.slice(1)
+					.map(({ rule, score }) => ({ label: rule.label, confidence: score.confidence })),
+			});
+		}),
+});
+
+/**
+ * Resolve a field label to its concrete answer string, applying the deferred-value
+ * convention (`value: null` → caller's `deferredValue`, defaulting to "General
+ * wellness"). Behavior-preserving with `fillRequiredTextareas`'s ladder:
+ *  - "work on"/"session" label → client notes (else "General wellness");
+ *  - "sleep" label → "7-8 hours";
+ *  - else → "N/A".
+ * Returns the chosen value AND the resolution, so the fill-form step can surface the
+ * resolution in `StepOutcome.resolutions`.
+ */
+export const resolveFieldAnswer = (
+	matcher: FuzzyMatcher<FieldMatchQuery, FieldRule>,
+	label: string,
+	deferredValue?: string,
+): Effect.Effect<{ readonly value: string; readonly resolution?: FuzzyResolution<FieldRule> }> =>
+	matcher.match({ label }, []).pipe(
+		Effect.map((resolution) => {
+			const ruleValue = resolution.value.value;
+			const value =
+				ruleValue ?? (deferredValue?.trim() ? deferredValue.trim() : DEFAULT_DEFERRED_VALUE);
+			return { value, resolution };
+		}),
+		// A floorless ruleset (no fallback) degrades to the inline default, never throws.
+		Effect.catchTag('FuzzyMatchError', () =>
+			Effect.succeed({
+				value: deferredValue?.trim() ? deferredValue.trim() : 'N/A',
+			}),
+		),
+	);
+
+export class FieldMatcher extends Context.Tag('scheduling-kit/FieldMatcher')<
+	FieldMatcher,
+	FuzzyMatcher<FieldMatchQuery, FieldRule>
+>() {}
+
+/** Default FieldMatcher layer (Layer substitution replaces test-seam overrides). */
+export const FieldMatcherLive: Layer.Layer<FieldMatcher> = Layer.sync(FieldMatcher, () =>
+	makeFieldMatcher(),
+);

--- a/src/fuzzy/fuzzy.ts
+++ b/src/fuzzy/fuzzy.ts
@@ -1,0 +1,210 @@
+/**
+ * Fuzzy-in primitives — tolerant matching with explicit confidence and audit trails.
+ * Design: docs/design/flow-dag-formalization.md §4 (fuzzy.ts) and §6.
+ *
+ * Backend-agnostic fuzzy-in primitives for tolerant matching with explicit confidence
+ * and audit trails. These scorers originated in scheduling-bridge's Acuity
+ * ServiceResolver cascade, but they are pure string/slot/field machinery and belong in
+ * the reusable kit surface so every adapter can share one scoring authority.
+ */
+
+import { Context, Data, Effect, Layer } from 'effect';
+
+/** Strategy vocabulary, identical to ServiceResolution.strategy. */
+export type FuzzyStrategy = 'id-match' | 'normalized-exact' | 'token-overlap' | 'fuzzy';
+
+/** The audit record every tolerant match produces. */
+export interface FuzzyResolution<A> {
+	readonly value: A;
+	/** 0..1 */
+	readonly confidence: number;
+	readonly strategy: FuzzyStrategy;
+	readonly matchedLabel: string;
+	/** Policy that admitted the match. */
+	readonly threshold: number;
+	readonly alternates: readonly { readonly label: string; readonly confidence: number }[];
+}
+
+/** Failure: no candidate cleared the admitting threshold. */
+export class FuzzyMatchError extends Data.TaggedError('FuzzyMatchError')<{
+	readonly query: string;
+	readonly threshold: number;
+	readonly bestConfidence: number;
+	readonly message: string;
+}> {}
+
+export interface FuzzyMatcher<Q, A> {
+	readonly threshold: number;
+	readonly match: (
+		query: Q,
+		candidates: readonly A[],
+	) => Effect.Effect<FuzzyResolution<A>, FuzzyMatchError>;
+}
+
+export interface ServiceMatchQuery {
+	readonly serviceName: string;
+	readonly appointmentTypeId?: string;
+}
+
+export interface ServiceCandidate {
+	readonly label: string;
+	readonly ref: string;
+}
+
+export class ServiceMatcher extends Context.Tag('scheduling-kit/ServiceMatcher')<
+	ServiceMatcher,
+	FuzzyMatcher<ServiceMatchQuery, ServiceCandidate>
+>() {}
+
+// =============================================================================
+// SHARED SCORING MACHINERY
+// =============================================================================
+
+/** Normalize a string: lowercase, strip non-alphanumeric (keep spaces), collapse whitespace. */
+export const normalize = (s: string): string =>
+	s.toLowerCase().replace(/[^\w\s]/g, '').replace(/\s+/g, ' ').trim();
+
+/** Tokenize: split on whitespace into lowercase words. */
+const tokenize = (s: string): Set<string> =>
+	new Set(normalize(s).split(' ').filter(Boolean));
+
+/** Token overlap score: |intersection| / max(|a|, |b|). */
+export const tokenOverlap = (a: string, b: string): number => {
+	const setA = tokenize(a);
+	const setB = tokenize(b);
+	if (setA.size === 0 || setB.size === 0) return 0;
+
+	let intersection = 0;
+	for (const token of setA) {
+		if (setB.has(token)) intersection++;
+	}
+
+	return intersection / Math.max(setA.size, setB.size);
+};
+
+/** Levenshtein edit distance between two strings. */
+export const levenshtein = (a: string, b: string): number => {
+	const m = a.length;
+	const n = b.length;
+
+	if (m === 0) return n;
+	if (n === 0) return m;
+
+	const row = Array.from({ length: n + 1 }, (_, i) => i);
+
+	for (let i = 1; i <= m; i++) {
+		let prev = i;
+		for (let j = 1; j <= n; j++) {
+			const cost = a[i - 1] === b[j - 1] ? 0 : 1;
+			const val = Math.min(
+				row[j] + 1,
+				prev + 1,
+				row[j - 1] + cost,
+			);
+			row[j - 1] = prev;
+			prev = val;
+		}
+		row[n] = prev;
+	}
+
+	return row[n];
+};
+
+/** Fuzzy match confidence: 1 - (distance / maxLen), after normalization. */
+export const fuzzyConfidence = (a: string, b: string): number => {
+	const na = normalize(a);
+	const nb = normalize(b);
+	const maxLen = Math.max(na.length, nb.length);
+	if (maxLen === 0) return 0;
+
+	const dist = levenshtein(na, nb);
+	return Math.max(0, 1 - dist / maxLen);
+};
+
+/** Cascade strategy thresholds. */
+export const TOKEN_THRESHOLD = 0.6;
+export const FUZZY_THRESHOLD = 0.6;
+
+/**
+ * Score one label against a query through the fuzzy-in cascade (sans id-match, which
+ * needs a stable ref): normalized-exact (0.95), token-overlap (raw >= 0.6 scaled onto
+ * 0.5-0.9), then fuzzy/Levenshtein (raw >= 0.6 scaled onto 0.3-0.7). Returns the best
+ * admitted strategy, or a zero-confidence `fuzzy` score when nothing is admitted.
+ */
+export const scoreLabel = (
+	query: string,
+	label: string,
+): { readonly strategy: FuzzyStrategy; readonly confidence: number } => {
+	if (normalize(query) === normalize(label) && normalize(query).length > 0) {
+		return { strategy: 'normalized-exact', confidence: 0.95 };
+	}
+
+	const overlap = tokenOverlap(query, label);
+	if (overlap >= TOKEN_THRESHOLD) {
+		const confidence = 0.5 + ((overlap - TOKEN_THRESHOLD) / (1 - TOKEN_THRESHOLD)) * 0.4;
+		return { strategy: 'token-overlap', confidence };
+	}
+
+	const fuzzy = fuzzyConfidence(query, label);
+	if (fuzzy >= FUZZY_THRESHOLD) {
+		const confidence = 0.3 + ((fuzzy - FUZZY_THRESHOLD) / (1 - FUZZY_THRESHOLD)) * 0.4;
+		return { strategy: 'fuzzy', confidence };
+	}
+
+	return { strategy: 'fuzzy', confidence: 0 };
+};
+
+/** Default service matcher: id-match first, then the label cascade over candidates. */
+export const makeServiceMatcher = (
+	threshold = 0.3,
+): FuzzyMatcher<ServiceMatchQuery, ServiceCandidate> => ({
+	threshold,
+	match: (query, candidates) =>
+		Effect.suspend(() => {
+			if (query.appointmentTypeId !== undefined) {
+				const byId = candidates.find((c) => c.ref === query.appointmentTypeId);
+				if (byId) {
+					return Effect.succeed<FuzzyResolution<ServiceCandidate>>({
+						value: byId,
+						confidence: 1.0,
+						strategy: 'id-match',
+						matchedLabel: byId.label,
+						threshold,
+						alternates: [],
+					});
+				}
+			}
+
+			const scored = candidates
+				.map((candidate) => ({ candidate, score: scoreLabel(query.serviceName, candidate.label) }))
+				.sort((a, b) => b.score.confidence - a.score.confidence);
+			const best = scored[0];
+
+			if (!best || best.score.confidence < threshold) {
+				return Effect.fail(
+					new FuzzyMatchError({
+						query: query.serviceName,
+						threshold,
+						bestConfidence: best?.score.confidence ?? 0,
+						message: `No service candidate cleared threshold ${threshold} for '${query.serviceName}'`,
+					}),
+				);
+			}
+
+			return Effect.succeed<FuzzyResolution<ServiceCandidate>>({
+				value: best.candidate,
+				confidence: best.score.confidence,
+				strategy: best.score.strategy,
+				matchedLabel: best.candidate.label,
+				threshold,
+				alternates: scored
+					.slice(1)
+					.map(({ candidate, score }) => ({ label: candidate.label, confidence: score.confidence })),
+			});
+		}),
+});
+
+/** Default ServiceMatcher layer (Layer substitution replaces test-seam overrides). */
+export const ServiceMatcherLive: Layer.Layer<ServiceMatcher> = Layer.sync(ServiceMatcher, () =>
+	makeServiceMatcher(),
+);

--- a/src/fuzzy/index.ts
+++ b/src/fuzzy/index.ts
@@ -1,0 +1,55 @@
+/**
+ * @tummycrypt/scheduling-kit/fuzzy
+ *
+ * Backend-agnostic tolerant matching primitives for adapter implementations.
+ * The scorer cascade is pure and journalable: every admitted fuzzy-in match
+ * carries confidence, strategy, threshold, matched label, and runner-up data.
+ */
+
+export {
+	FUZZY_THRESHOLD,
+	FuzzyMatchError,
+	ServiceMatcher,
+	ServiceMatcherLive,
+	TOKEN_THRESHOLD,
+	fuzzyConfidence,
+	levenshtein,
+	makeServiceMatcher,
+	normalize,
+	scoreLabel,
+	tokenOverlap,
+	type FuzzyMatcher,
+	type FuzzyResolution,
+	type FuzzyStrategy,
+	type ServiceCandidate,
+	type ServiceMatchQuery,
+} from './fuzzy.js';
+
+export {
+	DEFAULT_DATE_MIN_CONFIDENCE,
+	DateMatcher,
+	DateMatcherLive,
+	MONTH_NAMES,
+	makeDateMatcher,
+	matchSlotMembership,
+	parseMonthLabel,
+	parseYearMonthKey,
+	scoreMonthTarget,
+	scoreSlot,
+	stripTzSuffix,
+	type CalendarMonth,
+	type DateMatchQuery,
+	type SlotCandidate,
+} from './date-matcher.js';
+
+export {
+	DEFAULT_DEFERRED_VALUE,
+	DEFAULT_FIELD_RULES,
+	FieldMatcher,
+	FieldMatcherLive,
+	makeFieldMatcher,
+	resolveFieldAnswer,
+	scoreFieldRule,
+	type FieldMatchQuery,
+	type FieldRule,
+} from './field-matcher.js';

--- a/src/index.ts
+++ b/src/index.ts
@@ -53,3 +53,6 @@ export * from './stores/index.js';
 
 // Reconciliation (alt-payment matching)
 export * from './reconciliation/index.js';
+
+// Backend-agnostic fuzzy-in matcher primitives
+export * from './fuzzy/index.js';

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,7 +4,12 @@ import { svelte } from '@sveltejs/vite-plugin-svelte';
 export default defineConfig({
   plugins: [svelte({ hot: !process.env.VITEST })],
   test: {
-    include: ['src/tests/**/*.test.ts', 'src/adapters/__tests__/**/*.test.ts', 'src/onboarding/__tests__/**/*.test.ts'],
+    include: [
+      'src/tests/**/*.test.ts',
+      'src/adapters/__tests__/**/*.test.ts',
+      'src/fuzzy/__tests__/**/*.test.ts',
+      'src/onboarding/__tests__/**/*.test.ts',
+    ],
     environment: 'node',
     globals: true,
     setupFiles: ['src/tests/setup.ts'],


### PR DESCRIPTION
## Summary

TIN-2098 kit-side extraction: publish the bridge fuzzy-in scorer/matcher machinery as a backend-agnostic kit subpath.

- Adds `@tummycrypt/scheduling-kit/fuzzy` with the shared scorer cascade (`normalize`, token overlap, Levenshtein confidence, `scoreLabel`).
- Adds `ServiceMatcher`, `DateMatcher`, and `FieldMatcher` machinery with Effect Context tags under `scheduling-kit/*`.
- Adds the bridge-derived property suites to kit unit coverage: confidence bounds, threshold monotonicity, cascade ordering, slot membership, month parsing, and field-rule inference.
- Exports the subpath through `package.json` and re-exports it from the root kit surface.
- Extends the unit-test include list so `src/fuzzy/__tests__` is covered by default `pnpm test:unit`.

This is pure extraction: no browser automation, no Acuity DOM code, no app-specific deployment logic.

## Validation

- `pnpm exec svelte-kit sync && pnpm exec vitest run src/fuzzy/__tests__ --reporter=verbose` — 49 passed
- `pnpm check` — 0 errors / 0 warnings
- `pnpm test:unit` — 814 passed (30 files)
- `pnpm build` — emitted `dist/fuzzy/*`
- `pnpm exec publint` — All good
- `pnpm lint` — clean
- `pnpm check:release-metadata` — aligned for 0.9.1
- `bazel build //:pkg` — passed
- `git diff --check` — clean

## Notes

I intentionally did not add a new fine-grained `//:fuzzy` Bazel target in this PR. The repo's existing standalone `ts_project` pattern currently conflicts with the SvelteKit-generated tsconfig/noEmit setup; `//:pkg` remains the canonical package artifact and passes.

Refs TIN-2098.
