### PR TITLE
feat(adapters): availability substrate — RRULE windows minus CalDAV busy overlay (TIN-1996)

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -35,6 +35,20 @@ bazel_dep(name = "platforms", version = "1.0.0")
 bazel_dep(name = "aspect_bazel_lib", version = "2.22.5")
 
 # =============================================================================
+# Inter-module dependencies (tinyland-inc/bazel-registry)
+# =============================================================================
+# Availability substrate (TIN-1996): kit is the first consumer of the
+# tinyland-calendar (RRULE recurrence) and tinyland-caldav-client (external
+# calendar busy overlay) registry modules. npm parity per the TIN-2035
+# delivery doctrine: each bazel_dep below is mirrored by an exact-version
+# @tummycrypt devDependency in package.json (enforced by
+# scripts/check-release-metadata.mjs), so the Bzlmod graph and the
+# pnpm-lock-translated npm graph resolve identical versions.
+
+bazel_dep(name = "tummycrypt_tinyland_calendar", version = "0.2.3")
+bazel_dep(name = "tummycrypt_tinyland_caldav_client", version = "0.2.3")
+
+# =============================================================================
 # JavaScript / TypeScript toolchain (Aspect Build)
 # =============================================================================
 

--- a/docs/generated/package-surface.md
+++ b/docs/generated/package-surface.md
@@ -22,6 +22,8 @@ Generated from `package.json` and the current `src/` tree.
 | --- | --- | --- | --- |
 | `.` | `./dist/index.d.ts` | `./dist/index.js` | `./dist/index.js` |
 | `./adapters` | `./dist/adapters/index.d.ts` | `./dist/adapters/index.js` |  |
+| `./availability` | `./dist/adapters/availability-substrate.d.ts` | `./dist/adapters/availability-substrate.js` |  |
+| `./caldav` | `./dist/adapters/caldav-busy.d.ts` | `./dist/adapters/caldav-busy.js` |  |
 | `./capabilities` | `./dist/capabilities/index.d.ts` | `./dist/capabilities/index.js` |  |
 | `./components` | `./dist/components/index.d.ts` | `./dist/components/index.js` | `./dist/components/index.js` |
 | `./core` | `./dist/core/index.d.ts` | `./dist/core/index.js` |  |
@@ -39,7 +41,7 @@ Generated from `package.json` and the current `src/` tree.
 
 | Area | Files | Notes |
 | --- | --- | --- |
-| `src/adapters` | 10 | Scheduling provider integrations and availability helpers |
+| `src/adapters` | 14 | Scheduling provider integrations and availability helpers |
 | `src/capabilities` | 3 | Repo source area |
 | `src/components` | 13 | Svelte checkout and booking UI |
 | `src/core` | 6 | Effect-powered orchestration, error types, and utilities |

--- a/package.json
+++ b/package.json
@@ -39,6 +39,14 @@
       "types": "./dist/adapters/recurrence.d.ts",
       "default": "./dist/adapters/recurrence.js"
     },
+    "./caldav": {
+      "types": "./dist/adapters/caldav-busy.d.ts",
+      "default": "./dist/adapters/caldav-busy.js"
+    },
+    "./availability": {
+      "types": "./dist/adapters/availability-substrate.d.ts",
+      "default": "./dist/adapters/availability-substrate.js"
+    },
     "./core": {
       "types": "./dist/core/index.d.ts",
       "default": "./dist/core/index.js"
@@ -100,6 +108,7 @@
   },
   "peerDependencies": {
     "@tummycrypt/tinyland-auth-pg": "^0.2.1",
+    "@tummycrypt/tinyland-caldav-client": "^0.2.3",
     "@tummycrypt/tinyland-calendar": "^0.2.3",
     "@skeletonlabs/skeleton": "^4.0.0",
     "@skeletonlabs/skeleton-svelte": "^4.0.0",
@@ -107,6 +116,9 @@
   },
   "peerDependenciesMeta": {
     "@tummycrypt/tinyland-auth-pg": {
+      "optional": true
+    },
+    "@tummycrypt/tinyland-caldav-client": {
       "optional": true
     },
     "@tummycrypt/tinyland-calendar": {
@@ -132,7 +144,8 @@
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/svelte": "^5.3.1",
     "@tummycrypt/tinyland-auth-pg": "^0.2.4",
-    "@tummycrypt/tinyland-calendar": "^0.2.3",
+    "@tummycrypt/tinyland-caldav-client": "0.2.3",
+    "@tummycrypt/tinyland-calendar": "0.2.3",
     "@types/node": "^20.0.0",
     "@typescript-eslint/parser": "^8.58.2",
     "@vitest/coverage-v8": "^4.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,8 +45,11 @@ importers:
       '@tummycrypt/tinyland-auth-pg':
         specifier: ^0.2.4
         version: 0.2.4(@tummycrypt/tinyland-auth@0.2.0(@sveltejs/kit@2.55.0(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.54.1)(vite@6.4.1(@types/node@20.19.37)))(svelte@5.54.1)(typescript@5.9.3)(vite@6.4.1(@types/node@20.19.37)))(svelte@5.54.1))(@types/pg@8.11.6)
+      '@tummycrypt/tinyland-caldav-client':
+        specifier: 0.2.3
+        version: 0.2.3
       '@tummycrypt/tinyland-calendar':
-        specifier: ^0.2.3
+        specifier: 0.2.3
         version: 0.2.3
       '@types/node':
         specifier: ^20.0.0
@@ -488,6 +491,9 @@ packages:
   '@neondatabase/serverless@0.10.4':
     resolution: {integrity: sha512-2nZuh3VUO9voBauuh+IGYRhGU/MskWHt1IuZvHcJw6GLjDgtqj/KViKo7SIrLdGLdot7vFbiRRw+BgEy3wT9HA==}
 
+  '@nodable/entities@2.2.0':
+    resolution: {integrity: sha512-9uGyhaQavEUMC8AIddIjau4NsnsXhou+j5sBAGojCM1oxmQpVKTWR/9JxABD6UAv12vpIms55fPZKFQEhG6uBg==}
+
   '@open-draft/deferred-promise@2.2.0':
     resolution: {integrity: sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA==}
 
@@ -757,6 +763,10 @@ packages:
         optional: true
       svelte:
         optional: true
+
+  '@tummycrypt/tinyland-caldav-client@0.2.3':
+    resolution: {integrity: sha512-u7g1EdypRBPZ0BrXFyub68R72TqQ/WSCM0yvrj28/VEHf5fBza23mokwZqZIlRAv1VfQmNOPtFdssEHCyVUsJQ==}
+    engines: {node: '>=22.0.0'}
 
   '@tummycrypt/tinyland-calendar@0.2.3':
     resolution: {integrity: sha512-afVYVzTro2p00VuksEUS5e6C5cSJk8W1WFxqFVJiJmGxC5wg8PxxFKIST1m7e0lDnIecrTiHjCkb/n84nPba5w==}
@@ -1049,6 +1059,9 @@ packages:
   ansi-styles@5.2.0:
     resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
     engines: {node: '>=10'}
+
+  anynum@1.0.1:
+    resolution: {integrity: sha512-N6//FLET/tXYNM/F6ABca1oH6fWB+KlTt909Le28WMDBk8oaT4vY17DCrwg2MvmuqUKt3Ni4N5dGJ/EoBgcO6A==}
 
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
@@ -1436,6 +1449,13 @@ packages:
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
+  fast-xml-builder@1.2.1:
+    resolution: {integrity: sha512-tPb5TTWfgfVx5BNSi2xV0eLr89POeXXn0dXIsCJ9m1narrWxeIyx6je9d7Rce/3NyXLbvuQmLkxq+RuxMWejvw==}
+
+  fast-xml-parser@5.9.3:
+    resolution: {integrity: sha512-brCNCeScma/kqa54J4PIDriSSSLssRkuYaUCpvHJulGc3HGI/xxKUCTDcYkAdqJsyb//ydpbxecjC3hB9+tb/g==}
+    hasBin: true
+
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
     engines: {node: '>=12.0.0'}
@@ -1543,6 +1563,9 @@ packages:
 
   is-reference@3.0.3:
     resolution: {integrity: sha512-ixkJoqQvAP88E6wLydLGGqCJsrFUnqoH6HnaczB8XmDH1oaWU+xxdptvikTgaEhtZ53Ky6YXiBuUI2WXLMCwjw==}
+
+  is-unsafe@1.0.1:
+    resolution: {integrity: sha512-CLK2+VdgERgD96EYm5lUQssZYlRg2tkZnbsxZoacmSiRxiFJ4Nk4SzjCl+Ur+v3kXIY9dTIdb3IH22y1mZ56LA==}
 
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
@@ -1738,6 +1761,10 @@ packages:
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
+
+  path-expression-matcher@1.6.1:
+    resolution: {integrity: sha512-h7bxdzhHk8Knyc4Tj+jMaa7fEEoUJy7p1qtbVgkYg1Uhpe5Np5VuGXCRZnkZvU+Q42M1vStt0ifa3ueykRJPmQ==}
+    engines: {node: '>=14.0.0'}
 
   path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
@@ -2030,6 +2057,9 @@ packages:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
 
+  strnum@2.4.1:
+    resolution: {integrity: sha512-M9eUSMT2dCB2cTNPG7UYj6KuK7RJR2SN2+yCV/fTW3xzTCS6EaGZ5pSMgDIjB7r8zSfTGk+dvvn9rTjpVS9Mwg==}
+
   supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
@@ -2278,6 +2308,10 @@ packages:
   xml-name-validator@5.0.0:
     resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
     engines: {node: '>=18'}
+
+  xml-naming@0.1.0:
+    resolution: {integrity: sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==}
+    engines: {node: '>=16.0.0'}
 
   xmlchars@2.2.0:
     resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
@@ -2627,6 +2661,8 @@ snapshots:
     dependencies:
       '@types/pg': 8.11.6
 
+  '@nodable/entities@2.2.0': {}
+
   '@open-draft/deferred-promise@2.2.0': {}
 
   '@open-draft/logger@0.3.0':
@@ -2915,6 +2951,11 @@ snapshots:
     optionalDependencies:
       '@sveltejs/kit': 2.55.0(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.54.1)(vite@6.4.1(@types/node@20.19.37)))(svelte@5.54.1)(typescript@5.9.3)(vite@6.4.1(@types/node@20.19.37))
       svelte: 5.54.1
+
+  '@tummycrypt/tinyland-caldav-client@0.2.3':
+    dependencies:
+      '@tummycrypt/tinyland-calendar': 0.2.3
+      fast-xml-parser: 5.9.3
 
   '@tummycrypt/tinyland-calendar@0.2.3': {}
 
@@ -3411,6 +3452,8 @@ snapshots:
 
   ansi-styles@5.2.0: {}
 
+  anynum@1.0.1: {}
+
   argparse@2.0.1: {}
 
   aria-query@5.3.0:
@@ -3732,6 +3775,20 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
+  fast-xml-builder@1.2.1:
+    dependencies:
+      path-expression-matcher: 1.6.1
+      xml-naming: 0.1.0
+
+  fast-xml-parser@5.9.3:
+    dependencies:
+      '@nodable/entities': 2.2.0
+      fast-xml-builder: 1.2.1
+      is-unsafe: 1.0.1
+      path-expression-matcher: 1.6.1
+      strnum: 2.4.1
+      xml-naming: 0.1.0
+
   fdir@6.5.0(picomatch@4.0.3):
     optionalDependencies:
       picomatch: 4.0.3
@@ -3822,6 +3879,8 @@ snapshots:
   is-reference@3.0.3:
     dependencies:
       '@types/estree': 1.0.8
+
+  is-unsafe@1.0.1: {}
 
   isexe@2.0.0: {}
 
@@ -4025,6 +4084,8 @@ snapshots:
       entities: 6.0.1
 
   path-exists@4.0.0: {}
+
+  path-expression-matcher@1.6.1: {}
 
   path-key@3.1.1: {}
 
@@ -4285,6 +4346,10 @@ snapshots:
 
   strip-json-comments@3.1.1: {}
 
+  strnum@2.4.1:
+    dependencies:
+      anynum: 1.0.1
+
   supports-color@7.2.0:
     dependencies:
       has-flag: 4.0.0
@@ -4494,6 +4559,8 @@ snapshots:
       strip-ansi: 6.0.1
 
   xml-name-validator@5.0.0: {}
+
+  xml-naming@0.1.0: {}
 
   xmlchars@2.2.0: {}
 

--- a/scripts/check-release-metadata.mjs
+++ b/scripts/check-release-metadata.mjs
@@ -236,11 +236,19 @@ const checks = [
 // devDependency on the corresponding @tummycrypt npm package. The lockfile
 // drives Bazel's npm_translate_lock, so a range here would let the Bzlmod
 // module graph and the npm graph resolve different versions.
-const bazelDepPattern =
-	/bazel_dep\(\s*name = "(tummycrypt_[a-z0-9_]+)",\s*version = "([^"]+)"\s*\)/g;
+//
+// Fail-closed against reformatting: each bazel_dep(...) call is matched as a
+// whole (any formatting, including buildifier multi-line with trailing
+// commas); a tummycrypt_* dep whose version attribute cannot be extracted
+// surfaces as a mismatch instead of silently skipping the check.
 const npmNameFromModule = (moduleName) =>
 	`@tummycrypt/${moduleName.replace(/^tummycrypt_/, '').replaceAll('_', '-')}`;
-for (const [, moduleName, moduleVersion] of moduleBazel.matchAll(bazelDepPattern)) {
+for (const [call] of moduleBazel.matchAll(/bazel_dep\s*\([^)]*\)/g)) {
+	const moduleName = /(?<![\w.])name\s*=\s*"(tummycrypt_[a-z0-9_]+)"/.exec(
+		call,
+	)?.[1];
+	if (!moduleName) continue;
+	const moduleVersion = /(?<![\w.])version\s*=\s*"([^"]+)"/.exec(call)?.[1];
 	checks.push({
 		label: `in-house npm parity for ${moduleName}`,
 		actual: packageJson.devDependencies?.[npmNameFromModule(moduleName)],

--- a/scripts/check-release-metadata.mjs
+++ b/scripts/check-release-metadata.mjs
@@ -231,6 +231,23 @@ const checks = [
 	},
 ];
 
+// In-house Bzlmod/npm parity (TIN-1996, per the TIN-2035 delivery doctrine):
+// every tummycrypt_* bazel_dep must be mirrored by an exact-version
+// devDependency on the corresponding @tummycrypt npm package. The lockfile
+// drives Bazel's npm_translate_lock, so a range here would let the Bzlmod
+// module graph and the npm graph resolve different versions.
+const bazelDepPattern =
+	/bazel_dep\(\s*name = "(tummycrypt_[a-z0-9_]+)",\s*version = "([^"]+)"\s*\)/g;
+const npmNameFromModule = (moduleName) =>
+	`@tummycrypt/${moduleName.replace(/^tummycrypt_/, '').replaceAll('_', '-')}`;
+for (const [, moduleName, moduleVersion] of moduleBazel.matchAll(bazelDepPattern)) {
+	checks.push({
+		label: `in-house npm parity for ${moduleName}`,
+		actual: packageJson.devDependencies?.[npmNameFromModule(moduleName)],
+		expected: moduleVersion,
+	});
+}
+
 const failures = checks.filter((check) => check.actual !== check.expected);
 
 if (failures.length > 0) {

--- a/src/adapters/__tests__/availability-substrate.test.ts
+++ b/src/adapters/__tests__/availability-substrate.test.ts
@@ -1,0 +1,373 @@
+/**
+ * Availability substrate tests (TIN-1996 slice 2): RRULE windows minus
+ * CalDAV busy overlay.
+ *
+ * These are the acceptance tests for the first real availability path over
+ * the substrate: recurring RRULE windows are expanded via the optional peer
+ * @tummycrypt/tinyland-calendar (really installed here, so the path runs
+ * against the published 0.2.3 module) and external-calendar busy time
+ * subtracts from the generated slots.
+ *
+ * Calendar facts used below (verified):
+ *   - 2026-06-01 is a Monday, 2026-06-03 a Wednesday, 2026-06-05 a Friday
+ *   - 2026-05-04 is a Monday
+ *   - June 2026 is EDT (UTC-4) in America/New_York
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { SlotConfig } from '../availability-engine.js';
+import type { CalDavBusyQuery } from '../caldav-busy.js';
+import {
+  getSubstrateAvailability,
+  type SubstrateDayAvailability,
+} from '../availability-substrate.js';
+
+// Freeze the clock before every test date so the engine's minimum-advance
+// filter (`now + minAdvanceHours`) never eats slots on a real-clock run.
+// Per-test (beforeEach, matching availability-engine.test.ts): the suite
+// setup restores real timers between tests, so a beforeAll freeze silently
+// thaws after the first test.
+const FROZEN_NOW = new Date('2026-05-01T00:00:00.000Z');
+
+beforeEach(() => {
+  vi.useFakeTimers({ toFake: ['Date'] });
+  vi.setSystemTime(FROZEN_NOW);
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+const CONFIG: SlotConfig = {
+  duration: 60,
+  interval: 60,
+  buffer: 0,
+  minAdvanceHours: 0,
+  timezone: 'UTC',
+};
+
+/** Mon/Wed/Fri 09:00–12:00 window (three 60-minute slots per day). */
+const MWF_HOURS = [
+  {
+    rrule: 'RRULE:FREQ=WEEKLY;BYDAY=MO,WE,FR',
+    dtstart: '2026-06-01',
+    window: { opens: '09:00', closes: '12:00' },
+  },
+];
+
+const WEEK = { start: '2026-06-01', end: '2026-06-05' };
+
+const slotStarts = (days: SubstrateDayAvailability[]): Record<string, string[]> =>
+  Object.fromEntries(
+    days.map((d) => [d.date, d.slots.map((s) => s.datetime)]),
+  );
+
+const FULL_MON = [
+  '2026-06-01T09:00:00.000Z',
+  '2026-06-01T10:00:00.000Z',
+  '2026-06-01T11:00:00.000Z',
+];
+const FULL_FRI = [
+  '2026-06-05T09:00:00.000Z',
+  '2026-06-05T10:00:00.000Z',
+  '2026-06-05T11:00:00.000Z',
+];
+
+describe('getSubstrateAvailability — RRULE windows minus busy', () => {
+  it('expands windows into full slots when nothing is busy', async () => {
+    const days = await getSubstrateAvailability(
+      { hours: MWF_HOURS },
+      WEEK,
+      CONFIG,
+    );
+
+    expect(days.map((d) => d.date)).toEqual([
+      '2026-06-01',
+      '2026-06-03',
+      '2026-06-05',
+    ]);
+    expect(days[0].window).toEqual({ opens: '09:00', closes: '12:00' });
+    expect(slotStarts(days)['2026-06-03']).toEqual([
+      '2026-06-03T09:00:00.000Z',
+      '2026-06-03T10:00:00.000Z',
+      '2026-06-03T11:00:00.000Z',
+    ]);
+  });
+
+  it('subtracts a one-off CalDAV busy event from that day only', async () => {
+    const days = await getSubstrateAvailability(
+      {
+        hours: MWF_HOURS,
+        busyEvents: [
+          {
+            uid: 'external-mtg',
+            dtstart: '2026-06-03T10:00:00.000Z',
+            dtend: '2026-06-03T11:00:00.000Z',
+          },
+        ],
+      },
+      WEEK,
+      CONFIG,
+    );
+
+    expect(slotStarts(days)).toEqual({
+      '2026-06-01': FULL_MON,
+      '2026-06-03': [
+        '2026-06-03T09:00:00.000Z',
+        '2026-06-03T11:00:00.000Z',
+      ],
+      '2026-06-05': FULL_FRI,
+    });
+  });
+
+  it('subtracts a recurring busy event (daily standup) on every window day', async () => {
+    const days = await getSubstrateAvailability(
+      {
+        hours: MWF_HOURS,
+        busyEvents: [
+          {
+            uid: 'standup',
+            // Master starts before the range — occurrences still land in it.
+            dtstart: '2026-05-04T09:00:00.000Z',
+            dtend: '2026-05-04T09:30:00.000Z',
+            rrule: 'FREQ=DAILY',
+          },
+        ],
+      },
+      WEEK,
+      CONFIG,
+    );
+
+    expect(slotStarts(days)).toEqual({
+      '2026-06-01': ['2026-06-01T10:00:00.000Z', '2026-06-01T11:00:00.000Z'],
+      '2026-06-03': ['2026-06-03T10:00:00.000Z', '2026-06-03T11:00:00.000Z'],
+      '2026-06-05': ['2026-06-05T10:00:00.000Z', '2026-06-05T11:00:00.000Z'],
+    });
+  });
+
+  it('restores the slot on a recurring busy exdate', async () => {
+    const days = await getSubstrateAvailability(
+      {
+        hours: MWF_HOURS,
+        busyEvents: [
+          {
+            dtstart: '2026-05-04T09:00:00.000Z',
+            dtend: '2026-05-04T09:30:00.000Z',
+            rrule: 'FREQ=DAILY',
+            exdates: ['2026-06-03'],
+          },
+        ],
+      },
+      WEEK,
+      CONFIG,
+    );
+
+    expect(slotStarts(days)['2026-06-03']).toEqual([
+      '2026-06-03T09:00:00.000Z',
+      '2026-06-03T10:00:00.000Z',
+      '2026-06-03T11:00:00.000Z',
+    ]);
+    expect(slotStarts(days)['2026-06-01']).toEqual([
+      '2026-06-01T10:00:00.000Z',
+      '2026-06-01T11:00:00.000Z',
+    ]);
+  });
+
+  it('returns the window date with empty slots when busy covers it fully', async () => {
+    const days = await getSubstrateAvailability(
+      {
+        hours: MWF_HOURS,
+        busyEvents: [
+          {
+            dtstart: '2026-06-05T08:00:00.000Z',
+            dtend: '2026-06-05T13:00:00.000Z',
+          },
+        ],
+      },
+      WEEK,
+      CONFIG,
+    );
+
+    expect(days.map((d) => d.date)).toEqual([
+      '2026-06-01',
+      '2026-06-03',
+      '2026-06-05',
+    ]);
+    expect(slotStarts(days)['2026-06-05']).toEqual([]);
+  });
+
+  it('ignores cancelled busy events', async () => {
+    const days = await getSubstrateAvailability(
+      {
+        hours: MWF_HOURS,
+        busyEvents: [
+          {
+            dtstart: '2026-06-03T10:00:00.000Z',
+            dtend: '2026-06-03T11:00:00.000Z',
+            status: 'cancelled',
+          },
+        ],
+      },
+      WEEK,
+      CONFIG,
+    );
+
+    expect(slotStarts(days)['2026-06-03']).toHaveLength(3);
+  });
+
+  it('blocks morning slots with a busy event spilling over midnight', async () => {
+    const days = await getSubstrateAvailability(
+      {
+        hours: MWF_HOURS,
+        busyEvents: [
+          {
+            dtstart: '2026-06-02T20:00:00.000Z', // Tuesday evening
+            dtend: '2026-06-03T10:00:00.000Z', // ends Wednesday 10:00
+          },
+        ],
+      },
+      WEEK,
+      CONFIG,
+    );
+
+    expect(slotStarts(days)['2026-06-03']).toEqual([
+      '2026-06-03T10:00:00.000Z',
+      '2026-06-03T11:00:00.000Z',
+    ]);
+  });
+
+  it('blocks the whole day for an all-day external event', async () => {
+    const days = await getSubstrateAvailability(
+      {
+        hours: MWF_HOURS,
+        busyEvents: [{ uid: 'vacation', dtstart: '2026-06-05' }],
+      },
+      WEEK,
+      CONFIG,
+    );
+
+    expect(slotStarts(days)['2026-06-05']).toEqual([]);
+    expect(slotStarts(days)['2026-06-03']).toHaveLength(3);
+  });
+
+  it('queries an injected CalDAV busy source over the padded range', async () => {
+    const queries: Array<CalDavBusyQuery | undefined> = [];
+    const busySource = {
+      queryEvents: async (filters?: CalDavBusyQuery) => {
+        queries.push(filters);
+        return [
+          {
+            dtstart: '2026-06-03T10:00:00.000Z',
+            dtend: '2026-06-03T11:00:00.000Z',
+          },
+        ];
+      },
+    };
+
+    const days = await getSubstrateAvailability(
+      { hours: MWF_HOURS, busySource },
+      WEEK,
+      CONFIG,
+    );
+
+    expect(queries).toEqual([
+      { from: '2026-05-31T00:00:00.000Z', to: '2026-06-06T23:59:59.999Z' },
+    ]);
+    expect(slotStarts(days)['2026-06-03']).toEqual([
+      '2026-06-03T09:00:00.000Z',
+      '2026-06-03T11:00:00.000Z',
+    ]);
+  });
+
+  it('never queries the busy source when no window date lands in the range', async () => {
+    const queryEvents = vi.fn(async () => []);
+    const days = await getSubstrateAvailability(
+      { hours: MWF_HOURS, busySource: { queryEvents } },
+      { start: '2026-06-07', end: '2026-06-07' }, // Sunday — no MWF window
+      CONFIG,
+    );
+
+    expect(days).toEqual([]);
+    expect(queryEvents).not.toHaveBeenCalled();
+  });
+
+  it('subtracts recurring in-house blocks and materialized occupied blocks too', async () => {
+    const days = await getSubstrateAvailability(
+      {
+        hours: MWF_HOURS,
+        blocks: [
+          {
+            rrule: 'FREQ=WEEKLY;BYDAY=MO',
+            dtstart: '2026-06-01T09:00:00.000Z',
+            durationMinutes: 60,
+          },
+        ],
+        occupied: [
+          {
+            start: new Date('2026-06-01T11:00:00.000Z'),
+            end: new Date('2026-06-01T12:00:00.000Z'),
+          },
+        ],
+      },
+      WEEK,
+      CONFIG,
+    );
+
+    expect(slotStarts(days)['2026-06-01']).toEqual([
+      '2026-06-01T10:00:00.000Z',
+    ]);
+    expect(slotStarts(days)['2026-06-03']).toHaveLength(3);
+  });
+
+  it('lets the first hours rule win when two windows land on the same date', async () => {
+    const days = await getSubstrateAvailability(
+      {
+        hours: [
+          ...MWF_HOURS,
+          {
+            rrule: 'FREQ=WEEKLY;BYDAY=MO',
+            dtstart: '2026-06-01',
+            window: { opens: '08:00', closes: '10:00' },
+          },
+        ],
+      },
+      WEEK,
+      CONFIG,
+    );
+
+    expect(slotStarts(days)['2026-06-01']).toEqual(FULL_MON);
+  });
+
+  it('computes windows minus busy in a non-UTC business timezone', async () => {
+    const days = await getSubstrateAvailability(
+      {
+        hours: [
+          {
+            rrule: 'FREQ=WEEKLY;BYDAY=WE',
+            dtstart: '2026-06-03',
+            window: { opens: '09:00', closes: '12:00' }, // EDT wall clock
+          },
+        ],
+        busyEvents: [
+          {
+            // 10:00–11:00 EDT
+            dtstart: '2026-06-03T14:00:00.000Z',
+            dtend: '2026-06-03T15:00:00.000Z',
+          },
+        ],
+      },
+      { start: '2026-06-03', end: '2026-06-03' },
+      { ...CONFIG, timezone: 'America/New_York' },
+    );
+
+    expect(slotStarts(days)).toEqual({
+      '2026-06-03': ['2026-06-03T13:00:00.000Z', '2026-06-03T15:00:00.000Z'],
+    });
+  });
+
+  it('returns [] for an empty substrate without touching any peer', async () => {
+    await expect(
+      getSubstrateAvailability({ hours: [] }, WEEK, CONFIG),
+    ).resolves.toEqual([]);
+  });
+});

--- a/src/adapters/__tests__/caldav-busy.test.ts
+++ b/src/adapters/__tests__/caldav-busy.test.ts
@@ -142,6 +142,17 @@ describe('busyBlocksFromEvents — all-day events (DATE-valued DTSTART)', () => 
     ]);
   });
 
+  it('rejects an all-day event whose dtend equals dtstart (never silently under-blocks the day)', async () => {
+    // RFC 5545 §3.8.2.2 requires DTEND strictly after a DATE-valued DTSTART;
+    // producers emitting this malformation mean "busy all day".
+    await expect(
+      busyBlocksFromEvents(
+        [{ uid: 'bad-allday', dtstart: '2026-06-03', dtend: '2026-06-03' }],
+        JUNE_1_TO_5,
+      ),
+    ).rejects.toThrow(/DTEND strictly after DTSTART/);
+  });
+
   it('treats a DATE-valued dtend as exclusive per RFC 5545', async () => {
     const blocks = await busyBlocksFromEvents(
       [{ dtstart: '2026-06-03', dtend: '2026-06-05' }],
@@ -309,6 +320,23 @@ describe('loadCalDavClient — optional peer @tummycrypt/tinyland-caldav-client'
       /pnpm add @tummycrypt\/tinyland-caldav-client/,
     );
     expect((error as Error).message).toMatch(/Cause: /);
+  });
+
+  it('does not mislabel constructor errors as peer-unavailable', async () => {
+    vi.resetModules();
+    vi.doMock('@tummycrypt/tinyland-caldav-client', () => ({
+      CalendarClient: class {
+        constructor() {
+          throw new Error('bad baseUrl');
+        }
+      },
+    }));
+    const mod = await import('../caldav-busy.js');
+
+    const error = await mod.loadCalDavClient('::garbage::').catch((e: unknown) => e);
+
+    expect((error as Error).message).toBe('bad baseUrl');
+    expect((error as Error).name).not.toBe('CalDavPeerUnavailableError');
   });
 
   it('exposes the typed error class on the public surface', () => {

--- a/src/adapters/__tests__/caldav-busy.test.ts
+++ b/src/adapters/__tests__/caldav-busy.test.ts
@@ -1,0 +1,319 @@
+/**
+ * CalDAV busy overlay tests (TIN-1996 slice 2)
+ *
+ * Calendar facts used below (verified):
+ *   - 2026-06-01 is a Monday
+ *   - June 2026 is EDT (UTC-4) in America/New_York
+ */
+
+import { afterEach, describe, expect, it } from 'vitest';
+import { vi } from 'vitest';
+import {
+  busyBlocksFromEvents,
+  fetchCalDavBusy,
+  loadCalDavClient,
+  CalDavPeerUnavailableError,
+  type CalDavBusyEvent,
+  type CalDavBusyQuery,
+} from '../caldav-busy.js';
+
+const JUNE_1_TO_5 = { start: '2026-06-01', end: '2026-06-05' };
+
+const starts = async (
+  events: CalDavBusyEvent[],
+  range = JUNE_1_TO_5,
+): Promise<string[]> => {
+  const blocks = await busyBlocksFromEvents(events, range);
+  return blocks.map((b) => b.start.toISOString());
+};
+
+describe('busyBlocksFromEvents — one-off events', () => {
+  it('keeps the exact interval of events intersecting the range', async () => {
+    const blocks = await busyBlocksFromEvents(
+      [
+        {
+          uid: 'a',
+          dtstart: '2026-06-03T10:00:00.000Z',
+          dtend: '2026-06-03T11:00:00.000Z',
+        },
+      ],
+      JUNE_1_TO_5,
+    );
+    expect(blocks).toEqual([
+      {
+        start: new Date('2026-06-03T10:00:00.000Z'),
+        end: new Date('2026-06-03T11:00:00.000Z'),
+      },
+    ]);
+  });
+
+  it('drops events far outside the range but keeps midnight spillover', async () => {
+    await expect(
+      starts([
+        // > 1 day before the range — irrelevant to any slot in it
+        { dtstart: '2026-05-01T10:00:00Z', dtend: '2026-05-01T11:00:00Z' },
+        // starts the evening before a range day and spills into it
+        { dtstart: '2026-06-02T23:00:00Z', dtend: '2026-06-03T10:00:00Z' },
+      ]),
+    ).resolves.toEqual(['2026-06-02T23:00:00.000Z']);
+  });
+
+  it('skips cancelled events', async () => {
+    await expect(
+      starts([
+        {
+          dtstart: '2026-06-03T10:00:00Z',
+          dtend: '2026-06-03T11:00:00Z',
+          status: 'cancelled',
+        },
+      ]),
+    ).resolves.toEqual([]);
+  });
+
+  it('treats a DATE-TIME dtstart without dtend as zero-duration (blocks nothing)', async () => {
+    await expect(starts([{ dtstart: '2026-06-03T10:00:00Z' }])).resolves.toEqual(
+      [],
+    );
+  });
+
+  it('treats dtend === dtstart as zero-duration (blocks nothing)', async () => {
+    await expect(
+      starts([
+        { dtstart: '2026-06-03T10:00:00Z', dtend: '2026-06-03T10:00:00Z' },
+      ]),
+    ).resolves.toEqual([]);
+  });
+
+  it('rejects unparseable dtstart with the event uid in the message', async () => {
+    await expect(
+      busyBlocksFromEvents(
+        [{ uid: 'bad-event', dtstart: 'garbage' }],
+        JUNE_1_TO_5,
+      ),
+    ).rejects.toThrow(/CalDAV event bad-event has an unparseable dtstart/);
+  });
+
+  it('rejects events that end before they start', async () => {
+    await expect(
+      busyBlocksFromEvents(
+        [
+          {
+            uid: 'inverted',
+            dtstart: '2026-06-03T11:00:00Z',
+            dtend: '2026-06-03T10:00:00Z',
+          },
+        ],
+        JUNE_1_TO_5,
+      ),
+    ).rejects.toThrow(/ends before it starts/);
+  });
+
+  it('rejects inverted ranges', async () => {
+    await expect(
+      busyBlocksFromEvents([], { start: '2026-06-05', end: '2026-06-01' }),
+    ).rejects.toThrow(/precedes/);
+  });
+});
+
+describe('busyBlocksFromEvents — all-day events (DATE-valued DTSTART)', () => {
+  it('blocks the full UTC day without a timezone', async () => {
+    const blocks = await busyBlocksFromEvents(
+      [{ dtstart: '2026-06-03' }],
+      JUNE_1_TO_5,
+    );
+    expect(blocks).toEqual([
+      {
+        start: new Date('2026-06-03T00:00:00.000Z'),
+        end: new Date('2026-06-04T00:00:00.000Z'),
+      },
+    ]);
+  });
+
+  it('blocks the local day when a timezone is set', async () => {
+    const blocks = await busyBlocksFromEvents(
+      [{ dtstart: '2026-06-03', timezone: 'America/New_York' }],
+      JUNE_1_TO_5,
+    );
+    expect(blocks).toEqual([
+      {
+        start: new Date('2026-06-03T04:00:00.000Z'), // midnight EDT
+        end: new Date('2026-06-04T04:00:00.000Z'),
+      },
+    ]);
+  });
+
+  it('treats a DATE-valued dtend as exclusive per RFC 5545', async () => {
+    const blocks = await busyBlocksFromEvents(
+      [{ dtstart: '2026-06-03', dtend: '2026-06-05' }],
+      JUNE_1_TO_5,
+    );
+    expect(blocks).toEqual([
+      {
+        start: new Date('2026-06-03T00:00:00.000Z'),
+        end: new Date('2026-06-05T00:00:00.000Z'),
+      },
+    ]);
+  });
+});
+
+describe('busyBlocksFromEvents — recurring events', () => {
+  it('expands RRULE events through the slice-1 walker', async () => {
+    const blocks = await busyBlocksFromEvents(
+      [
+        {
+          dtstart: '2026-06-01T09:00:00.000Z',
+          dtend: '2026-06-01T09:30:00.000Z',
+          rrule: 'RRULE:FREQ=DAILY',
+        },
+      ],
+      { start: '2026-06-01', end: '2026-06-03' },
+    );
+    const inRange = blocks.map((b) => b.start.toISOString());
+    expect(inRange).toEqual(
+      expect.arrayContaining([
+        '2026-06-01T09:00:00.000Z',
+        '2026-06-02T09:00:00.000Z',
+        '2026-06-03T09:00:00.000Z',
+      ]),
+    );
+    expect(blocks[0].end.getTime() - blocks[0].start.getTime()).toBe(
+      30 * 60_000,
+    );
+  });
+
+  it('keeps occurrences that start before the range but spill into it', async () => {
+    const blocks = await busyBlocksFromEvents(
+      [
+        {
+          dtstart: '2026-05-20T23:00:00.000Z',
+          dtend: '2026-05-21T00:30:00.000Z',
+          rrule: 'FREQ=DAILY',
+        },
+      ],
+      { start: '2026-06-01', end: '2026-06-02' },
+    );
+    // The 05-31T23:00Z occurrence spills into June 1 and must be kept.
+    expect(blocks.map((b) => b.start.toISOString())).toContain(
+      '2026-05-31T23:00:00.000Z',
+    );
+  });
+
+  it('honors exdates on recurring busy events', async () => {
+    const startList = await starts(
+      [
+        {
+          dtstart: '2026-06-01T09:00:00.000Z',
+          dtend: '2026-06-01T09:30:00.000Z',
+          rrule: 'FREQ=DAILY',
+          exdates: ['2026-06-02'],
+        },
+      ],
+      { start: '2026-06-01', end: '2026-06-03' },
+    );
+    expect(startList).toContain('2026-06-01T09:00:00.000Z');
+    expect(startList).toContain('2026-06-03T09:00:00.000Z');
+    expect(startList).not.toContain('2026-06-02T09:00:00.000Z');
+  });
+
+  it('fails loud on RRULEs outside the supported subset (never under-blocks)', async () => {
+    await expect(
+      busyBlocksFromEvents(
+        [
+          {
+            dtstart: '2026-06-01T09:00:00Z',
+            dtend: '2026-06-01T10:00:00Z',
+            rrule: 'FREQ=MONTHLY;BYDAY=MO;BYSETPOS=2',
+          },
+        ],
+        JUNE_1_TO_5,
+      ),
+    ).rejects.toMatchObject({ code: 'RECURRENCE_UNSUPPORTED' });
+  });
+
+  it('skips cancelled recurring events', async () => {
+    await expect(
+      starts([
+        {
+          dtstart: '2026-06-01T09:00:00Z',
+          dtend: '2026-06-01T09:30:00Z',
+          rrule: 'FREQ=DAILY',
+          status: 'cancelled',
+        },
+      ]),
+    ).resolves.toEqual([]);
+  });
+});
+
+describe('fetchCalDavBusy', () => {
+  it('queries the source with a padded window and converts the events', async () => {
+    const queries: Array<CalDavBusyQuery | undefined> = [];
+    const source = {
+      queryEvents: async (filters?: CalDavBusyQuery) => {
+        queries.push(filters);
+        return [
+          {
+            dtstart: '2026-06-03T10:00:00.000Z',
+            dtend: '2026-06-03T11:00:00.000Z',
+          },
+        ];
+      },
+    };
+
+    const blocks = await fetchCalDavBusy(source, JUNE_1_TO_5);
+
+    expect(queries).toEqual([
+      {
+        from: '2026-05-31T00:00:00.000Z',
+        to: '2026-06-06T23:59:59.999Z',
+      },
+    ]);
+    expect(blocks).toEqual([
+      {
+        start: new Date('2026-06-03T10:00:00.000Z'),
+        end: new Date('2026-06-03T11:00:00.000Z'),
+      },
+    ]);
+  });
+});
+
+describe('loadCalDavClient — optional peer @tummycrypt/tinyland-caldav-client', () => {
+  afterEach(() => {
+    vi.doUnmock('@tummycrypt/tinyland-caldav-client');
+    vi.resetModules();
+  });
+
+  it('constructs a real CalendarClient when the peer is installed', async () => {
+    const client = await loadCalDavClient('http://localhost:5232');
+    expect(typeof client.queryEvents).toBe('function');
+  });
+
+  it('rejects with an actionable error when the peer is absent', async () => {
+    vi.resetModules();
+    vi.doMock('@tummycrypt/tinyland-caldav-client', () => {
+      throw new Error(
+        "Cannot find module '@tummycrypt/tinyland-caldav-client'",
+      );
+    });
+    const mod = await import('../caldav-busy.js');
+
+    const error = await mod
+      .loadCalDavClient()
+      .catch((e: unknown) => e);
+
+    // Fresh module instance after resetModules — match shape, not identity.
+    expect(error).toMatchObject({
+      name: 'CalDavPeerUnavailableError',
+      code: 'CALDAV_PEER_UNAVAILABLE',
+    });
+    expect((error as Error).message).toMatch(
+      /pnpm add @tummycrypt\/tinyland-caldav-client/,
+    );
+    expect((error as Error).message).toMatch(/Cause: /);
+  });
+
+  it('exposes the typed error class on the public surface', () => {
+    expect(new CalDavPeerUnavailableError(new Error('x')).code).toBe(
+      'CALDAV_PEER_UNAVAILABLE',
+    );
+  });
+});

--- a/src/adapters/availability-substrate.ts
+++ b/src/adapters/availability-substrate.ts
@@ -1,0 +1,127 @@
+/**
+ * Availability substrate (TIN-1996, slice 2): RRULE windows minus busy.
+ *
+ * The first real availability path over the substrate modules: RRULE-backed
+ * recurring availability windows (expanded by `./recurrence.ts` via the
+ * optional peer `@tummycrypt/tinyland-calendar`) minus a CalDAV busy overlay
+ * (`./caldav-busy.ts`, events from the optional peer
+ * `@tummycrypt/tinyland-caldav-client` or any structural equivalent).
+ *
+ * The availability engine stays pure and untouched: this module only
+ * composes `expandRecurrence` + `busyBlocksFromEvents` into the engine's
+ * existing inputs and calls `getAvailableSlots` per window date.
+ */
+
+import {
+  getAvailableSlots,
+  type GeneratedSlot,
+  type HoursWindow,
+  type OccupiedBlock,
+  type SlotConfig,
+} from './availability-engine.js';
+import {
+  busyBlocksFromEvents,
+  fetchCalDavBusy,
+  type CalDavBusyEvent,
+  type CalDavBusySource,
+} from './caldav-busy.js';
+import {
+  expandRecurrence,
+  type RecurrenceExpansionRange,
+  type RecurringBlock,
+  type RecurringHoursRule,
+} from './recurrence.js';
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+export interface AvailabilitySubstrate {
+  /** RRULE-backed recurring availability windows (the only hours source). */
+  hours: RecurringHoursRule[];
+  /** Recurring in-house closures/blocks (expanded to busy time). */
+  blocks?: RecurringBlock[];
+  /** Pre-fetched external-calendar events overlaid as busy time. */
+  busyEvents?: CalDavBusyEvent[];
+  /** CalDAV source queried for additional busy events over the range. */
+  busySource?: CalDavBusySource;
+  /** Already-materialized occupied blocks (bookings, holds, reservations). */
+  occupied?: OccupiedBlock[];
+}
+
+export interface SubstrateDayAvailability {
+  /** Window date (YYYY-MM-DD). */
+  date: string;
+  /** Effective hours window for the date. */
+  window: HoursWindow;
+  /** Available slots after subtracting every busy input (may be empty). */
+  slots: GeneratedSlot[];
+}
+
+// ---------------------------------------------------------------------------
+// Windows minus busy
+// ---------------------------------------------------------------------------
+
+/**
+ * Compute per-date availability over an inclusive range: expand the
+ * substrate's RRULE windows into date-specific hours, union every busy
+ * input (recurring blocks, external-calendar events, materialized
+ * occupied blocks), and generate slots for each window date.
+ *
+ * Returns one entry per date that has an availability window, in date
+ * order, including dates whose slots were fully consumed by busy time
+ * (empty `slots`). Dates without a window are omitted (closed).
+ *
+ * When multiple hours rules land on the same date, the first rule's window
+ * wins — the same `overrides.find(...)` semantics the engine's
+ * `getDatesWithAvailability` applies.
+ *
+ * The optional peers load lazily: `@tummycrypt/tinyland-calendar` on first
+ * RRULE expansion (rejecting with `RecurrencePeerUnavailableError` when
+ * absent), and the CalDAV peer never — `busySource` is injected, so any
+ * structurally compatible client works. `busySource` is only queried when
+ * at least one window date exists in the range.
+ */
+export const getSubstrateAvailability = async (
+  substrate: AvailabilitySubstrate,
+  range: RecurrenceExpansionRange,
+  config: SlotConfig,
+): Promise<SubstrateDayAvailability[]> => {
+  const { overrides, occupied: recurringBusy } = await expandRecurrence(
+    { hours: substrate.hours, blocks: substrate.blocks },
+    range,
+  );
+  if (overrides.length === 0) return [];
+
+  const eventBusy = substrate.busyEvents?.length
+    ? await busyBlocksFromEvents(substrate.busyEvents, range)
+    : [];
+  const fetchedBusy = substrate.busySource
+    ? await fetchCalDavBusy(substrate.busySource, range)
+    : [];
+
+  const occupied: OccupiedBlock[] = [
+    ...recurringBusy,
+    ...eventBusy,
+    ...fetchedBusy,
+    ...(substrate.occupied ?? []),
+  ];
+
+  const seen = new Set<string>();
+  const days: SubstrateDayAvailability[] = [];
+  for (const override of overrides) {
+    if (seen.has(override.date)) continue; // first rule wins per engine semantics
+    seen.add(override.date);
+    if (override.opens === null || override.closes === null) continue; // unreachable for expanded windows
+    const window: HoursWindow = {
+      opens: override.opens,
+      closes: override.closes,
+    };
+    days.push({
+      date: override.date,
+      window,
+      slots: getAvailableSlots(override.date, null, override, occupied, config),
+    });
+  }
+  return days;
+};

--- a/src/adapters/caldav-busy.ts
+++ b/src/adapters/caldav-busy.ts
@@ -34,7 +34,11 @@
  * - A DATE-valued (all-day) `DTSTART` with no `DTEND` blocks the whole
  *   calendar day — local to `timezone` when set, UTC otherwise.
  * - A DATE-valued `DTEND` is exclusive (the block ends at local midnight of
- *   that date).
+ *   that date). An all-day event whose interval collapses to zero
+ *   (`DTEND` equal to `DTSTART` — invalid per RFC 5545 §3.8.2.2, which
+ *   requires DTEND strictly after DTSTART) fails loud: producers emitting
+ *   that malformation mean "busy all day", so silently blocking nothing
+ *   would under-block a full day.
  * - Recurring durations are minute-precision (`Math.ceil`), matching the
  *   expander's `RecurringBlock.durationMinutes` contract; all-day recurring
  *   events use a fixed 24h/day duration, so occurrences that cross a DST
@@ -131,12 +135,15 @@ export class CalDavPeerUnavailableError extends Error {
 export const loadCalDavClient = async (
   baseUrl?: string,
 ): Promise<CalDavBusySource> => {
+  let mod: typeof import('@tummycrypt/tinyland-caldav-client');
   try {
-    const mod = await import('@tummycrypt/tinyland-caldav-client');
-    return new mod.CalendarClient(baseUrl);
+    mod = await import('@tummycrypt/tinyland-caldav-client');
   } catch (error) {
     throw new CalDavPeerUnavailableError(error);
   }
+  // Construction errors (e.g. a bad baseUrl) propagate as-is — they are not
+  // peer-availability problems and must not be mislabeled as such.
+  return new mod.CalendarClient(baseUrl);
 };
 
 // ---------------------------------------------------------------------------
@@ -231,7 +238,20 @@ const eventInterval = (event: CalDavBusyEvent): EventInterval | undefined => {
       `${label} ends before it starts (dtstart ${event.dtstart}, dtend ${event.dtend})`,
     );
   }
-  if (end.getTime() === start.getTime()) return undefined;
+  if (end.getTime() === start.getTime()) {
+    if (allDay) {
+      // RFC 5545 §3.8.2.2: DTEND MUST be strictly after a DATE-valued
+      // DTSTART. Producers emitting DTEND == DTSTART mean "busy all day";
+      // silently blocking nothing would under-block a full day.
+      throw new Error(
+        `${label} is all-day (DATE-valued dtstart ${event.dtstart}) but its ` +
+          `interval is zero-length (dtend ${event.dtend}); RFC 5545 requires ` +
+          `an exclusive DTEND strictly after DTSTART — use dtend ` +
+          `${nextDateStr(event.dtstart)} to block the day`,
+      );
+    }
+    return undefined; // DATE-TIME zero-duration: valid per RFC, blocks nothing
+  }
 
   return { start, end };
 };

--- a/src/adapters/caldav-busy.ts
+++ b/src/adapters/caldav-busy.ts
@@ -1,0 +1,332 @@
+/**
+ * CalDAV busy overlay (TIN-1996, slice 2)
+ *
+ * Converts external-calendar events — as returned by the optional peer
+ * `@tummycrypt/tinyland-caldav-client`'s `CalendarClient` (`queryEvents` /
+ * `listEvents`) — into the availability engine's `OccupiedBlock` inputs, so
+ * external busy time subtracts from RRULE-expanded availability windows
+ * ("windows minus busy", see `./availability-substrate.ts`).
+ *
+ * Dependency posture (mirrors `./recurrence.ts`):
+ * - The peer is loaded lazily via dynamic import only inside
+ *   `loadCalDavClient`. Everything else in this module is peer-free: types
+ *   are structural (assignable from the peer's `CalendarEvent` without
+ *   importing it), and `busyBlocksFromEvents` accepts plain objects, so
+ *   consumers can fetch events however they like and kit never hard-requires
+ *   the peer.
+ * - When the peer is absent, `loadCalDavClient` rejects with an actionable
+ *   `CalDavPeerUnavailableError`.
+ *
+ * Recurring busy events route through the slice-1 expander
+ * (`expandRecurrence`), which uses the optional peer
+ * `@tummycrypt/tinyland-calendar` for RRULE tokenization and carries the
+ * documented workarounds for the verified upstream gaps at
+ * tinyland-calendar 0.2.3 (BYDAY, UNTIL, silent-drop parsing — see the
+ * `./recurrence.ts` module docs and TIN-1996). RRULEs outside the supported
+ * subset throw `UnsupportedRecurrenceError` — an external event we cannot
+ * expand faithfully fails loud instead of silently under-blocking (which
+ * would risk double-booking).
+ *
+ * RFC 5545 semantics honored here:
+ * - `status: 'cancelled'` events block nothing.
+ * - A DATE-TIME `DTSTART` with no `DTEND` is a zero-duration event and
+ *   blocks nothing (RFC 5545 §3.6.1).
+ * - A DATE-valued (all-day) `DTSTART` with no `DTEND` blocks the whole
+ *   calendar day — local to `timezone` when set, UTC otherwise.
+ * - A DATE-valued `DTEND` is exclusive (the block ends at local midnight of
+ *   that date).
+ * - Recurring durations are minute-precision (`Math.ceil`), matching the
+ *   expander's `RecurringBlock.durationMinutes` contract; all-day recurring
+ *   events use a fixed 24h/day duration, so occurrences that cross a DST
+ *   transition may over/under-shoot local midnight by the DST offset.
+ *
+ * Known upstream gap (documented in the TIN-1996 design spike): at
+ * caldav-client 0.2.3, `package.json` omits its `@tummycrypt/tinyland-calendar`
+ * type dependency, so kit depends on tinyland-calendar directly rather than
+ * relying on transitive resolution. Additionally, whether `queryEvents`'
+ * server-side time-range filter matches *recurring masters* that started
+ * before the window is server-dependent; `fetchCalDavBusy` pads the query
+ * window, and the Xandikos-targeted client already falls back to
+ * `listEvents()` on 501/405. For strict servers, fetch with `listEvents()`
+ * and hand the events to `busyBlocksFromEvents` directly.
+ */
+
+import type { OccupiedBlock } from './availability-engine.js';
+import { parseTimeInTz } from './availability-engine.js';
+import {
+  expandRecurrence,
+  type RecurrenceExpansionRange,
+  type RecurringBlock,
+} from './recurrence.js';
+
+// ---------------------------------------------------------------------------
+// Public types (structural — no imports from the optional peers)
+// ---------------------------------------------------------------------------
+
+/**
+ * Structural subset of `@tummycrypt/tinyland-calendar`'s `CalendarEvent`
+ * consumed by the busy overlay. A real `CalendarEvent` is assignable as-is.
+ */
+export interface CalDavBusyEvent {
+  /** iCalendar UID, used only for error context. */
+  uid?: string;
+  /** ISO 8601 instant, or YYYY-MM-DD for all-day events. */
+  dtstart: string;
+  /** ISO 8601 instant, or YYYY-MM-DD (exclusive) for all-day events. */
+  dtend?: string;
+  /** IANA timezone for wall-clock recurrence + all-day day bounds. */
+  timezone?: string;
+  /** Events with status `'cancelled'` block nothing. */
+  status?: string;
+  /** RFC 5545 RRULE; when present the event expands as recurring busy. */
+  rrule?: string;
+  /** Occurrence exdates (ISO instants or YYYY-MM-DD dates). */
+  exdates?: string[];
+}
+
+/** Filters accepted by `CalDavBusySource.queryEvents` (subset of the peer's `EventFilters`). */
+export interface CalDavBusyQuery {
+  from?: string;
+  to?: string;
+}
+
+/**
+ * Structural slice of the peer's `CalendarClient` needed for the busy
+ * overlay. A real `CalendarClient` satisfies it; tests inject fakes.
+ */
+export interface CalDavBusySource {
+  queryEvents(filters?: CalDavBusyQuery): Promise<CalDavBusyEvent[]>;
+}
+
+// ---------------------------------------------------------------------------
+// Errors
+// ---------------------------------------------------------------------------
+
+/** The optional peer `@tummycrypt/tinyland-caldav-client` could not be loaded. */
+export class CalDavPeerUnavailableError extends Error {
+  readonly code = 'CALDAV_PEER_UNAVAILABLE';
+
+  constructor(cause: unknown) {
+    const message = cause instanceof Error ? cause.message : String(cause);
+    super(
+      'loadCalDavClient requires the optional peer dependency ' +
+        '@tummycrypt/tinyland-caldav-client (^0.2.3). Install it alongside ' +
+        '@tummycrypt/scheduling-kit to use the ./caldav subpath ' +
+        `(e.g. \`pnpm add @tummycrypt/tinyland-caldav-client\`). Cause: ${message}`,
+    );
+    this.name = 'CalDavPeerUnavailableError';
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Optional peer loading
+// ---------------------------------------------------------------------------
+
+/**
+ * Lazily load the optional peer and construct a per-instance
+ * `CalendarClient` (preferred over the peer's module-global `configure()`
+ * singleton; note the peer only supports a global `calendarPath` today —
+ * upstream constructor param tracked in TIN-1996).
+ */
+export const loadCalDavClient = async (
+  baseUrl?: string,
+): Promise<CalDavBusySource> => {
+  try {
+    const mod = await import('@tummycrypt/tinyland-caldav-client');
+    return new mod.CalendarClient(baseUrl);
+  } catch (error) {
+    throw new CalDavPeerUnavailableError(error);
+  }
+};
+
+// ---------------------------------------------------------------------------
+// Range + interval helpers
+// ---------------------------------------------------------------------------
+
+const DAY_MS = 86_400_000;
+const MINUTE_MS = 60_000;
+const DATE_ONLY = /^\d{4}-\d{2}-\d{2}$/;
+
+/**
+ * Slack applied around the requested range: one-off blocks and query windows
+ * keep a full day of margin so timezone offsets (±14h) between the engine's
+ * business timezone and UTC range bounds never drop an edge block. Extra
+ * blocks outside the range are harmless — `hasOverlap` compares instants.
+ */
+const RANGE_SLACK_MS = DAY_MS;
+
+interface RangeBounds {
+  startMs: number;
+  endMs: number;
+}
+
+const rangeBounds = (range: RecurrenceExpansionRange): RangeBounds => {
+  const startMs = DATE_ONLY.test(range.start)
+    ? Date.parse(`${range.start}T00:00:00.000Z`)
+    : Date.parse(range.start);
+  const endMs = DATE_ONLY.test(range.end)
+    ? Date.parse(`${range.end}T23:59:59.999Z`)
+    : Date.parse(range.end);
+  if (Number.isNaN(startMs)) {
+    throw new Error(`range.start is not a parseable date: "${range.start}"`);
+  }
+  if (Number.isNaN(endMs)) {
+    throw new Error(`range.end is not a parseable date: "${range.end}"`);
+  }
+  if (endMs < startMs) {
+    throw new Error(
+      `range.end (${range.end}) precedes range.start (${range.start})`,
+    );
+  }
+  return { startMs, endMs };
+};
+
+const nextDateStr = (dateStr: string): string =>
+  new Date(Date.parse(`${dateStr}T00:00:00.000Z`) + DAY_MS)
+    .toISOString()
+    .slice(0, 10);
+
+/** Local (or UTC) midnight instant of a YYYY-MM-DD date. */
+const midnightInstant = (dateStr: string, tz: string | undefined): Date =>
+  tz ? parseTimeInTz(dateStr, '00:00', tz) : new Date(`${dateStr}T00:00:00.000Z`);
+
+interface EventInterval {
+  start: Date;
+  end: Date;
+}
+
+/**
+ * Resolve an event's first-occurrence interval. Returns `undefined` for
+ * zero-duration events (they block nothing); throws on unparseable or
+ * inverted data — corrupt busy input fails loud rather than silently
+ * showing a slot as free.
+ */
+const eventInterval = (event: CalDavBusyEvent): EventInterval | undefined => {
+  const label = event.uid ? `CalDAV event ${event.uid}` : 'CalDAV event';
+  const allDay = DATE_ONLY.test(event.dtstart);
+
+  const start = allDay
+    ? midnightInstant(event.dtstart, event.timezone)
+    : new Date(event.dtstart);
+  if (Number.isNaN(start.getTime())) {
+    throw new Error(`${label} has an unparseable dtstart: "${event.dtstart}"`);
+  }
+
+  let end: Date;
+  if (event.dtend === undefined) {
+    if (!allDay) return undefined; // RFC 5545: zero-duration, blocks nothing
+    end = midnightInstant(nextDateStr(event.dtstart), event.timezone);
+  } else if (DATE_ONLY.test(event.dtend)) {
+    // DATE-valued DTEND is exclusive: the block ends at its local midnight.
+    end = midnightInstant(event.dtend, event.timezone);
+  } else {
+    end = new Date(event.dtend);
+  }
+  if (Number.isNaN(end.getTime())) {
+    throw new Error(`${label} has an unparseable dtend: "${event.dtend}"`);
+  }
+
+  if (end.getTime() < start.getTime()) {
+    throw new Error(
+      `${label} ends before it starts (dtstart ${event.dtstart}, dtend ${event.dtend})`,
+    );
+  }
+  if (end.getTime() === start.getTime()) return undefined;
+
+  return { start, end };
+};
+
+// ---------------------------------------------------------------------------
+// Busy conversion
+// ---------------------------------------------------------------------------
+
+/**
+ * Convert external-calendar events into `OccupiedBlock`s relevant to an
+ * inclusive range (each bound a YYYY-MM-DD date or ISO instant).
+ *
+ * One-off events keep their exact interval; recurring events (any with an
+ * `rrule`) expand through the slice-1 recurrence walker, honoring
+ * `timezone` wall-clock semantics and `exdates`. The expansion window is
+ * widened by the longest recurring duration plus a day of slack so
+ * occurrences that start before the range but spill into it are kept.
+ *
+ * Loads the optional peer `@tummycrypt/tinyland-calendar` only when at
+ * least one recurring event is present (via `expandRecurrence`).
+ */
+export const busyBlocksFromEvents = async (
+  events: readonly CalDavBusyEvent[],
+  range: RecurrenceExpansionRange,
+): Promise<OccupiedBlock[]> => {
+  const { startMs, endMs } = rangeBounds(range);
+
+  const oneOff: OccupiedBlock[] = [];
+  const recurring: RecurringBlock[] = [];
+  let maxRecurringDurationMs = 0;
+
+  for (const event of events) {
+    if (event.status === 'cancelled') continue;
+
+    const interval = eventInterval(event);
+    if (!interval) continue;
+
+    const rrule = event.rrule?.trim();
+    if (rrule) {
+      const durationMinutes = Math.ceil(
+        (interval.end.getTime() - interval.start.getTime()) / MINUTE_MS,
+      );
+      maxRecurringDurationMs = Math.max(
+        maxRecurringDurationMs,
+        durationMinutes * MINUTE_MS,
+      );
+      recurring.push({
+        rrule,
+        dtstart: interval.start.toISOString(),
+        durationMinutes,
+        timezone: event.timezone,
+        exdates: event.exdates,
+      });
+    } else if (
+      interval.end.getTime() > startMs - RANGE_SLACK_MS &&
+      interval.start.getTime() < endMs + RANGE_SLACK_MS
+    ) {
+      oneOff.push({ start: interval.start, end: interval.end });
+    }
+  }
+
+  let expanded: OccupiedBlock[] = [];
+  if (recurring.length > 0) {
+    const expansionRange: RecurrenceExpansionRange = {
+      start: new Date(
+        startMs - RANGE_SLACK_MS - maxRecurringDurationMs,
+      ).toISOString(),
+      end: new Date(endMs + RANGE_SLACK_MS).toISOString(),
+    };
+    ({ occupied: expanded } = await expandRecurrence(
+      { blocks: recurring },
+      expansionRange,
+    ));
+  }
+
+  return [...oneOff, ...expanded].sort(
+    (a, b) => a.start.getTime() - b.start.getTime(),
+  );
+};
+
+/**
+ * Fetch busy blocks for a range from a CalDAV source (`CalendarClient` or
+ * anything structurally compatible). The `queryEvents` window is padded by
+ * a day on each side; conversion re-filters, so servers that ignore the
+ * filter (the client falls back to `listEvents()` on 501/405) only cost
+ * extra harmless blocks.
+ */
+export const fetchCalDavBusy = async (
+  source: CalDavBusySource,
+  range: RecurrenceExpansionRange,
+): Promise<OccupiedBlock[]> => {
+  const { startMs, endMs } = rangeBounds(range);
+  const events = await source.queryEvents({
+    from: new Date(startMs - RANGE_SLACK_MS).toISOString(),
+    to: new Date(endMs + RANGE_SLACK_MS).toISOString(),
+  });
+  return busyBlocksFromEvents(events, range);
+};

--- a/src/adapters/index.ts
+++ b/src/adapters/index.ts
@@ -36,6 +36,26 @@ export {
   type RecurrenceExpansion,
 } from './recurrence.js';
 
+// CalDAV busy overlay (TIN-1996 slice 2).
+// Event conversion is peer-free; only loadCalDavClient touches the optional
+// peer @tummycrypt/tinyland-caldav-client (lazily) — safe to re-export.
+export {
+  busyBlocksFromEvents,
+  fetchCalDavBusy,
+  loadCalDavClient,
+  CalDavPeerUnavailableError,
+  type CalDavBusyEvent,
+  type CalDavBusyQuery,
+  type CalDavBusySource,
+} from './caldav-busy.js';
+
+// Availability substrate (TIN-1996 slice 2): RRULE windows minus busy.
+export {
+  getSubstrateAvailability,
+  type AvailabilitySubstrate,
+  type SubstrateDayAvailability,
+} from './availability-substrate.js';
+
 // Availability Engine (pure functions)
 export {
   getAvailableSlots,


### PR DESCRIPTION
## Why

[TIN-1996](https://linear.app/tinyland/issue/TIN-1996) — kit becomes the **first consumer** of the availability substrate modules published in [tinyland-inc/bazel-registry](https://github.com/tinyland-inc/bazel-registry): `tinyland-calendar` (RRULE recurrence) and `tinyland-caldav-client` (external calendar sync), both at **0.2.3** and previously consumed by nothing. This is slice 2 of the design spike on TIN-1996: RRULE-backed availability windows minus a CalDAV-driven busy overlay, a prerequisite for two-way Acuity feature parity.

## Dependency mechanics (TIN-2035 delivery doctrine)

- **MODULE.bazel**: `bazel_dep` on `tummycrypt_tinyland_calendar` 0.2.3 and `tummycrypt_tinyland_caldav_client` 0.2.3 — kit's first in-house module edges. Both resolve from the registry (`bazel mod graph` verified; caldav-client's own inter-module dep on calendar 0.2.3 rides along).
- **package.json**: `@tummycrypt/tinyland-caldav-client` joins as an **optional peer** (`^0.2.3`), same posture as tinyland-calendar (core never imports it; only the `./caldav` subpath loads it lazily). Both are pinned **exact 0.2.3 in devDependencies**: the lockfile drives Bazel's `npm_translate_lock`, so exact devDeps keep the Bzlmod graph and the npm graph resolving identical versions.
- **Parity is now enforced**: `check-release-metadata` gains an in-house parity check — every `tummycrypt_*` `bazel_dep` must have a matching exact-version devDependency (negative-tested: a `^` range fails the check).

## First real availability path (windows minus busy)

- `src/adapters/caldav-busy.ts` — converts external-calendar events (structurally `CalendarEvent`-shaped; a real `CalendarClient` result passes as-is) into engine `OccupiedBlock`s:
  - one-off events keep exact intervals (with midnight-spillover kept via range slack)
  - all-day events (DATE-valued `DTSTART`, exclusive `DTEND`) block the local/UTC day
  - recurring events route through the slice-1 `expandRecurrence` walker, inheriting its documented workarounds for the verified upstream gaps at tinyland-calendar 0.2.3 (BYDAY ignored, UNTIL unparsed, silent token drops — see `recurrence.ts` module docs)
  - zero-duration events block nothing (RFC 5545 §3.6.1); corrupt or unsupported busy input **fails loud** (`UnsupportedRecurrenceError`) instead of silently under-blocking and risking double-booking
  - `loadCalDavClient` lazily imports the optional peer, rejecting with an actionable `CalDavPeerUnavailableError` when absent
- `src/adapters/availability-substrate.ts` — `getSubstrateAvailability(substrate, range, config)`: expands RRULE windows into per-date hours, unions every busy input (recurring blocks, CalDAV events, an injectable `CalDavBusySource`, materialized bookings), and generates slots through the **untouched pure engine**.
- New subpath exports: `./caldav`, `./availability`.

## Upstream notes (honest workarounds, not fakes)

- The recurrence walker (slice 1) remains local; the peer's `generateOccurrences`/`expandPattern` is still unusable at 0.2.3 for the documented reasons. Busy expansion reuses that walker unchanged.
- caldav-client 0.2.3 `package.json` omits its `@tummycrypt/tinyland-calendar` type dep — kit depends on tinyland-calendar directly rather than relying on transitive resolution (upstream fix still needed).
- Whether `queryEvents`' server-side time-range filter matches recurring masters is server-dependent; `fetchCalDavBusy` pads the query window and conversion re-filters. Documented in the module header with the `listEvents()` alternative.

## Acceptance: kit availability tests proving windows-minus-busy

34 new tests (all against the really-installed 0.2.3 peers), including:

- Mon/Wed/Fri RRULE windows minus a one-off CalDAV event → exact slot lists per day
- recurring busy master starting **before** the range still subtracts inside it
- exdates restore slots; cancelled events ignored; all-day events empty the day
- busy spilling over midnight blocks the next morning
- non-UTC business timezone (EDT wall-clock windows vs UTC busy instants)
- injectable busy source queried with a padded window, and never queried when no window date lands in range
- peer-absent behavior for the new caldav loader

## Validation

- `pnpm test:unit` — 848 passed (32 files)
- `pnpm test:integration` — 27 passed
- `pnpm check` — 0 errors / 0 warnings
- `pnpm lint` — clean
- `pnpm check:release-metadata` — aligned (incl. new parity checks)
- `pnpm build` + `publint` — green; `docs/generated/package-surface.md` regenerated
- `bazel mod graph` — both modules resolve 0.2.3 from tinyland-inc/bazel-registry
- `just flywheel-build` (local mode) — `//:typecheck //:pkg //:test` built green (1847 actions)
- `just flywheel-test` (local mode) — `//:test` PASSED
- `just cache-contract-strict` — fails closed locally by design (`BAZEL_REMOTE_CACHE` unset; endpoint is injected only by the in-cluster nix-setup)