### PR TITLE
release: bump scheduling-kit to 0.9.2

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,7 +56,7 @@ Closed but still relevant context:
 - `TIN-103` closed the release-authority ambiguity for `Jesssullivan/scheduling-kit`
 - `TIN-104` was canceled as a duplicate during that convergence work
 - `TIN-165` is done: the tinyland bazel-registry is generated from standalone
-  package truth and currently carries scheduling-kit `0.9.1+` and
+  package truth and currently carries scheduling-kit `0.9.2+` and
   scheduling-bridge `0.5.11+`; the registry line is in `.bazelrc`
 - `TIN-677` is done: HomegrownAdapter takes injected schemas from
   `@tummycrypt/tinyland-business-pg`, with `tinyland-auth-pg` kept only as an
@@ -66,9 +66,9 @@ Current operational truth:
 
 - local development should default to `jesssullivan/main`
 - that branch is the current functional release line
-- current released version is `0.9.1`: git tag plus GitHub Release, GitHub
+- current released version is `0.9.2`: git tag plus GitHub Release, GitHub
   Packages `@jesssullivan/scheduling-kit`, and the active tinyland Bazel
-  registry (`0.9.1+`)
+  registry (`0.9.2+`)
 - npmjs `@tummycrypt/scheduling-kit` is retired for new versions and frozen at
   `0.8.0`; `npm_publish_mode: disabled` is permanent policy, not a temporary
   outage

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -166,7 +166,7 @@ npm_package(
     ],
     package = "@tummycrypt/scheduling-kit",
     tags = ["manual"],
-    version = "0.9.1",
+    version = "0.9.2",
     visibility = ["//visibility:public"],
 )
 

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -22,7 +22,7 @@ Subpackage targets (finer-grained caching):
 
 module(
     name = "tummycrypt_scheduling_kit",
-    version = "0.9.1",
+    version = "0.9.2",
     compatibility_level = 1,
 )
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ The Bazel module graph is the canonical delivery mechanism. Depend on the
 module through the tinyland Bazel registry:
 
 ```starlark
-bazel_dep(name = "tummycrypt_scheduling_kit", version = "0.9.1")
+bazel_dep(name = "tummycrypt_scheduling_kit", version = "0.9.2")
 ```
 
 with the registry line (already in this repo's `.bazelrc`):
@@ -105,7 +105,7 @@ Current reality:
 - the functional release line is `Jesssullivan/scheduling-kit`
 - `tinyland-inc/scheduling-kit` is now a downstream mirror and validation
   surface, not a second publish authority
-- the active tinyland Bazel registry carries `scheduling-kit` `0.9.1+` (and
+- the active tinyland Bazel registry carries `scheduling-kit` `0.9.2+` (and
   `scheduling-bridge` `0.5.11+`); the registry line is already in `.bazelrc`
 
 Treat `Jesssullivan/main` as the release authority for package publication and

--- a/docs/generated/package-surface.md
+++ b/docs/generated/package-surface.md
@@ -11,7 +11,7 @@ Generated from `package.json` and the current `src/` tree.
 | Field | Value |
 | --- | --- |
 | Package | `@tummycrypt/scheduling-kit` |
-| Version | `0.9.1` |
+| Version | `0.9.2` |
 | Description | Backend-agnostic scheduling components with alternative payment support |
 | Node range | `>=20 <25` |
 | Repository | https://github.com/Jesssullivan/scheduling-kit.git |
@@ -25,11 +25,13 @@ Generated from `package.json` and the current `src/` tree.
 | `./capabilities` | `./dist/capabilities/index.d.ts` | `./dist/capabilities/index.js` |  |
 | `./components` | `./dist/components/index.d.ts` | `./dist/components/index.js` | `./dist/components/index.js` |
 | `./core` | `./dist/core/index.d.ts` | `./dist/core/index.js` |  |
+| `./fuzzy` | `./dist/fuzzy/index.d.ts` | `./dist/fuzzy/index.js` |  |
 | `./lib` | `./dist/lib/index.d.ts` | `./dist/lib/index.js` |  |
 | `./onboarding` | `./dist/onboarding/index.d.ts` | `./dist/onboarding/index.js` |  |
 | `./payments` | `./dist/payments/index.d.ts` | `./dist/payments/index.js` |  |
 | `./payments/types` | `./dist/payments/types.d.ts` | `./dist/payments/types.js` |  |
 | `./reconciliation` | `./dist/reconciliation/index.d.ts` | `./dist/reconciliation/index.js` |  |
+| `./recurrence` | `./dist/adapters/recurrence.d.ts` | `./dist/adapters/recurrence.js` |  |
 | `./stores` | `./dist/stores/index.d.ts` | `./dist/stores/index.js` | `./dist/stores/index.js` |
 | `./testing` | `./dist/testing/index.d.ts` | `./dist/testing/index.js` |  |
 
@@ -37,10 +39,11 @@ Generated from `package.json` and the current `src/` tree.
 
 | Area | Files | Notes |
 | --- | --- | --- |
-| `src/adapters` | 8 | Scheduling provider integrations and availability helpers |
+| `src/adapters` | 10 | Scheduling provider integrations and availability helpers |
 | `src/capabilities` | 3 | Repo source area |
 | `src/components` | 13 | Svelte checkout and booking UI |
 | `src/core` | 6 | Effect-powered orchestration, error types, and utilities |
+| `src/fuzzy` | 7 | Repo source area |
 | `src/lib` | 3 | Small reusable helpers and Acuity iframe listener |
 | `src/onboarding` | 11 | Settings-driven onboarding and credential helpers |
 | `src/payments` | 6 | Payment adapters and capability contracts |

--- a/docs/generated/release-metadata.md
+++ b/docs/generated/release-metadata.md
@@ -11,9 +11,9 @@ Generated from `package.json`, `MODULE.bazel`, `BUILD.bazel`,
 
 | Surface | Value |
 | --- | --- |
-| package.json version | `0.9.1` |
-| MODULE.bazel version | `0.9.1` |
-| BUILD.bazel npm_package version | `0.9.1` |
+| package.json version | `0.9.2` |
+| MODULE.bazel version | `0.9.2` |
+| BUILD.bazel npm_package version | `0.9.2` |
 | BUILD.bazel package name | `@tummycrypt/scheduling-kit` |
 | .bazelversion | `8.1.1` |
 | pnpm packageManager | `pnpm@9.15.9` |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tummycrypt/scheduling-kit",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "description": "Backend-agnostic scheduling components with alternative payment support",
   "type": "module",
   "packageManager": "pnpm@9.15.9",


### PR DESCRIPTION
Patch release: 0.9.1 -> 0.9.2.

Carries #109 (TIN-2098 fuzzy scorer graduation): the backend-agnostic tolerant matching primitives now ship from `@tummycrypt/scheduling-kit/fuzzy`, including ServiceMatcher, DateMatcher, FieldMatcher, confidence/audit records, and deterministic tests. This gives scheduling-bridge a public-registry kit surface to consume instead of owning duplicated scorer code.

- package.json, MODULE.bazel, BUILD.bazel aligned at 0.9.2
- docs/generated surfaces regenerated; package surface now lists `./fuzzy` (and catches the existing `./recurrence` export)
- `pnpm check:release-metadata` green locally
- `pnpm build` + `pnpm exec publint` green locally
- `bazel build //:pkg` green locally

After merge: tag `v0.9.2`, publish workflow ships the derived GitHub Packages artifact with npmjs still disabled, then 0.9.2 is registered in tinyland-inc/bazel-registry so scheduling-bridge can consume the fuzzy module via `bazel_dep`.

Refs TIN-2098.
