### PR TITLE
release: scheduling-kit 0.10.0 — availability substrate (TIN-1996)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,7 +83,7 @@ Closed but still relevant context:
 - `TIN-103` closed the release-authority ambiguity for `Jesssullivan/scheduling-kit`
 - `TIN-104` was canceled as a duplicate during that convergence work
 - `TIN-165` is done: the tinyland bazel-registry is generated from standalone
-  package truth and currently carries scheduling-kit `0.9.2+` and
+  package truth and currently carries scheduling-kit `0.10.0+` and
   scheduling-bridge `0.5.11+`; the registry line is in `.bazelrc`
 - `TIN-677` is done: HomegrownAdapter takes injected schemas from
   `@tummycrypt/tinyland-business-pg`, with `tinyland-auth-pg` kept only as an
@@ -93,9 +93,9 @@ Current operational truth:
 
 - local development should default to `jesssullivan/main`
 - that branch is the current functional release line
-- current released version is `0.9.2`: git tag plus GitHub Release, GitHub
+- current released version is `0.10.0`: git tag plus GitHub Release, GitHub
   Packages `@jesssullivan/scheduling-kit`, and the active tinyland Bazel
-  registry (`0.9.2+`)
+  registry (`0.10.0+`)
 - npmjs `@tummycrypt/scheduling-kit` is retired for new versions and frozen at
   `0.8.0`; `npm_publish_mode: disabled` is permanent policy, not a temporary
   outage

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -166,7 +166,7 @@ npm_package(
     ],
     package = "@tummycrypt/scheduling-kit",
     tags = ["manual"],
-    version = "0.9.2",
+    version = "0.10.0",
     visibility = ["//visibility:public"],
 )
 

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -22,7 +22,7 @@ Subpackage targets (finer-grained caching):
 
 module(
     name = "tummycrypt_scheduling_kit",
-    version = "0.9.2",
+    version = "0.10.0",
     compatibility_level = 1,
 )
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ The Bazel module graph is the canonical delivery mechanism. Depend on the
 module through the tinyland Bazel registry:
 
 ```starlark
-bazel_dep(name = "tummycrypt_scheduling_kit", version = "0.9.2")
+bazel_dep(name = "tummycrypt_scheduling_kit", version = "0.10.0")
 ```
 
 with the registry line (already in this repo's `.bazelrc`):
@@ -105,7 +105,7 @@ Current reality:
 - the functional release line is `Jesssullivan/scheduling-kit`
 - `tinyland-inc/scheduling-kit` is now a downstream mirror and validation
   surface, not a second publish authority
-- the active tinyland Bazel registry carries `scheduling-kit` `0.9.2+` (and
+- the active tinyland Bazel registry carries `scheduling-kit` `0.10.0+` (and
   `scheduling-bridge` `0.5.11+`); the registry line is already in `.bazelrc`
 
 Treat `Jesssullivan/main` as the release authority for package publication and

--- a/docs/generated/package-surface.md
+++ b/docs/generated/package-surface.md
@@ -11,7 +11,7 @@ Generated from `package.json` and the current `src/` tree.
 | Field | Value |
 | --- | --- |
 | Package | `@tummycrypt/scheduling-kit` |
-| Version | `0.9.2` |
+| Version | `0.10.0` |
 | Description | Backend-agnostic scheduling components with alternative payment support |
 | Node range | `>=20 <25` |
 | Repository | https://github.com/Jesssullivan/scheduling-kit.git |
@@ -41,7 +41,7 @@ Generated from `package.json` and the current `src/` tree.
 
 | Area | Files | Notes |
 | --- | --- | --- |
-| `src/adapters` | 14 | Scheduling provider integrations and availability helpers |
+| `src/adapters` | 15 | Scheduling provider integrations and availability helpers |
 | `src/capabilities` | 3 | Repo source area |
 | `src/components` | 13 | Svelte checkout and booking UI |
 | `src/core` | 6 | Effect-powered orchestration, error types, and utilities |

--- a/docs/generated/release-metadata.md
+++ b/docs/generated/release-metadata.md
@@ -11,9 +11,9 @@ Generated from `package.json`, `MODULE.bazel`, `BUILD.bazel`,
 
 | Surface | Value |
 | --- | --- |
-| package.json version | `0.9.2` |
-| MODULE.bazel version | `0.9.2` |
-| BUILD.bazel npm_package version | `0.9.2` |
+| package.json version | `0.10.0` |
+| MODULE.bazel version | `0.10.0` |
+| BUILD.bazel npm_package version | `0.10.0` |
 | BUILD.bazel package name | `@tummycrypt/scheduling-kit` |
 | .bazelversion | `8.1.1` |
 | pnpm packageManager | `pnpm@9.15.9` |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tummycrypt/scheduling-kit",
-  "version": "0.9.2",
+  "version": "0.10.0",
   "description": "Backend-agnostic scheduling components with alternative payment support",
   "type": "module",
   "packageManager": "pnpm@9.15.9",


### PR DESCRIPTION
## Release: scheduling-kit 0.10.0 — availability substrate (TIN-1996)

Cuts the release that makes the **availability substrate** consumable off the
`tinyland-inc/bazel-registry` SSOT and the derived GitHub Packages artifact.

### Why 0.10.0 (MINOR)

Since the last release (`0.9.2`), the following landed on `main`:

- **#114** — availability substrate: two **net-new public subpath exports**
  (`./caldav` → `caldav-busy`, `./availability` → `availability-substrate`)
  plus new inter-module deps (`tummycrypt_tinyland_calendar`,
  `tummycrypt_tinyland_caldav_client`) mirrored as exact-version `@tummycrypt`
  npm devDependencies (TIN-1996).
- **#116** — availability **snapshot freshness attribution** (TIN-945 row 3):
  net-new additive public API on the existing `./availability` (`./adapters`)
  subpath — `getAvailabilitySnapshot` plus `AvailabilitySnapshot` /
  `AvailabilityFreshness` / `SnapshotFreshnessPolicy` and
  `isSnapshotStale` / `isSnapshotExpired` / `isSnapshotReusable`. Thin wrapper
  over `getSubstrateAvailability` (#114) that stamps `observedAt` / `staleAt` /
  `expiresAt` + cold-read `readMs` so a cache consumer can attribute cold-read
  cost and reason about reuse. No new subpath, no change to existing exports —
  additive-only, reinforcing the MINOR bump.
- **#115** — cassette-backed idempotency replay proof (TIN-1995).
- **#111–#113** — Bazel cache-lane enrollment, ci-templates v2.5.0 gate, and the
  SchedulingAdapter parity matrix.

Net-additive public API surface with no breaking changes to existing exports is
a SemVer **MINOR** bump: `0.9.2 → 0.10.0`. The repo has no `CHANGELOG.md` and no
written SemVer policy that overrides this; release truth lives in the version
triple + `AGENTS.md` + the generated docs, all updated here.

> **Rebased onto `main` after #116 landed.** This branch was rebased on top of
> the merged #116 commit and `generate-doc-artifacts` was re-run, so the 0.10.0
> generated `package-surface.md` reflects the source actually on `main`
> (`src/adapters` file count 14 → 15, picking up the new snapshot suite). The
> release description above and the validation below match the landed surface.

### Version triple + surfaces (aligned)

| Surface | Value |
| --- | --- |
| `package.json` version | `0.10.0` |
| `MODULE.bazel` module version | `0.10.0` |
| `BUILD.bazel` `//:pkg` npm_package version | `0.10.0` |
| `AGENTS.md` current-released / registry truth | `0.10.0` / `0.10.0+` |
| `README.md` `bazel_dep` + registry truth | `0.10.0` / `0.10.0+` |
| `docs/generated/{package-surface,release-metadata}.md` | regenerated → `0.10.0` |

### Validation (all green, run against this rebased branch)

- `pnpm check:release-metadata` → `release metadata aligned for @tummycrypt/scheduling-kit@0.10.0` (includes the in-house Bzlmod↔npm parity loop)
- `node scripts/generate-doc-artifacts.mjs --check` → generated docs in sync
- `pnpm test:unit` → 860 passed (33 files) — includes #116's 10 snapshot acceptance tests
- `pnpm test:integration` → 34 passed (3 files)
- `pnpm check` (svelte-check) → 0 errors, 0 warnings
- `pnpm build` → `src -> dist` OK; `./caldav` and `./availability` resolve to real `dist/adapters/*.js` + `.d.ts`
- `pnpm check:package` (publint) → `All good!`

### Publish handoff

Per the delivery doctrine, the git tag is the publish trigger and stays an
operator step. **Do not push a tag from this PR.**

**merge then operator tags v0.10.0 to publish.**

npmjs stays retired/frozen at `0.8.0` (`npm_publish_mode: disabled`); delivery is
the Bzlmod module graph (SSOT) + derived GitHub Packages `@jesssullivan/scheduling-kit`.

Closes the release-prep slice of TIN-1996.
