### PR TITLE
feat(kit): availability snapshot freshness attribution (TIN-945 row 3)

### DIFF
--- a/src/adapters/__tests__/availability-snapshot.test.ts
+++ b/src/adapters/__tests__/availability-snapshot.test.ts
@@ -1,0 +1,207 @@
+/**
+ * Availability snapshot freshness attribution tests (TIN-945 row 3).
+ *
+ * The ledger row: cold Acuity/CalDAV reads run 7–15s vs 1–2ms cache hits, so
+ * a consumer caching the availability path needs freshness + cold-read-cost
+ * metadata to attribute the cost and decide whether to reuse. These are the
+ * acceptance tests for `getAvailabilitySnapshot` and its reuse predicates,
+ * layered over the same substrate path #114 landed (`getSubstrateAvailability`).
+ *
+ * Calendar facts reused from availability-substrate.test.ts (verified):
+ *   - 2026-06-01 Mon, 2026-06-03 Wed, 2026-06-05 Fri; June 2026 is EDT.
+ *
+ * The engine's Date is frozen (as in the sibling suite) so slot generation is
+ * deterministic; the snapshot's own clock is injected via `policy.now`, kept
+ * independent so cold-read timing is controlled without moving engine time.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { SlotConfig } from '../availability-engine.js';
+import {
+  getAvailabilitySnapshot,
+  getSubstrateAvailability,
+  isSnapshotExpired,
+  isSnapshotReusable,
+  isSnapshotStale,
+} from '../availability-substrate.js';
+
+const FROZEN_NOW = new Date('2026-05-01T00:00:00.000Z');
+
+beforeEach(() => {
+  vi.useFakeTimers({ toFake: ['Date'] });
+  vi.setSystemTime(FROZEN_NOW);
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+const CONFIG: SlotConfig = {
+  duration: 60,
+  interval: 60,
+  buffer: 0,
+  minAdvanceHours: 0,
+  timezone: 'UTC',
+};
+
+/** Mon/Wed/Fri 09:00–12:00 window (three 60-minute slots per day). */
+const MWF_HOURS = [
+  {
+    rrule: 'RRULE:FREQ=WEEKLY;BYDAY=MO,WE,FR',
+    dtstart: '2026-06-01',
+    window: { opens: '09:00', closes: '12:00' },
+  },
+];
+
+const WEEK = { start: '2026-06-01', end: '2026-06-05' };
+
+const MINUTE = 60_000;
+/** The instant the injected read "completes" — aligned to the frozen engine clock. */
+const OBSERVED = FROZEN_NOW.getTime();
+
+/** A clock stub returning each queued value on successive calls, holding the last. */
+const clockOf = (...valuesMs: number[]): (() => number) => {
+  let i = 0;
+  return () => {
+    const value = valuesMs[Math.min(i, valuesMs.length - 1)]!;
+    i += 1;
+    return value;
+  };
+};
+
+describe('getAvailabilitySnapshot — fresh snapshot stamping', () => {
+  it('reports observedAt at read completion and derives staleAt/expiresAt from the policy', async () => {
+    const snap = await getAvailabilitySnapshot({ hours: MWF_HOURS }, WEEK, CONFIG, {
+      staleAfterMs: 5 * MINUTE,
+      expiresAfterMs: 15 * MINUTE,
+      now: () => OBSERVED,
+    });
+
+    expect(snap.freshness.observedAt).toBe(new Date(OBSERVED).toISOString());
+    expect(snap.freshness.staleAt).toBe(new Date(OBSERVED + 5 * MINUTE).toISOString());
+    expect(snap.freshness.expiresAt).toBe(new Date(OBSERVED + 15 * MINUTE).toISOString());
+
+    // A just-observed snapshot is neither stale nor expired.
+    expect(isSnapshotStale(snap, OBSERVED)).toBe(false);
+    expect(isSnapshotExpired(snap, OBSERVED)).toBe(false);
+    expect(isSnapshotReusable(snap, OBSERVED)).toBe(true);
+  });
+
+  it('passes the days payload through unchanged from getSubstrateAvailability', async () => {
+    const snap = await getAvailabilitySnapshot({ hours: MWF_HOURS }, WEEK, CONFIG, {
+      staleAfterMs: MINUTE,
+      expiresAfterMs: 2 * MINUTE,
+      now: () => OBSERVED,
+    });
+    const direct = await getSubstrateAvailability({ hours: MWF_HOURS }, WEEK, CONFIG);
+
+    expect(snap.days).toEqual(direct);
+    expect(snap.days.map((d) => d.date)).toEqual([
+      '2026-06-01',
+      '2026-06-03',
+      '2026-06-05',
+    ]);
+  });
+});
+
+describe('getAvailabilitySnapshot — cold-read cost attribution', () => {
+  it('attributes a cold read: readMs is the elapsed clock across the read', async () => {
+    // Clock advances 8_000ms between read start and completion — a cold Acuity read.
+    const snap = await getAvailabilitySnapshot({ hours: MWF_HOURS }, WEEK, CONFIG, {
+      staleAfterMs: MINUTE,
+      expiresAfterMs: 2 * MINUTE,
+      now: clockOf(OBSERVED, OBSERVED + 8_000),
+    });
+
+    expect(snap.freshness.readMs).toBe(8_000);
+    // observedAt is stamped at completion, not start.
+    expect(snap.freshness.observedAt).toBe(new Date(OBSERVED + 8_000).toISOString());
+    expect(snap.freshness.staleAt).toBe(new Date(OBSERVED + 8_000 + MINUTE).toISOString());
+  });
+
+  it('attributes a warm serve: readMs is 0 when the clock does not advance', async () => {
+    const snap = await getAvailabilitySnapshot({ hours: MWF_HOURS }, WEEK, CONFIG, {
+      staleAfterMs: MINUTE,
+      expiresAfterMs: 2 * MINUTE,
+      now: () => OBSERVED,
+    });
+
+    expect(snap.freshness.readMs).toBe(0);
+  });
+});
+
+describe('isSnapshotStale — staleAt bounds freshness', () => {
+  const freshPolicy = {
+    staleAfterMs: 5 * MINUTE,
+    expiresAfterMs: 15 * MINUTE,
+    now: () => OBSERVED,
+  };
+
+  it('is fresh up to and at staleAt, stale strictly after (matches core/cache.ts)', async () => {
+    const snap = await getAvailabilitySnapshot({ hours: MWF_HOURS }, WEEK, CONFIG, freshPolicy);
+    const staleAt = OBSERVED + 5 * MINUTE;
+
+    expect(isSnapshotStale(snap, staleAt - 1)).toBe(false);
+    expect(isSnapshotStale(snap, staleAt)).toBe(false);
+    expect(isSnapshotStale(snap, staleAt + 1)).toBe(true);
+  });
+});
+
+describe('isSnapshotExpired / isSnapshotReusable — expiresAt bounds reuse', () => {
+  const freshPolicy = {
+    staleAfterMs: 5 * MINUTE,
+    expiresAfterMs: 15 * MINUTE,
+    now: () => OBSERVED,
+  };
+
+  it('stays reusable through expiresAt and must not be reused strictly after', async () => {
+    const snap = await getAvailabilitySnapshot({ hours: MWF_HOURS }, WEEK, CONFIG, freshPolicy);
+    const expiresAt = OBSERVED + 15 * MINUTE;
+
+    expect(isSnapshotExpired(snap, expiresAt)).toBe(false);
+    expect(isSnapshotReusable(snap, expiresAt)).toBe(true);
+
+    expect(isSnapshotExpired(snap, expiresAt + 1)).toBe(true);
+    expect(isSnapshotReusable(snap, expiresAt + 1)).toBe(false);
+  });
+
+  it('is stale yet still reusable between staleAt and expiresAt', async () => {
+    const snap = await getAvailabilitySnapshot({ hours: MWF_HOURS }, WEEK, CONFIG, freshPolicy);
+    const between = OBSERVED + 10 * MINUTE; // past staleAt (5m), before expiresAt (15m)
+
+    expect(isSnapshotStale(snap, between)).toBe(true);
+    expect(isSnapshotReusable(snap, between)).toBe(true);
+  });
+});
+
+describe('getAvailabilitySnapshot — fail-loud policy validation', () => {
+  it('rejects an expiry that precedes staleness', async () => {
+    await expect(
+      getAvailabilitySnapshot({ hours: MWF_HOURS }, WEEK, CONFIG, {
+        staleAfterMs: 10 * MINUTE,
+        expiresAfterMs: 5 * MINUTE,
+        now: () => OBSERVED,
+      }),
+    ).rejects.toThrow(/cannot expire before it goes stale/);
+  });
+
+  it('rejects a negative staleAfterMs', async () => {
+    await expect(
+      getAvailabilitySnapshot({ hours: MWF_HOURS }, WEEK, CONFIG, {
+        staleAfterMs: -1,
+        expiresAfterMs: 5 * MINUTE,
+        now: () => OBSERVED,
+      }),
+    ).rejects.toThrow(/staleAfterMs must be a non-negative/);
+  });
+
+  it('rejects a non-finite expiresAfterMs', async () => {
+    await expect(
+      getAvailabilitySnapshot({ hours: MWF_HOURS }, WEEK, CONFIG, {
+        staleAfterMs: MINUTE,
+        expiresAfterMs: Number.POSITIVE_INFINITY,
+        now: () => OBSERVED,
+      }),
+    ).rejects.toThrow(/expiresAfterMs must be a non-negative/);
+  });
+});

--- a/src/adapters/availability-substrate.ts
+++ b/src/adapters/availability-substrate.ts
@@ -125,3 +125,153 @@ export const getSubstrateAvailability = async (
   }
   return days;
 };
+
+// ---------------------------------------------------------------------------
+// Snapshot freshness attribution (TIN-945 row 3)
+// ---------------------------------------------------------------------------
+
+/**
+ * Freshness + cost metadata carried alongside a materialized availability
+ * read so a consumer that caches the result can attribute cold-read cost
+ * (a fresh Acuity/CalDAV read is 7–15s vs a 1–2ms cache hit — TIN-945 row 3)
+ * and reason about reuse without instrumenting the read site itself.
+ *
+ * All instants are ISO 8601 strings for wire/JSON parity with the rest of
+ * the kit's public surface (bookings, soft holds, payment intents).
+ */
+export interface AvailabilityFreshness {
+  /** ISO instant the underlying read completed — when the data was observed. */
+  observedAt: string;
+  /**
+   * ISO instant after which the snapshot is stale and SHOULD be refreshed.
+   * Soft bound: a stale snapshot is still reusable, but a consumer that can
+   * afford a refresh should take one.
+   */
+  staleAt: string;
+  /**
+   * ISO instant after which the snapshot MUST NOT be reused. Hard bound:
+   * past this point a consumer must re-read rather than serve the cache.
+   */
+  expiresAt: string;
+  /**
+   * Wall-clock cost of the underlying read, in whole milliseconds. Lets a
+   * consumer attribute a cold read (a fresh substrate/Acuity/CalDAV fetch)
+   * apart from a warm serve without wrapping the read site in its own timer.
+   */
+  readMs: number;
+}
+
+/**
+ * A materialized availability read plus its freshness/cost metadata. The
+ * `days` payload is exactly what {@link getSubstrateAvailability} returns —
+ * the snapshot wraps that path rather than reshaping it, so nothing
+ * downstream of the days array changes.
+ */
+export interface AvailabilitySnapshot {
+  /** Per-date availability (windows minus busy), unchanged from getSubstrateAvailability. */
+  days: SubstrateDayAvailability[];
+  /** Cold-read cost + staleness attribution for cache-reuse decisions. */
+  freshness: AvailabilityFreshness;
+}
+
+/**
+ * How long a snapshot stays fresh, then reusable. Both durations are
+ * measured from `observedAt` (read completion), in milliseconds.
+ */
+export interface SnapshotFreshnessPolicy {
+  /** ms after observedAt at which the snapshot goes stale (soft refresh). */
+  staleAfterMs: number;
+  /**
+   * ms after observedAt at which the snapshot expires (hard, no reuse).
+   * Must be >= staleAfterMs — a snapshot cannot expire before it goes stale.
+   */
+  expiresAfterMs: number;
+  /**
+   * Injectable clock (ms since epoch), defaulting to `Date.now`. Tests pin
+   * it to make cold-read timing and staleness deterministic; a caller can
+   * also supply a monotonic source.
+   */
+  now?: () => number;
+}
+
+/**
+ * Materialize availability over the substrate and stamp it with freshness
+ * and cold-read-cost metadata (TIN-945 row 3).
+ *
+ * This is a thin wrapper over {@link getSubstrateAvailability}: it times the
+ * read with the policy clock, records `observedAt` at read completion, and
+ * derives `staleAt`/`expiresAt` from the policy durations. The `days` payload
+ * is passed through untouched, so this composes the existing availability
+ * path instead of forking it.
+ *
+ * Fails loud on an incoherent policy (negative durations, or an expiry that
+ * precedes staleness) rather than emitting a snapshot that can never be
+ * trusted — matching the substrate's fail-closed posture.
+ */
+export const getAvailabilitySnapshot = async (
+  substrate: AvailabilitySubstrate,
+  range: RecurrenceExpansionRange,
+  config: SlotConfig,
+  policy: SnapshotFreshnessPolicy,
+): Promise<AvailabilitySnapshot> => {
+  if (!Number.isFinite(policy.staleAfterMs) || policy.staleAfterMs < 0) {
+    throw new Error(
+      `SnapshotFreshnessPolicy.staleAfterMs must be a non-negative finite number, got ${policy.staleAfterMs}`,
+    );
+  }
+  if (!Number.isFinite(policy.expiresAfterMs) || policy.expiresAfterMs < 0) {
+    throw new Error(
+      `SnapshotFreshnessPolicy.expiresAfterMs must be a non-negative finite number, got ${policy.expiresAfterMs}`,
+    );
+  }
+  if (policy.expiresAfterMs < policy.staleAfterMs) {
+    throw new Error(
+      `SnapshotFreshnessPolicy.expiresAfterMs (${policy.expiresAfterMs}) must be >= ` +
+        `staleAfterMs (${policy.staleAfterMs}); a snapshot cannot expire before it goes stale`,
+    );
+  }
+
+  const now = policy.now ?? Date.now;
+  const startedMs = now();
+  const days = await getSubstrateAvailability(substrate, range, config);
+  const observedMs = now();
+
+  return {
+    days,
+    freshness: {
+      observedAt: new Date(observedMs).toISOString(),
+      staleAt: new Date(observedMs + policy.staleAfterMs).toISOString(),
+      expiresAt: new Date(observedMs + policy.expiresAfterMs).toISOString(),
+      readMs: Math.max(0, observedMs - startedMs),
+    },
+  };
+};
+
+/**
+ * Whether the snapshot is past its soft freshness bound at `nowMs` (default:
+ * the real clock). Stale snapshots remain reusable — this only signals that
+ * a refresh is warranted. Strictly-after semantics match `core/cache.ts`.
+ */
+export const isSnapshotStale = (
+  snapshot: AvailabilitySnapshot,
+  nowMs: number = Date.now(),
+): boolean => nowMs > Date.parse(snapshot.freshness.staleAt);
+
+/**
+ * Whether the snapshot is past its hard reuse bound at `nowMs` (default: the
+ * real clock). An expired snapshot MUST be re-read rather than served.
+ */
+export const isSnapshotExpired = (
+  snapshot: AvailabilitySnapshot,
+  nowMs: number = Date.now(),
+): boolean => nowMs > Date.parse(snapshot.freshness.expiresAt);
+
+/**
+ * Whether the snapshot may still be served at `nowMs` — i.e. it has not
+ * expired. The single reuse gate a cache should consult: `expiresAt` bounds
+ * reuse, `staleAt` only advises a refresh.
+ */
+export const isSnapshotReusable = (
+  snapshot: AvailabilitySnapshot,
+  nowMs: number = Date.now(),
+): boolean => !isSnapshotExpired(snapshot, nowMs);

--- a/src/adapters/index.ts
+++ b/src/adapters/index.ts
@@ -50,10 +50,19 @@ export {
 } from './caldav-busy.js';
 
 // Availability substrate (TIN-1996 slice 2): RRULE windows minus busy.
+// Snapshot freshness attribution (TIN-945 row 3): observedAt/staleAt/expiresAt
+// + cold-read cost, wrapping the substrate read for cache-reuse decisions.
 export {
   getSubstrateAvailability,
+  getAvailabilitySnapshot,
+  isSnapshotStale,
+  isSnapshotExpired,
+  isSnapshotReusable,
   type AvailabilitySubstrate,
   type SubstrateDayAvailability,
+  type AvailabilitySnapshot,
+  type AvailabilityFreshness,
+  type SnapshotFreshnessPolicy,
 } from './availability-substrate.js';
 
 // Availability Engine (pure functions)


### PR DESCRIPTION
## What

TIN-945 ledger row 3: *cold Acuity/CalDAV availability reads run 7–15s vs 1–2ms cache hits — need snapshot freshness attribution.*

#114 landed `getSubstrateAvailability`, which returns `SubstrateDayAvailability[]` with **no** timestamp or cost signal, so a consumer caching that result cannot attribute cold-read cost or detect staleness. This wraps that path (no fork, no parallel days type) with a freshness-stamped snapshot.

## Landed

`src/adapters/availability-substrate.ts` (+ re-exported from `./adapters` and the `./availability` subpath):

- **`getAvailabilitySnapshot(substrate, range, config, policy)`** — thin wrapper over `getSubstrateAvailability`. Times the read with the policy clock, returns `AvailabilitySnapshot { days, freshness }`. `days` is the existing substrate payload, untouched.
- **`AvailabilityFreshness`** — `observedAt` (read completion), `staleAt` (soft refresh bound), `expiresAt` (hard reuse bound), `readMs` (cold-read cost, whole ms).
- **`SnapshotFreshnessPolicy`** — `staleAfterMs` / `expiresAfterMs` measured from `observedAt`, plus an injectable `now()` used for both timing and bound derivation. Fails loud on an incoherent policy (negative durations, or `expiresAfterMs < staleAfterMs`), matching the substrate's fail-closed posture.
- **`isSnapshotStale` / `isSnapshotExpired` / `isSnapshotReusable`** — reuse predicates. Strictly-after (`>`) semantics match `core/cache.ts`. `expiresAt` bounds reuse; `staleAt` only advises a refresh, so a snapshot can be stale yet still reusable.

## Proof

`src/adapters/__tests__/availability-snapshot.test.ts` — 10 acceptance tests:

- fresh snapshot reports `observedAt` and derives `staleAt`/`expiresAt` from the policy; a just-observed snapshot is neither stale nor expired;
- `days` payload deep-equals the direct `getSubstrateAvailability` return;
- cold-read cost is attributed via `readMs` (8s advance) vs a warm 0ms serve;
- `staleAt` bounds freshness (fresh at/​before, stale strictly after);
- `expiresAt` bounds reuse (reusable through `expiresAt`, not after) and a snapshot is stale-yet-reusable between the two bounds;
- policy validation fails loud (expiry-before-stale, negative, non-finite).

Gates: `pnpm run test:unit` 860 passed (850 prior + 10 new), `pnpm run check` (svelte-check) 0 errors, `pnpm run lint` clean.

## Not doing here

- No change to `getSubstrateAvailability` or `SubstrateDayAvailability` — non-breaking, additive only.
- No cache implementation — this supplies the metadata a cache consults; the store stays the consumer's choice (`core/cache.ts` remains available).

Do not merge — queued for the next review round.